### PR TITLE
feat: mobile-first responsive pass — Navbar hamburger + student pages

### DIFF
--- a/docs/changes/2026-05-20-proficiency-trends-parent-assignments-mobile.md
+++ b/docs/changes/2026-05-20-proficiency-trends-parent-assignments-mobile.md
@@ -1,0 +1,132 @@
+# 2026-05-20 — Proficiency Trend Snapshots, Parent Assignment View, Mobile Responsive Pass
+
+## Summary
+
+Three independent features shipped as three atomic PRs, all targeting `modernization`.
+
+---
+
+## Priority 1: Proficiency Trend Snapshots
+
+**PR**: [#80](https://github.com/openshiksha/openshiksha/pull/80)
+**Branch**: `feat/2026-05-20-proficiency-trend-snapshots`
+**Classification**: New — legacy discarded scores on every proficiency update; no trend tracking existed.
+
+### What was built
+
+- **`StudentProficiencySnapshot` model** (`edge` app): append-only record written by `_recalculate_percentile` after every grading cycle. Never updated — only inserted. Survives even if the live `StudentProficiency` record is deleted or the student moves rooms.
+- **Migration**: `edge 0002_add_student_proficiency_snapshot` — one new table, no field changes on existing tables.
+- **`GET /api/v1/proficiency/history/?tag=&subject_room=`** action on `StudentProficiencyViewSet`. Students see their own history; parents see a child's history via `?student=<child_id>` (ownership enforced — unlinked students return empty list).
+- **`StudentProficiencySnapshotSerializer`** — minimal read-only payload: `{id, score, recorded_at}`.
+- **`question_tag` integer FK** added to `StudentProficiencySerializer` — non-breaking addition so the frontend can look up history without a second serializer call.
+- **`useProficiencyHistory` hook** (React Query) — fetches snapshot list per (tag, subject_room).
+- **`TrendSparkline` SVG component** — pure SVG polyline, no external chart library. Green = improving trend, red = declining, grey = flat. Renders in 80×24px inline.
+- **`ProficiencyPage` updated** — sparkline appears next to each proficiency score when ≥2 snapshots exist.
+
+### Tests written
+
+8 new tests in `test_proficiency_history_api.py`:
+- Missing params → 400
+- Student gets own history
+- Empty list when no snapshots yet
+- Parent gets child history
+- Parent blocked from non-child student history
+- Parent without `?student=` gets empty
+- `_recalculate_percentile` auto-creates snapshot (integration test)
+
+Full suite: **291 tests passing**, 90% coverage.
+
+### What's different from legacy
+
+Legacy `edge/models.py` had a single `StudentProficiency.score` field overwritten on every recalculation. No history, no trend, no way to answer "am I improving?" This is the first time OpenShiksha has time-series proficiency data.
+
+### Next steps
+
+- Batch `useProficiencyHistory` calls into a single `?tags=1,2,3` endpoint to reduce N+1 parallel requests when the proficiency page has many tags.
+- Show child's sparklines on `ParentDashboard` (extends the parent assignment view from Priority 2).
+- Feed snapshot history into `PerformancePrediction` AI model for forecasting.
+
+---
+
+## Priority 2: Parent Assignment View
+
+**PR**: [#81](https://github.com/openshiksha/openshiksha/pull/81)
+**Branch**: `feat/2026-05-20-parent-assignment-view`
+**Classification**: New — legacy parents had zero web visibility into assignments (SMS-only via Pylon).
+
+### What was built
+
+- **`AssignmentViewSet.get_queryset` parent branch**: `GET /api/v1/assignments/?student=<child_id>` returns the child's active assignments, sorted by `-assigned_at`. Ownership enforced — non-linked `?student=` returns empty queryset. `prefetch_related("submissions")` included for the parent branch to avoid N+1 on `child_submission_status`.
+- **`child_submission_status` field** on `AssignmentSerializer`: `SerializerMethodField` returning `'submitted'` or `'not_submitted'` for parent role; `None` for all other roles (non-breaking for student/teacher responses). Uses `_prefetched_objects_cache` when present to avoid extra queries.
+- **`Assignment` TypeScript interface**: `child_submission_status?: 'submitted' | 'not_submitted' | null` added as optional field.
+- **`useChildAssignments` hook** (React Query, 2-minute stale time) — fetches child assignment list with `?student=<child_id>`.
+- **`ParentDashboard` tabbed interface**: "Progress" tab (existing proficiency bars) and "Assignments" tab (new). `ChildAssignmentsView` shows assignment cards sorted by due date with colour-coded status badges (green = submitted, amber = pending, overdue label in red).
+
+### Tests written
+
+4 new tests in `test_parent_dashboard_api.py` (10 total):
+- Parent sees child assignments via `?student=<child_id>`
+- `child_submission_status` is `'not_submitted'` for unsubmitted assignment
+- Parent cannot see non-linked child's assignments
+- Parent without `?student=` gets empty list
+
+Suite: **287 tests passing**, 89% coverage.
+
+### What's different from legacy
+
+Legacy parents received only SMS notifications via Pylon (`pylon/` app). No web interface existed. Phase 1 (PR #79, May 7) added proficiency bars. Phase 2 (this PR) adds the most practical daily question: "Did my child do their homework?"
+
+---
+
+## Priority 3: Mobile-First Responsive Pass
+
+**PR**: [#82](https://github.com/openshiksha/openshiksha/pull/82)
+**Branch**: `feat/2026-05-20-mobile-responsive-student`
+**Classification**: New — legacy was desktop-only Django template UI with no mobile consideration.
+
+### What was built
+
+**Navbar** (`features/layout/Navbar.tsx`):
+- Hamburger button (`sm:hidden`) with open/close toggle and `aria-expanded`
+- Desktop nav links hidden on mobile (`hidden sm:flex`)
+- Mobile dropdown: user identity header (name + role badge), role-specific nav links, sign-out button
+- `useEffect` closes mobile menu on `location.pathname` change
+- `z-20` on nav so dropdown overlays page content
+
+**AssignmentCard** (`features/student/AssignmentCard.tsx`):
+- CTA button: `w-full sm:w-auto` (full-width on mobile, auto on desktop)
+- Footer: `flex-col sm:flex-row` (stacks vertically on mobile)
+- Touch target height: `py-2.5 sm:py-1.5`
+
+**AssignmentDetailPage** (`features/student/AssignmentDetailPage.tsx`):
+- Submit button: `w-full sm:w-auto`, `py-3 sm:py-2.5` for 44px+ touch target
+
+**StudentDashboard** (`features/student/StudentDashboard.tsx`):
+- Header: `min-w-0` + `truncate` on greeting, `shrink-0` on "My Progress" link
+
+### What's different from legacy
+
+Legacy had no mobile support. India's student demographic skews heavily mobile — students in rural/semi-urban areas may have no desktop. This pass removes the primary UX friction for actual users. Scoped to the three highest-traffic student pages; full site audit remains a lower-priority follow-up.
+
+### Verification
+
+Manual at 375px (Chrome DevTools, iPhone SE preset):
+- [ ] Navbar hamburger visible, nav links hidden
+- [ ] Tapping hamburger opens mobile menu
+- [ ] Nav link tap navigates and closes menu
+- [ ] StudentDashboard renders without horizontal scroll
+- [ ] AssignmentCard CTA spans full width
+- [ ] AssignmentDetailPage submit button spans full width
+
+---
+
+## Migration Notes
+
+Run `python manage.py migrate` to apply `edge 0002_add_student_proficiency_snapshot`. One new table; no changes to existing tables.
+
+## Next Session Priorities
+
+1. Proficiency sparklines on parent dashboard (extends PR #80 + #81)
+2. Batch proficiency history endpoint (`?tags=1,2,3`)
+3. Question content search (add `subparts__question_text` to `QuestionViewSet.search_fields`)
+4. Notification system (email on assignment-due / grading-complete)

--- a/frontend_modern/src/features/layout/Navbar.tsx
+++ b/frontend_modern/src/features/layout/Navbar.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { UserRole } from '@/types/index';
@@ -21,16 +22,22 @@ const ROLE_COLORS: Record<string, string> = {
 export const Navbar = () => {
   const { user, logout } = useAuth();
   const location = useLocation();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  // Close mobile menu on route change
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [location.pathname]);
 
   const isStudent = user?.role === UserRole.STUDENT || user?.role === UserRole.OPEN_STUDENT;
   const isTeacher = user?.role === UserRole.TEACHER;
   const isParent = user?.role === UserRole.PARENT;
 
   return (
-    <nav className="bg-white border-b border-gray-200 sticky top-0 z-10">
+    <nav className="bg-white border-b border-gray-200 sticky top-0 z-20">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
-          {/* Left: Brand + Nav links */}
+          {/* Left: Brand + Desktop nav links */}
           <div className="flex items-center gap-6">
             <Link to="/" className="flex items-center gap-2">
               <div className="w-8 h-8 bg-indigo-600 rounded-lg flex items-center justify-center">
@@ -39,7 +46,8 @@ export const Navbar = () => {
               <span className="font-semibold text-gray-900 hidden sm:block">OpenShiksha</span>
             </Link>
 
-            <div className="flex items-center gap-1">
+            {/* Desktop nav — hidden on mobile */}
+            <div className="hidden sm:flex items-center gap-1">
               {isStudent && (
                 <>
                   <NavLink to="/student" active={location.pathname === '/student'}>
@@ -74,29 +82,101 @@ export const Navbar = () => {
             </div>
           </div>
 
-          {/* Right: User info + logout */}
-          {user && (
-            <div className="flex items-center gap-3">
-              <span className="text-sm text-gray-700 hidden sm:block">
+          {/* Right: User info + logout (desktop) + hamburger (mobile) */}
+          <div className="flex items-center gap-2">
+            {user && (
+              <>
+                <span className="text-sm text-gray-700 hidden sm:block">
+                  {user.first_name || user.username}
+                </span>
+                <span
+                  className={`hidden sm:inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                    ROLE_COLORS[user.role] ?? 'bg-gray-100 text-gray-700'
+                  }`}
+                >
+                  {ROLE_LABELS[user.role] ?? user.role}
+                </span>
+                <button
+                  onClick={logout}
+                  className="hidden sm:block text-sm text-gray-500 hover:text-gray-900 transition-colors px-3 py-1.5 rounded-lg hover:bg-gray-100"
+                >
+                  Sign out
+                </button>
+              </>
+            )}
+
+            {/* Hamburger button — mobile only */}
+            {user && (
+              <button
+                className="sm:hidden p-2 rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+                onClick={() => setMenuOpen((v) => !v)}
+                aria-label="Toggle navigation"
+                aria-expanded={menuOpen}
+              >
+                {menuOpen ? (
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                ) : (
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                  </svg>
+                )}
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile dropdown menu */}
+      {menuOpen && user && (
+        <div className="sm:hidden border-t border-gray-200 bg-white z-20">
+          <div className="px-4 py-3 space-y-1">
+            {/* User identity */}
+            <div className="flex items-center gap-2 pb-3 border-b border-gray-100 mb-2">
+              <span className="text-sm font-medium text-gray-900">
                 {user.first_name || user.username}
               </span>
               <span
-                className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
                   ROLE_COLORS[user.role] ?? 'bg-gray-100 text-gray-700'
                 }`}
               >
                 {ROLE_LABELS[user.role] ?? user.role}
               </span>
+            </div>
+
+            {/* Role-specific nav links */}
+            {isStudent && (
+              <>
+                <MobileNavLink to="/student">Dashboard</MobileNavLink>
+                <MobileNavLink to="/student/learning-path">Learning Path</MobileNavLink>
+                <MobileNavLink to="/student/proficiency">My Progress</MobileNavLink>
+              </>
+            )}
+            {isTeacher && (
+              <>
+                <MobileNavLink to="/teacher">Dashboard</MobileNavLink>
+                <MobileNavLink to="/teacher/questions">Questions</MobileNavLink>
+              </>
+            )}
+            {isParent && <MobileNavLink to="/parent">Dashboard</MobileNavLink>}
+
+            {/* Sign out */}
+            <div className="pt-2 border-t border-gray-100 mt-2">
               <button
-                onClick={logout}
-                className="text-sm text-gray-500 hover:text-gray-900 transition-colors px-3 py-1.5 rounded-lg hover:bg-gray-100"
+                onClick={() => {
+                  logout();
+                  setMenuOpen(false);
+                }}
+                className="w-full text-left px-3 py-2.5 text-sm text-red-600 hover:bg-red-50 rounded-md transition-colors"
               >
                 Sign out
               </button>
             </div>
-          )}
+          </div>
         </div>
-      </div>
+      )}
     </nav>
   );
 };
@@ -115,6 +195,15 @@ const NavLink = ({ to, active, children }: NavLinkProps) => (
         ? 'bg-indigo-50 text-indigo-700'
         : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
     }`}
+  >
+    {children}
+  </Link>
+);
+
+const MobileNavLink = ({ to, children }: { to: string; children: React.ReactNode }) => (
+  <Link
+    to={to}
+    className="block px-3 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-100 rounded-md transition-colors"
   >
     {children}
   </Link>

--- a/frontend_modern/src/features/student/AssignmentCard.tsx
+++ b/frontend_modern/src/features/student/AssignmentCard.tsx
@@ -71,13 +71,13 @@ export const AssignmentCard = ({ assignment }: AssignmentCardProps) => {
       )}
 
       {/* Footer: due date + CTA */}
-      <div className="flex items-center justify-between mt-4">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mt-4">
         <span className={`text-xs ${isOverdue && !isSubmitted ? 'text-red-600 font-medium' : 'text-gray-400'}`}>
           {isSubmitted ? 'Submitted' : dueDateLabel}
         </span>
         <button
           onClick={() => navigate(`/student/assignments/${assignment.id}`)}
-          className={`text-sm font-medium px-4 py-1.5 rounded-lg transition-colors ${ctaStyle}`}
+          className={`w-full sm:w-auto text-sm font-medium px-4 py-2.5 sm:py-1.5 rounded-lg transition-colors ${ctaStyle}`}
         >
           {cta}
         </button>

--- a/frontend_modern/src/features/student/AssignmentDetailPage.tsx
+++ b/frontend_modern/src/features/student/AssignmentDetailPage.tsx
@@ -231,7 +231,7 @@ export const AssignmentDetailPage = () => {
           <button
             onClick={() => setShowConfirm(true)}
             disabled={answered === 0}
-            className="bg-indigo-600 text-white px-6 py-2.5 rounded-lg font-medium text-sm hover:bg-indigo-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            className="w-full sm:w-auto bg-indigo-600 text-white px-6 py-3 sm:py-2.5 rounded-lg font-medium text-sm hover:bg-indigo-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
           >
             Submit assignment
           </button>

--- a/frontend_modern/src/features/student/StudentDashboard.tsx
+++ b/frontend_modern/src/features/student/StudentDashboard.tsx
@@ -16,14 +16,14 @@ export const StudentDashboard = () => {
   return (
     <div>
       {/* Page header */}
-      <div className="flex items-start justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">{greeting}</h1>
-          <p className="text-gray-500 mt-1">Here are your assignments</p>
+      <div className="flex items-start justify-between gap-4 mb-6">
+        <div className="min-w-0">
+          <h1 className="text-2xl font-bold text-gray-900 truncate">{greeting}</h1>
+          <p className="text-gray-500 mt-1 text-sm sm:text-base">Here are your assignments</p>
         </div>
         <button
           onClick={() => navigate('/student/proficiency')}
-          className="text-sm text-indigo-600 hover:text-indigo-800 font-medium whitespace-nowrap"
+          className="text-sm text-indigo-600 hover:text-indigo-800 font-medium whitespace-nowrap shrink-0 mt-1"
         >
           My Progress →
         </button>


### PR DESCRIPTION
## Summary

- **New** — legacy was desktop-only (Django template UI, no mobile consideration)
- Navbar hamburger menu on mobile: role-specific links, user identity, sign-out; auto-closes on route change
- Desktop nav links hidden on mobile (`hidden sm:flex`); hamburger hidden on desktop (`sm:hidden`)
- AssignmentCard: CTA button full-width on mobile, stacks footer vertically, taller touch targets (44px+)
- AssignmentDetailPage: submit button full-width on mobile
- StudentDashboard: header flex layout fixes title truncation on narrow viewports
- AppShell already had responsive padding — no change needed

## Classification
**New** — legacy had no mobile consideration. India's student demographic skews heavily mobile; 375px support removes a real access barrier.

## Scope
Targeted to the 3 highest-traffic student pages (dashboard, assignment detail, Navbar). Not a full site audit.

## Tests written
No automated tests (layout/responsive verification is manual). Frontend type-check and lint pass clean.

## How to verify
At 375px viewport (Chrome DevTools → iPhone SE):
1. Navbar shows hamburger icon, not nav links
2. Tap hamburger → mobile menu opens with role-specific links + sign out
3. Tap a link → menu closes automatically
4. StudentDashboard: no horizontal scroll, heading truncates cleanly
5. AssignmentCard: CTA button spans full width, footer stacks date above button
6. AssignmentDetailPage: submit button spans full width with comfortable tap target

🤖 Generated with [Claude Code](https://claude.com/claude-code)