### PR TITLE
feat: student learning path page

### DIFF
--- a/frontend_modern/src/App.tsx
+++ b/frontend_modern/src/App.tsx
@@ -6,6 +6,7 @@ import { ProtectedRoute } from './features/layout/ProtectedRoute';
 import { StudentDashboard } from './features/student/StudentDashboard';
 import { AssignmentDetailPage } from './features/student/AssignmentDetailPage';
 import { ProficiencyPage } from './features/student/ProficiencyPage';
+import { LearningPathPage } from './features/student/LearningPathPage';
 import { TeacherDashboard } from './features/teacher/TeacherDashboard';
 import { CreateAssignmentPage } from './features/teacher/CreateAssignmentPage';
 import { CreateQuestionPage } from './features/teacher/CreateQuestionPage';
@@ -78,6 +79,17 @@ function App() {
             <ProtectedRoute>
               <AppShell>
                 <ProficiencyPage />
+              </AppShell>
+            </ProtectedRoute>
+          }
+        />
+
+        <Route
+          path="/student/learning-path"
+          element={
+            <ProtectedRoute>
+              <AppShell>
+                <LearningPathPage />
               </AppShell>
             </ProtectedRoute>
           }

--- a/frontend_modern/src/features/layout/Navbar.tsx
+++ b/frontend_modern/src/features/layout/Navbar.tsx
@@ -40,9 +40,17 @@ export const Navbar = () => {
 
             <div className="flex items-center gap-1">
               {isStudent && (
-                <NavLink to="/student" active={location.pathname.startsWith('/student')}>
-                  Dashboard
-                </NavLink>
+                <>
+                  <NavLink to="/student" active={location.pathname === '/student'}>
+                    Dashboard
+                  </NavLink>
+                  <NavLink
+                    to="/student/learning-path"
+                    active={location.pathname.startsWith('/student/learning-path')}
+                  >
+                    Learning Path
+                  </NavLink>
+                </>
               )}
               {isTeacher && (
                 <NavLink to="/teacher" active={location.pathname.startsWith('/teacher')}>

--- a/frontend_modern/src/features/student/LearningPathPage.tsx
+++ b/frontend_modern/src/features/student/LearningPathPage.tsx
@@ -1,0 +1,119 @@
+import { useLearningPaths } from './useLearningPaths';
+import type { LearningPath, LearningPathStep } from './useLearningPaths';
+import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
+
+const StepRow = ({ step, isCurrent }: { step: LearningPathStep; isCurrent: boolean }) => {
+  const isCompleted = step.status === 'completed';
+  return (
+    <div
+      className={`flex items-start gap-3 py-3 border-b border-gray-100 last:border-0 ${
+        isCurrent ? 'bg-indigo-50 -mx-4 px-4 rounded-lg' : ''
+      }`}
+    >
+      <div
+        className={`mt-0.5 shrink-0 flex items-center justify-center w-6 h-6 rounded-full text-xs font-bold ${
+          isCompleted
+            ? 'bg-green-100 text-green-700'
+            : isCurrent
+              ? 'bg-indigo-600 text-white'
+              : 'bg-gray-100 text-gray-400'
+        }`}
+      >
+        {isCompleted ? '✓' : step.position + 1}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p
+          className={`text-sm font-medium ${
+            isCompleted ? 'text-gray-400 line-through' : isCurrent ? 'text-gray-900' : 'text-gray-500'
+          }`}
+        >
+          {step.chapter_name}
+        </p>
+        <p className="text-xs text-gray-400 mt-0.5">
+          {step.subject_name}
+          {step.is_review && <span className="ml-2 text-amber-600">• Review</span>}
+          {isCompleted && step.score_when_completed !== null && (
+            <span className="ml-2 text-green-600">
+              {Math.round(step.score_when_completed * 100)}%
+            </span>
+          )}
+        </p>
+      </div>
+      {isCurrent && (
+        <span className="shrink-0 text-xs font-medium text-indigo-600 bg-indigo-100 px-2 py-0.5 rounded-full">
+          Up next
+        </span>
+      )}
+    </div>
+  );
+};
+
+const PathCard = ({ path }: { path: LearningPath }) => {
+  const progressPct = Math.round(path.progress_pct * 100);
+  const sorted = [...path.steps].sort((a, b) => a.position - b.position);
+  const currentIndex = (() => {
+    const inProgress = sorted.findIndex((s) => s.status === 'in_progress');
+    return inProgress !== -1 ? inProgress : sorted.findIndex((s) => s.status === 'not_started');
+  })();
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 p-5">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-sm font-semibold text-gray-900">{path.status_display}</h3>
+        <span className="text-xs text-gray-500">
+          {path.completed_steps} / {path.total_steps} steps
+        </span>
+      </div>
+      <div className="h-2 bg-gray-100 rounded-full mb-4 overflow-hidden">
+        <div
+          className="h-full bg-indigo-500 rounded-full transition-all"
+          style={{ width: `${progressPct}%` }}
+        />
+      </div>
+      <div>
+        {sorted.map((step, i) => (
+          <StepRow key={step.id} step={step} isCurrent={i === currentIndex} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export const LearningPathPage = () => {
+  const { data: paths, isLoading } = useLearningPaths();
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-64">
+        <LoadingSpinner size="lg" />
+      </div>
+    );
+  }
+
+  const activePaths = (paths ?? []).filter((p) => p.status !== 'completed');
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-8">
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-gray-900">Your Learning Path</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Steps are ordered by mastery gaps from your practice history.
+        </p>
+      </div>
+      {activePaths.length === 0 ? (
+        <div className="text-center py-16 text-gray-400">
+          <p className="text-base font-medium">No learning paths yet</p>
+          <p className="text-sm mt-1">
+            Complete some practice assignments to generate your path.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {activePaths.map((path) => (
+            <PathCard key={path.id} path={path} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend_modern/src/features/student/RecommendationsPanel.tsx
+++ b/frontend_modern/src/features/student/RecommendationsPanel.tsx
@@ -57,12 +57,20 @@ export const RecommendationsPanel = () => {
           <span className="text-xs text-gray-500">
             {plan.recommendations.length} topic{plan.recommendations.length !== 1 ? 's' : ''} in today&apos;s plan
           </span>
-          <a
-            href="/student/proficiency"
-            className="text-xs font-medium text-indigo-600 hover:text-indigo-800"
-          >
-            View progress →
-          </a>
+          <div className="flex items-center gap-3">
+            <a
+              href="/student/proficiency"
+              className="text-xs font-medium text-indigo-600 hover:text-indigo-800"
+            >
+              View progress →
+            </a>
+            <a
+              href="/student/learning-path"
+              className="text-xs font-medium text-indigo-600 hover:text-indigo-800"
+            >
+              View learning path →
+            </a>
+          </div>
         </div>
       )}
     </div>

--- a/frontend_modern/src/features/student/useLearningPaths.ts
+++ b/frontend_modern/src/features/student/useLearningPaths.ts
@@ -1,0 +1,42 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+import type { PaginatedResponse } from '@/types/index';
+
+export interface LearningPathStep {
+  id: number;
+  position: number;
+  knowledge_node: number;
+  chapter_name: string;
+  subject_name: string;
+  problem_set: number | null;
+  status: 'not_started' | 'in_progress' | 'completed' | 'skipped';
+  status_display: string;
+  is_review: boolean;
+  score_when_completed: number | null;
+  completed_at: string | null;
+}
+
+export interface LearningPath {
+  id: number;
+  subject_room: number;
+  status: 'active' | 'completed' | 'paused';
+  status_display: string;
+  total_steps: number;
+  completed_steps: number;
+  progress_pct: number;
+  steps: LearningPathStep[];
+  generated_at: string;
+  updated_at: string;
+}
+
+const fetchLearningPaths = async (): Promise<LearningPath[]> => {
+  const { data } = await apiClient.get<PaginatedResponse<LearningPath>>('/ai/learning-paths/');
+  return data.results;
+};
+
+export const useLearningPaths = () =>
+  useQuery<LearningPath[]>({
+    queryKey: ['ai', 'learning-paths'],
+    queryFn: fetchLearningPaths,
+    staleTime: 5 * 60 * 1000,
+  });


### PR DESCRIPTION
## Summary

- **Classification**: New (no learning path existed in the legacy system)
- Surfaces the AI-generated `LearningPath` to students. The `LearningPathViewSet` at `/api/ai/learning-paths/` has been live since the AI pipeline PR — this is the first frontend that consumes it

## What's implemented

- `useLearningPaths()` hook — fetches `/ai/learning-paths/`, 5-min stale time
- `LearningPathPage` — `PathCard` per active path showing:
  - Progress bar (`progress_pct * 100` for width)
  - Steps sorted by `position`, not insertion order
  - "Up next" badge on the first `in_progress` or `not_started` step
  - Completed steps shown with strikethrough and score percentage
  - Review steps (SM-2 spaced repetition) marked with "• Review"
  - Empty state for students with no AI-generated paths yet
- Route `/student/learning-path` registered in `App.tsx`
- **Navbar**: "Learning Path" link added for students; Dashboard `active` check fixed from `startsWith('/student')` → `=== '/student'` (was incorrectly highlighting Dashboard on `/student/proficiency`)
- **RecommendationsPanel**: "View learning path →" companion link alongside existing "View progress →"

## How to verify

1. Log in as student → "Learning Path" appears in navbar
2. `/student/learning-path` → shows empty state (before AI pipeline runs)
3. `POST /api/ai/trigger/` (as teacher) → re-check → `PathCard` with ordered steps appears
4. Confirm Dashboard nav link no longer stays active when on `/student/learning-path`

🤖 Generated with [Claude Code](https://claude.com/claude-code)