### PR TITLE
fix(security): upgrade Django 4.2.29 -> 4.2.30 (5 CVEs)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 # Django Core (LTS 4.2.x)
-Django==4.2.29
+Django==4.2.30
 djangorestframework==3.15.2
 django-cors-headers==4.6.0
 django-filter==24.3


### PR DESCRIPTION
## Summary

- Upgrades Django from 4.2.29 to 4.2.30 to fix 5 known CVEs reported by `pip-audit`

## Vulnerabilities fixed

| ID | Fixed in |
|----|----------|
| GHSA-5mf9-h53q-7mhq | 4.2.30 |
| GHSA-933h-hp56-hf7m | 4.2.30 |
| GHSA-mmwr-2jhp-mc7j | 4.2.30 |
| GHSA-pwjp-ccjc-ghwg | 4.2.30 |
| GHSA-mvfq-ggxm-9mc5 | 4.2.30 |

## Test plan

- [x] `pip-audit -r requirements.txt` — 0 vulnerabilities after upgrade
- [x] All 272 backend tests pass
- [x] Django 4.2.30 is a patch release — no breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)