### PR TITLE
fix: auto-create logs/ directory on startup to unblock CI

### DIFF
--- a/backend/openshiksha/settings/base.py
+++ b/backend/openshiksha/settings/base.py
@@ -205,6 +205,9 @@ EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD', '')
 DEFAULT_FROM_EMAIL = os.getenv('DEFAULT_FROM_EMAIL', 'noreply@openshiksha.org')
 
 # Logging Configuration
+# Ensure the logs directory exists (CI environments and fresh checkouts won't have it)
+(BASE_DIR / 'logs').mkdir(exist_ok=True)
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,


### PR DESCRIPTION
## Problem

CI has been failing on every push since the analytics engine was added. The root cause is that Django's file logging handler in `base.py` tries to open `backend/logs/openshiksha.log` at startup, but the `logs/` directory is git-ignored and doesn't exist in CI runners or fresh checkouts.

This causes `manage.py check` (and any other Django command) to crash immediately with:

```
FileNotFoundError: [Errno 2] No such file or directory: '.../backend/logs/openshiksha.log'
ValueError: Unable to configure handler 'file'
```

## Fix

Add one line before the `LOGGING` config in `base.py`:

```python
(BASE_DIR / 'logs').mkdir(exist_ok=True)
```

This ensures the directory is created at settings load time, regardless of environment. No migration, no dependency change.

## Test plan

- [ ] Verify CI passes on this PR (watch the Actions tab)
- [ ] Confirm `manage.py check` runs cleanly in a fresh environment
- [ ] Confirm existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)