### PR TITLE
fix(docker): point frontend service to frontend_modern

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,20 +112,20 @@ services:
     networks:
       - openshiksha-network
 
-  # React Frontend
+  # React Frontend (modern)
   frontend:
     build:
-      context: ./frontend
+      context: ./frontend_modern
       dockerfile: Dockerfile
     container_name: openshiksha-frontend
     command: npm run dev -- --host
     volumes:
-      - ./frontend:/app
+      - ./frontend_modern:/app
       - /app/node_modules  # Anonymous volume for node_modules
     ports:
       - "5173:5173"
     env_file:
-      - ./frontend/.env
+      - ./frontend_modern/.env
     environment:
       - VITE_API_BASE_URL=http://localhost:8000/api/v1
       - VITE_WS_URL=ws://localhost:8000/ws

--- a/frontend_modern/Dockerfile
+++ b/frontend_modern/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host"]


### PR DESCRIPTION
## Summary

- **docker-compose.yml** was referencing `./frontend` (the legacy Django app directory) for the frontend service. Updated to `./frontend_modern` (the actual Vite + React app).
- **Added `frontend_modern/Dockerfile`** — a simple Node 20 Alpine image that runs `npm run dev -- --host`.

Without this fix, `docker compose up` fails to build/start the frontend.

## Test plan

- [x] `docker compose up --build` starts all 4 services (postgres, redis, backend, frontend)
- [x] http://localhost:5173 returns 200
- [x] http://localhost:8000/api/v1/health/ returns healthy
- [x] Backend Django check passes
- [x] Frontend tsc passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)