### PR TITLE
feat: teacher question-mistake analytics

### DIFF
--- a/backend/openshiksha/apps/api/serializers/__init__.py
+++ b/backend/openshiksha/apps/api/serializers/__init__.py
@@ -4,6 +4,7 @@ from .core import (
     ChapterSerializer,
     ProblemSetSerializer,
     ProblemSetWriteSerializer,
+    QuestionMistakeSerializer,
     QuestionSerializer,
     QuestionSubpartSerializer,
     QuestionTagSerializer,
@@ -30,4 +31,5 @@ __all__ = [
     "AssignmentDetailSerializer",
     "SubmissionSerializer",
     "StudentProficiencySerializer",
+    "QuestionMistakeSerializer",
 ]

--- a/backend/openshiksha/apps/api/serializers/core.py
+++ b/backend/openshiksha/apps/api/serializers/core.py
@@ -20,7 +20,7 @@ from openshiksha.apps.core.models import (
     User,
     UserRole,
 )
-from openshiksha.apps.edge.models import StudentProficiency
+from openshiksha.apps.edge.models import StudentProficiency, SubjectRoomQuestionMistake
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -487,3 +487,35 @@ class StudentProficiencySerializer(serializers.ModelSerializer):
     def get_classroom_display(self, obj) -> str:
         classroom = obj.subject_room.classroom
         return f"Standard {classroom.standard.number} {classroom.division}"
+
+
+class QuestionMistakeSerializer(serializers.ModelSerializer):
+    """
+    Exposes a subject room's question mistake data for teachers.
+
+    Ordered by regression (highest = hardest question for that class).
+    question_text and question_type are from the first subpart of each question.
+    """
+
+    question_text = serializers.SerializerMethodField()
+    question_type = serializers.SerializerMethodField()
+    question_id = serializers.IntegerField(source="question.id", read_only=True)
+
+    class Meta:
+        model = SubjectRoomQuestionMistake
+        fields = [
+            "id",
+            "question_id",
+            "question_text",
+            "question_type",
+            "regression",
+            "updated_at",
+        ]
+        read_only_fields = fields
+
+    def get_question_text(self, obj) -> str:
+        first_subpart = obj.question.subparts.order_by("index").first()
+        return first_subpart.question_text if first_subpart else ""
+
+    def get_question_type(self, obj) -> str:
+        return obj.question.question_type

--- a/backend/openshiksha/apps/api/tests/test_question_mistake_api.py
+++ b/backend/openshiksha/apps/api/tests/test_question_mistake_api.py
@@ -1,0 +1,199 @@
+"""
+Tests for QuestionMistakeViewSet.
+
+Covers:
+- Students are denied (403)
+- Teachers only see their own subject rooms
+- Cross-teacher isolation (teacher B cannot see teacher A's data)
+- Results ordered by regression descending
+"""
+
+import pytest
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from openshiksha.apps.core.models import (
+    Board,
+    Chapter,
+    ClassRoom,
+    Question,
+    QuestionSubpart,
+    School,
+    Standard,
+    Subject,
+    SubjectRoom,
+    User,
+    UserRole,
+)
+from openshiksha.apps.edge.models import SubjectRoomQuestionMistake
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def board(db):
+    return Board.objects.create(name="CBSE-QM")
+
+
+@pytest.fixture
+def school(db, board):
+    return School.objects.create(name="QM School", board=board)
+
+
+@pytest.fixture
+def standard(db):
+    return Standard.objects.create(number=9)
+
+
+@pytest.fixture
+def subject(db):
+    return Subject.objects.create(name="Science-QM")
+
+
+@pytest.fixture
+def chapter(db, subject, standard):
+    return Chapter.objects.create(name="Motion", subject=subject, standard=standard, order=1)
+
+
+@pytest.fixture
+def classroom(db, school, standard):
+    return ClassRoom.objects.create(school=school, standard=standard, division="B", academic_year="2025-26")
+
+
+@pytest.fixture
+def classroom_b(db, school, standard):
+    """A second classroom so teacher_b's subject room doesn't hit the unique constraint."""
+    return ClassRoom.objects.create(school=school, standard=standard, division="C", academic_year="2025-26")
+
+
+@pytest.fixture
+def teacher(db, school):
+    return User.objects.create_user(username="teacher_qm", password="pass", role=UserRole.TEACHER, school=school)
+
+
+@pytest.fixture
+def teacher_b(db, school):
+    return User.objects.create_user(username="teacher_qm_b", password="pass", role=UserRole.TEACHER, school=school)
+
+
+@pytest.fixture
+def student(db, school):
+    return User.objects.create_user(username="student_qm", password="pass", role=UserRole.STUDENT, school=school)
+
+
+@pytest.fixture
+def subject_room(db, classroom, subject, teacher, student):
+    room = SubjectRoom.objects.create(classroom=classroom, subject=subject, teacher=teacher)
+    room.students.add(student)
+    return room
+
+
+@pytest.fixture
+def subject_room_b(db, classroom_b, subject, teacher_b, student):
+    """A second subject room owned by teacher_b (different classroom to avoid unique constraint)."""
+    room = SubjectRoom.objects.create(classroom=classroom_b, subject=subject, teacher=teacher_b)
+    room.students.add(student)
+    return room
+
+
+@pytest.fixture
+def question(db, school, standard, subject, chapter):
+    q = Question.objects.create(school=school, standard=standard, subject=subject, chapter=chapter)
+    QuestionSubpart.objects.create(question=q, index=0, question_text="What is velocity?")
+    return q
+
+
+@pytest.fixture
+def question2(db, school, standard, subject, chapter):
+    q = Question.objects.create(school=school, standard=standard, subject=subject, chapter=chapter)
+    QuestionSubpart.objects.create(question=q, index=0, question_text="Define acceleration.")
+    return q
+
+
+@pytest.fixture
+def mistake_high(db, subject_room, question):
+    """High-regression mistake (regression=5.0)."""
+    return SubjectRoomQuestionMistake.objects.create(subject_room=subject_room, question=question, regression=5.0)
+
+
+@pytest.fixture
+def mistake_low(db, subject_room, question2):
+    """Low-regression mistake (regression=1.5)."""
+    return SubjectRoomQuestionMistake.objects.create(subject_room=subject_room, question=question2, regression=1.5)
+
+
+@pytest.fixture
+def mistake_room_b(db, subject_room_b, question):
+    """A mistake in teacher_b's room."""
+    return SubjectRoomQuestionMistake.objects.create(subject_room=subject_room_b, question=question, regression=3.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestStudentDenied:
+    def test_student_gets_403(self, api_client, student, subject_room, mistake_high):
+        api_client.force_authenticate(user=student)
+        url = reverse("question-mistake-list")
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+class TestTeacherOwnership:
+    def test_teacher_sees_own_rooms_only(self, api_client, teacher, subject_room, mistake_high, mistake_low):
+        api_client.force_authenticate(user=teacher)
+        url = reverse("question-mistake-list")
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        ids = [r["id"] for r in response.data["results"]]
+        assert mistake_high.id in ids
+        assert mistake_low.id in ids
+
+    def test_subject_room_filter_narrows_results(self, api_client, teacher, subject_room, mistake_high, mistake_low):
+        api_client.force_authenticate(user=teacher)
+        url = reverse("question-mistake-list")
+        response = api_client.get(url, {"subject_room": subject_room.id})
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["results"]) == 2
+
+
+class TestCrossTeacherIsolation:
+    def test_cross_teacher_isolation(
+        self,
+        api_client,
+        teacher,
+        teacher_b,
+        subject_room,
+        subject_room_b,
+        mistake_high,
+        mistake_room_b,
+    ):
+        # teacher_b should NOT see teacher's room mistakes
+        api_client.force_authenticate(user=teacher_b)
+        url = reverse("question-mistake-list")
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        ids = [r["id"] for r in response.data["results"]]
+        assert mistake_room_b.id in ids
+        assert mistake_high.id not in ids
+
+
+class TestOrdering:
+    def test_results_ordered_by_regression_desc(self, api_client, teacher, subject_room, mistake_high, mistake_low):
+        api_client.force_authenticate(user=teacher)
+        url = reverse("question-mistake-list")
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        regressions = [r["regression"] for r in response.data["results"]]
+        assert regressions == sorted(regressions, reverse=True)

--- a/backend/openshiksha/apps/api/urls.py
+++ b/backend/openshiksha/apps/api/urls.py
@@ -11,6 +11,7 @@ from openshiksha.apps.api.views.core import (
     AssignmentViewSet,
     ChapterViewSet,
     ProblemSetViewSet,
+    QuestionMistakeViewSet,
     QuestionTagViewSet,
     QuestionViewSet,
     StudentProficiencyViewSet,
@@ -32,6 +33,7 @@ router.register(r"problem-sets", ProblemSetViewSet, basename="problemset")
 router.register(r"assignments", AssignmentViewSet, basename="assignment")
 router.register(r"submissions", SubmissionViewSet, basename="submission")
 router.register(r"proficiency", StudentProficiencyViewSet, basename="proficiency")
+router.register(r"question-mistakes", QuestionMistakeViewSet, basename="question-mistake")
 
 urlpatterns = [
     # Authentication endpoints

--- a/backend/openshiksha/apps/api/views/core.py
+++ b/backend/openshiksha/apps/api/views/core.py
@@ -14,6 +14,7 @@ from openshiksha.apps.api.serializers import (
     ChapterSerializer,
     ProblemSetSerializer,
     ProblemSetWriteSerializer,
+    QuestionMistakeSerializer,
     QuestionSerializer,
     QuestionTagSerializer,
     QuestionWriteSerializer,
@@ -35,7 +36,7 @@ from openshiksha.apps.core.models import (
     User,
     UserRole,
 )
-from openshiksha.apps.edge.models import StudentProficiency
+from openshiksha.apps.edge.models import StudentProficiency, SubjectRoomQuestionMistake
 
 
 class IsTeacher(permissions.BasePermission):
@@ -401,3 +402,27 @@ class StudentProficiencyViewSet(viewsets.ReadOnlyModelViewSet):
             )
             .order_by("subject_room__subject__name", "question_tag__name")
         )
+
+
+class QuestionMistakeViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    GET /api/question-mistakes/?subject_room=<id>
+
+    Returns questions ordered by regression (hardest first).
+    Restricted to teachers; only returns data for their own subject rooms.
+    """
+
+    serializer_class = QuestionMistakeSerializer
+    permission_classes = [permissions.IsAuthenticated, IsTeacher]
+
+    def get_queryset(self):
+        qs = (
+            SubjectRoomQuestionMistake.objects.filter(subject_room__teacher=self.request.user)
+            .select_related("question", "subject_room")
+            .prefetch_related("question__subparts")
+            .order_by("-regression")
+        )
+        subject_room_id = self.request.query_params.get("subject_room")
+        if subject_room_id:
+            qs = qs.filter(subject_room_id=subject_room_id)
+        return qs

--- a/frontend_modern/src/features/teacher/TeacherAssignmentDetailPage.tsx
+++ b/frontend_modern/src/features/teacher/TeacherAssignmentDetailPage.tsx
@@ -1,7 +1,9 @@
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTeacherAssignmentDetail } from './useTeacherAssignmentDetail';
+import { useQuestionMistakes } from './useQuestionMistakes';
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import type { SubmissionWithStudent } from './useTeacherAssignmentDetail';
+import type { QuestionMistake } from './useQuestionMistakes';
 
 const formatDate = (iso: string) =>
   new Date(iso).toLocaleDateString('en-IN', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' });
@@ -44,12 +46,44 @@ const SubmissionRow = ({ sub }: { sub: SubmissionWithStudent }) => (
   </tr>
 );
 
+const HardestQuestionsPanel = ({ mistakes }: { mistakes: QuestionMistake[] }) => {
+  if (!mistakes.length) return null;
+  const maxRegression = Math.max(...mistakes.map((m) => m.regression));
+  return (
+    <div className="mt-6 bg-white rounded-xl border border-red-100 p-5">
+      <h3 className="text-sm font-semibold text-gray-900 mb-3">
+        Hardest Questions{' '}
+        <span className="text-gray-400 font-normal">(by cumulative marks lost)</span>
+      </h3>
+      <div className="space-y-3">
+        {mistakes.slice(0, 5).map((m) => (
+          <div key={m.id} className="flex items-start gap-3">
+            <div className="min-w-0 flex-1">
+              <p className="text-xs text-gray-700 line-clamp-2">{m.question_text}</p>
+              <div className="mt-1 h-1.5 bg-gray-100 rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-red-400 rounded-full"
+                  style={{ width: `${Math.round((m.regression / maxRegression) * 100)}%` }}
+                />
+              </div>
+            </div>
+            <span className="shrink-0 text-xs font-semibold text-red-700">
+              {m.regression.toFixed(1)} pts lost
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
 export const TeacherAssignmentDetailPage = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const assignmentId = id ? parseInt(id, 10) : 0;
 
   const { metaQuery, submissionsQuery } = useTeacherAssignmentDetail(assignmentId);
+  const { data: mistakes } = useQuestionMistakes(metaQuery.data?.subject_room);
 
   const isLoading = metaQuery.isLoading || submissionsQuery.isLoading;
   const isError = metaQuery.isError || submissionsQuery.isError;
@@ -171,6 +205,8 @@ export const TeacherAssignmentDetailPage = () => {
           </div>
         )}
       </div>
+
+      <HardestQuestionsPanel mistakes={mistakes ?? []} />
     </div>
   );
 };

--- a/frontend_modern/src/features/teacher/useQuestionMistakes.ts
+++ b/frontend_modern/src/features/teacher/useQuestionMistakes.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+import type { PaginatedResponse } from '@/types/index';
+
+export interface QuestionMistake {
+  id: number;
+  question_id: number;
+  question_text: string;
+  question_type: string;
+  regression: number;
+  updated_at: string;
+}
+
+const fetchQuestionMistakes = async (subjectRoomId: number): Promise<QuestionMistake[]> => {
+  const { data } = await apiClient.get<PaginatedResponse<QuestionMistake>>(
+    `/question-mistakes/?subject_room=${subjectRoomId}`
+  );
+  return data.results;
+};
+
+export const useQuestionMistakes = (subjectRoomId: number | undefined) =>
+  useQuery<QuestionMistake[]>({
+    queryKey: ['question-mistakes', subjectRoomId],
+    queryFn: () => fetchQuestionMistakes(subjectRoomId!),
+    enabled: !!subjectRoomId,
+    staleTime: 2 * 60 * 1000,
+  });


### PR DESCRIPTION
## Summary

- **Classification**: New (no legacy equivalent — legacy had no per-question difficulty analytics)
- Surfaces `SubjectRoomQuestionMistake.regression` data that has been written on every grading cycle since Croupier Phase 2 (PR #73) but was never visible to teachers

## What's implemented

**Backend**
- `QuestionMistakeSerializer` — exposes `question_text` (first subpart), `question_type` (from `Question`), `regression`, `updated_at`
- `QuestionMistakeViewSet` — teacher-only `ReadOnlyModelViewSet`; filters by `?subject_room=<id>`; ordered by `-regression`; uses `prefetch_related("question__subparts")` to avoid N+1
- Registered at `GET /api/question-mistakes/`

**Frontend**
- `useQuestionMistakes(subjectRoomId)` hook — 2-min stale time, disabled when no `subjectRoomId`
- `HardestQuestionsPanel` — top-5 hardest questions with proportional red difficulty bars; hides itself when no data
- `TeacherAssignmentDetailPage` — wires hook to `assignment.subject_room`, renders panel below submissions table

## Tests

5 new tests in `test_question_mistake_api.py`:
- Student gets 403
- Teacher sees own rooms only
- `?subject_room` filter narrows results
- Cross-teacher isolation (teacher B cannot see teacher A's data)
- Results ordered by regression descending

277 backend tests pass total.

## How to verify

1. Run `seed_demo_data`, submit as student (some wrong), grade fires
2. `GET /api/question-mistakes/?subject_room=1` as teacher → regression values present
3. Load `/teacher/assignments/<id>` → "Hardest Questions" panel below submissions table
4. `GET /api/question-mistakes/` as student → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)