### PR TITLE
feat(srs): practice drill mode closes the spaced-repetition loop

### DIFF
--- a/backend/openshiksha/apps/ai/tests/test_srs_drill_api.py
+++ b/backend/openshiksha/apps/ai/tests/test_srs_drill_api.py
@@ -1,0 +1,254 @@
+"""
+Tests for the SRS practice drill API.
+
+Covers:
+- /api/v1/ai/spaced-repetition/{id}/review/    — returns chapter questions (student-safe)
+- /api/v1/ai/spaced-repetition/{id}/mark-reviewed/ — applies SM-2 update
+
+Two grading shapes are supported:
+- {"answers": {<subpart_id>: <answer>}} → server grades using core._grade_subpart
+- {"score": 0.8}                        → client-supplied score (fallback)
+"""
+
+import json
+
+import pytest
+
+from django.test import Client
+from django.utils import timezone
+
+from openshiksha.apps.ai.models import SpacedRepetitionEntry
+from openshiksha.apps.ai.tests.test_adaptive_learning import make_chapter, make_knowledge_node, make_subject, make_user
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _make_question_with_subpart(chapter, *, qtype="mcq", correct="A", options=None):
+    """Create a Question with one QuestionSubpart in the given chapter."""
+    from openshiksha.apps.core.models import Question, QuestionSubpart, Standard
+
+    standard, _ = Standard.objects.get_or_create(number=7)
+    q = Question.objects.create(
+        standard=standard,
+        subject=chapter.subject,
+        chapter=chapter,
+        question_type=qtype,
+    )
+    if options is None and qtype == "mcq":
+        options = [
+            {"key": "A", "text": "Photosynthesis"},
+            {"key": "B", "text": "Respiration"},
+            {"key": "C", "text": "Digestion"},
+            {"key": "D", "text": "Excretion"},
+        ]
+    subpart = QuestionSubpart.objects.create(
+        question=q,
+        index=0,
+        question_text="What process produces oxygen in plants?",
+        options=options,
+        correct_answer={"answer": correct},
+    )
+    return q, subpart
+
+
+def _make_entry(student, subject_name="Biology", chapter_name="Plants"):
+    subject = make_subject(subject_name)
+    chapter = make_chapter(chapter_name, subject=subject)
+    node = make_knowledge_node(subject, chapter)
+    entry = SpacedRepetitionEntry.objects.create(
+        student=student,
+        knowledge_node=node,
+        interval_days=1,
+        easiness_factor=2.5,
+        repetitions=0,
+        next_review_date=timezone.localdate(),
+    )
+    return entry, chapter
+
+
+def _client_for(student):
+    client = Client()
+    client.force_login(student)
+    return client
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# review action
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestSRSReviewAction:
+    def test_review_returns_chapter_questions(self):
+        student = make_user(role="student", username="srs_review_student")
+        entry, chapter = _make_entry(student)
+        _make_question_with_subpart(chapter)
+        _make_question_with_subpart(chapter)
+
+        client = _client_for(student)
+        response = client.get(f"/api/v1/ai/spaced-repetition/{entry.id}/review/")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["entry_id"] == entry.id
+        assert data["chapter_name"] == chapter.name
+        assert data["subject_name"] == chapter.subject.name
+        assert len(data["questions"]) == 2
+        # Student-safe serializer must not expose correct_answer
+        for question in data["questions"]:
+            for subpart in question["subparts"]:
+                assert "correct_answer" not in subpart
+
+    def test_review_requires_owning_student(self):
+        owner = make_user(role="student", username="srs_owner")
+        other = make_user(role="student", username="srs_other")
+        entry, _ = _make_entry(owner)
+
+        client = _client_for(other)
+        response = client.get(f"/api/v1/ai/spaced-repetition/{entry.id}/review/")
+        # other student can't even see the entry — get_queryset filters by student
+        assert response.status_code == 404
+
+    def test_review_caps_at_five_questions(self):
+        student = make_user(role="student", username="srs_cap_student")
+        entry, chapter = _make_entry(student)
+        for _ in range(8):
+            _make_question_with_subpart(chapter)
+
+        client = _client_for(student)
+        response = client.get(f"/api/v1/ai/spaced-repetition/{entry.id}/review/")
+        assert response.status_code == 200
+        assert len(response.json()["questions"]) == 5
+
+    def test_review_empty_chapter(self):
+        student = make_user(role="student", username="srs_empty_student")
+        entry, _ = _make_entry(student)
+        client = _client_for(student)
+        response = client.get(f"/api/v1/ai/spaced-repetition/{entry.id}/review/")
+        assert response.status_code == 200
+        assert response.json()["questions"] == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# mark_reviewed action
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestMarkReviewedAction:
+    def test_score_success_grows_interval(self):
+        student = make_user(role="student", username="srs_success")
+        entry, _ = _make_entry(student)
+        entry.repetitions = 2
+        entry.interval_days = 6
+        entry.save()
+
+        client = _client_for(student)
+        response = client.post(
+            f"/api/v1/ai/spaced-repetition/{entry.id}/mark-reviewed/",
+            data=json.dumps({"score": 0.9}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        entry.refresh_from_db()
+        assert entry.repetitions == 3
+        # interval grows: 6 * easiness_factor (≥ 6)
+        assert entry.interval_days >= 6
+        assert entry.next_review_date > timezone.localdate()
+        assert entry.last_reviewed_at is not None
+
+    def test_score_failure_resets(self):
+        student = make_user(role="student", username="srs_fail")
+        entry, _ = _make_entry(student)
+        entry.repetitions = 5
+        entry.interval_days = 30
+        entry.save()
+
+        client = _client_for(student)
+        response = client.post(
+            f"/api/v1/ai/spaced-repetition/{entry.id}/mark-reviewed/",
+            data=json.dumps({"score": 0.4}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        entry.refresh_from_db()
+        assert entry.repetitions == 0
+        assert entry.interval_days == 1
+
+    def test_invalid_score_returns_400(self):
+        student = make_user(role="student", username="srs_invalid")
+        entry, _ = _make_entry(student)
+        client = _client_for(student)
+        response = client.post(
+            f"/api/v1/ai/spaced-repetition/{entry.id}/mark-reviewed/",
+            data=json.dumps({"score": "banana"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_answers_grading_correct_mcq(self):
+        student = make_user(role="student", username="srs_grade_mcq")
+        entry, chapter = _make_entry(student)
+        _, subpart = _make_question_with_subpart(chapter, qtype="mcq", correct="A")
+
+        # Fetch what the student actually sees (croupier may shuffle MCQ keys)
+        client = _client_for(student)
+        review = client.get(f"/api/v1/ai/spaced-repetition/{entry.id}/review/").json()
+        # Find the displayed key for the "Photosynthesis" option (correct text)
+        displayed_subpart = review["questions"][0]["subparts"][0]
+        displayed_key = next(o["key"] for o in displayed_subpart["options"] if o["text"] == "Photosynthesis")
+
+        response = client.post(
+            f"/api/v1/ai/spaced-repetition/{entry.id}/mark-reviewed/",
+            data=json.dumps({"answers": {str(subpart.id): displayed_key}}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["score"] == 1.0
+        entry.refresh_from_db()
+        assert entry.repetitions == 1
+
+    def test_answers_grading_partial(self):
+        student = make_user(role="student", username="srs_grade_partial")
+        entry, chapter = _make_entry(student)
+        _, subpart_a = _make_question_with_subpart(chapter, qtype="numeric", correct="42", options=None)
+        _, subpart_b = _make_question_with_subpart(chapter, qtype="numeric", correct="100", options=None)
+
+        client = _client_for(student)
+        response = client.post(
+            f"/api/v1/ai/spaced-repetition/{entry.id}/mark-reviewed/",
+            data=json.dumps({"answers": {str(subpart_a.id): "42", str(subpart_b.id): "1"}}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        body = response.json()
+        # 1 of 2 correct = 0.5 — failed recall, resets
+        assert body["score"] == 0.5
+        entry.refresh_from_db()
+        assert entry.repetitions == 0
+        assert entry.interval_days == 1
+
+    def test_other_student_cannot_mark_reviewed(self):
+        owner = make_user(role="student", username="srs_mr_owner")
+        other = make_user(role="student", username="srs_mr_other")
+        entry, _ = _make_entry(owner)
+        client = _client_for(other)
+        response = client.post(
+            f"/api/v1/ai/spaced-repetition/{entry.id}/mark-reviewed/",
+            data=json.dumps({"score": 0.9}),
+            content_type="application/json",
+        )
+        assert response.status_code == 404
+
+    def test_no_body_returns_400(self):
+        student = make_user(role="student", username="srs_no_body")
+        entry, _ = _make_entry(student)
+        client = _client_for(student)
+        response = client.post(
+            f"/api/v1/ai/spaced-repetition/{entry.id}/mark-reviewed/",
+            data=json.dumps({}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400

--- a/backend/openshiksha/apps/ai/views.py
+++ b/backend/openshiksha/apps/ai/views.py
@@ -418,6 +418,142 @@ class SpacedRepetitionViewSet(ReadOnlyModelViewSet):
             .order_by("next_review_date")
         )
 
+    @action(detail=True, methods=["get"], url_path="review")
+    def review(self, request, pk=None):
+        """
+        GET /api/v1/ai/spaced-repetition/{id}/review/
+        Returns up to 5 questions from the chapter associated with this SRS entry.
+        Only the owning student may access this — uses student-safe serializer
+        (no correct_answer exposed; grading happens in mark_reviewed).
+        """
+        entry = self.get_object()
+        if entry.student_id != request.user.id:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        from openshiksha.apps.api.serializers.core import QuestionWithSubpartsStudentSerializer
+        from openshiksha.apps.core.models import Question
+
+        questions = list(
+            Question.objects.filter(
+                chapter=entry.knowledge_node.chapter,
+                is_active=True,
+            )
+            .prefetch_related("subparts__tags", "tags")
+            .order_by("?")[:5]
+        )
+
+        return Response(
+            {
+                "entry_id": entry.id,
+                "chapter_name": entry.knowledge_node.chapter.name,
+                "subject_name": entry.knowledge_node.subject.name,
+                "questions": QuestionWithSubpartsStudentSerializer(
+                    questions, many=True, context={"request": request}
+                ).data,
+            }
+        )
+
+    @action(detail=True, methods=["post"], url_path="mark-reviewed")
+    def mark_reviewed(self, request, pk=None):
+        """
+        POST /api/v1/ai/spaced-repetition/{id}/mark-reviewed/
+
+        Two accepted body shapes:
+          {"answers": {"<subpart_id>": "<student_answer>", ...}}  (preferred — server grades)
+          {"score": 0.8}                                          (fallback — client-supplied score)
+
+        Updates SM-2 schedule:
+          score >= 0.6 → successful recall, interval grows
+          score <  0.6 → failed recall, reset to interval=1
+        """
+        entry = self.get_object()
+        if entry.student_id != request.user.id:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from openshiksha.apps.core.models import QuestionSubpart
+        from openshiksha.apps.core.tasks import _grade_subpart
+
+        answers = request.data.get("answers")
+        if answers is not None:
+            if not isinstance(answers, dict):
+                return Response({"detail": "answers must be an object."}, status=400)
+            if not answers:
+                return Response({"detail": "answers must not be empty."}, status=400)
+            subparts = QuestionSubpart.objects.select_related("question").filter(
+                id__in=[int(k) for k in answers.keys() if str(k).isdigit()],
+                question__chapter=entry.knowledge_node.chapter,
+            )
+            total = 0
+            correct_sum = 0.0
+            for subpart in subparts:
+                student_answer = answers.get(str(subpart.id))
+                if student_answer is None or student_answer == "":
+                    total += 1
+                    continue
+                fraction = _grade_subpart(
+                    question_type=subpart.question.question_type,
+                    student_answer=student_answer,
+                    correct_answer=subpart.correct_answer or {},
+                    student_id=request.user.id,
+                    subpart_id=subpart.id,
+                    original_options=subpart.options,
+                    variable_constraints=subpart.variable_constraints,
+                )
+                correct_sum += fraction
+                total += 1
+            if total == 0:
+                return Response({"detail": "no valid subparts to grade."}, status=400)
+            score = correct_sum / total
+        else:
+            raw_score = request.data.get("score")
+            try:
+                score = float(raw_score)
+                if not (0.0 <= score <= 1.0):
+                    raise ValueError()
+            except (TypeError, ValueError):
+                return Response(
+                    {"detail": "Provide either answers (object) or score (0.0–1.0)."},
+                    status=400,
+                )
+
+        if score >= 0.60:
+            if entry.repetitions == 0:
+                new_interval = 1
+            elif entry.repetitions == 1:
+                new_interval = 6
+            else:
+                new_interval = max(1, round(entry.interval_days * entry.easiness_factor))
+            new_ef = max(1.3, entry.easiness_factor + 0.1 - (1 - score) * 0.8)
+            new_reps = entry.repetitions + 1
+        else:
+            new_interval = 1
+            new_ef = entry.easiness_factor
+            new_reps = 0
+
+        entry.interval_days = new_interval
+        entry.easiness_factor = new_ef
+        entry.repetitions = new_reps
+        entry.next_review_date = timezone.localdate() + timedelta(days=new_interval)
+        entry.last_reviewed_at = timezone.now()
+        entry.save(
+            update_fields=[
+                "interval_days",
+                "easiness_factor",
+                "repetitions",
+                "next_review_date",
+                "last_reviewed_at",
+                "updated_at",
+            ]
+        )
+
+        data = self.get_serializer(entry).data
+        data["score"] = round(score, 4)
+        return Response(data)
+
     @action(detail=False, methods=["get"], url_path="due")
     def due(self, request):
         """Return SRS entries due for review today or in the next 3 days."""

--- a/docs/changes/2026-05-21-srs-drill-mode.md
+++ b/docs/changes/2026-05-21-srs-drill-mode.md
@@ -1,0 +1,59 @@
+# SRS Practice Drill Mode
+
+**Date**: 2026-05-21
+**Classification**: New
+**PR Target**: `feat/2026-05-21-srs-drill` → `modernization`
+
+## Summary
+
+Closes the spaced-repetition loop. Students could already *see* what chapters were due for review via the `DueForReviewPanel`, but the rows were inert. Now tapping **Practice** opens a drill page that pulls up to 5 questions from that chapter, lets the student answer them, and updates the SM-2 schedule based on a server-graded score.
+
+## Legacy Reference
+
+None — legacy OpenShiksha had no spaced repetition system. This builds on the modern `SpacedRepetitionEntry` (SM-2) infrastructure shipped earlier.
+
+## What's New vs. Plan
+
+The plan suggested computing the score on the client and POSTing it raw. We deviated to **server-side grading**:
+
+- `mark_reviewed` accepts `{"answers": {<subpart_id>: <answer>}}` and grades server-side via the existing `core.tasks._grade_subpart` helper.
+- This keeps `correct_answer` off the wire (the review endpoint uses `QuestionWithSubpartsStudentSerializer`, consistent with assignment endpoints).
+- A `{"score": <float>}` fallback shape is also accepted, so future client surfaces (or tests) can supply a pre-computed score.
+
+This adds two lines of defense:
+1. Croupier MCQ shuffling still works (server reverses the shuffle during grading).
+2. A student can't open devtools and read off the answers.
+
+## Technical Details
+
+### Backend
+- `backend/openshiksha/apps/ai/views.py` — added two actions to `SpacedRepetitionViewSet`:
+  - `GET /api/v1/ai/spaced-repetition/{id}/review/` — returns up to 5 random active questions from the entry's chapter via the student-safe serializer.
+  - `POST /api/v1/ai/spaced-repetition/{id}/mark-reviewed/` — grades answers server-side (or accepts a raw `score`), applies the SM-2 update inline, returns the refreshed entry plus the computed `score`.
+- SM-2 update logic ported directly from the model docstring: success grows interval (1 → 6 → `interval * ef`), failure resets to interval 1 with reps 0.
+
+### Frontend
+- `frontend_modern/src/features/student/useSRSDrill.ts` — `useSRSDrill` (GET) and `useMarkReviewed` (POST) hooks.
+- `frontend_modern/src/features/student/SRSDrillPage.tsx` — new page with loading, empty, in-progress, and result states. Reuses existing `QuestionCard`.
+- `frontend_modern/src/App.tsx` — registered `/student/srs-drill/:entryId` route.
+- `frontend_modern/src/features/student/DueForReviewPanel.tsx` — added **Practice** pill button to each row, leading to the drill.
+
+## Tests
+
+**Backend** (`backend/openshiksha/apps/ai/tests/test_srs_drill_api.py`, 11 tests):
+- `review` returns chapter questions, caps at 5, hides `correct_answer`, scopes to owning student, handles empty chapters.
+- `mark_reviewed` grows interval on success, resets on failure, accepts raw `score`, accepts `answers` (with correct MCQ key after Croupier shuffle) for full credit and partial credit, rejects invalid input, scopes to owning student.
+
+Full backend suite: **306 passed**, up from 291.
+
+Frontend: type-check, lint, build, and vitest suite all clean.
+
+## Migration Notes
+
+No model changes — no migration required.
+
+## Next Steps
+
+- Feed drill scores back into `StudentProficiency` / `StudentMastery` (Phase 2). Right now the drill only nudges SM-2; the broader proficiency pipeline is not touched.
+- Move SM-2 update into a model method (`SpacedRepetitionEntry.apply_sm2(score)`) so the same logic can be reused by the existing Celery-side scheduler in `adaptive_analytics.compute_srs_update`.
+- Activity Streaks (Priority 2 on today's plan) — deferred to a follow-up PR for atomic review.

--- a/frontend_modern/src/App.tsx
+++ b/frontend_modern/src/App.tsx
@@ -7,6 +7,7 @@ import { StudentDashboard } from './features/student/StudentDashboard';
 import { AssignmentDetailPage } from './features/student/AssignmentDetailPage';
 import { ProficiencyPage } from './features/student/ProficiencyPage';
 import { LearningPathPage } from './features/student/LearningPathPage';
+import { SRSDrillPage } from './features/student/SRSDrillPage';
 import { TeacherDashboard } from './features/teacher/TeacherDashboard';
 import { CreateAssignmentPage } from './features/teacher/CreateAssignmentPage';
 import { CreateQuestionPage } from './features/teacher/CreateQuestionPage';
@@ -94,6 +95,17 @@ function App() {
             <ProtectedRoute>
               <AppShell>
                 <LearningPathPage />
+              </AppShell>
+            </ProtectedRoute>
+          }
+        />
+
+        <Route
+          path="/student/srs-drill/:entryId"
+          element={
+            <ProtectedRoute>
+              <AppShell>
+                <SRSDrillPage />
               </AppShell>
             </ProtectedRoute>
           }

--- a/frontend_modern/src/features/student/DueForReviewPanel.tsx
+++ b/frontend_modern/src/features/student/DueForReviewPanel.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { useSpacedRepetitionDue } from './useSpacedRepetitionDue';
 import type { SRSEntry } from './useSpacedRepetitionDue';
 
@@ -37,9 +38,17 @@ const SRSRow = ({ entry }: { entry: SRSEntry }) => {
           <p className={`text-xs ${style.text}`}>{dueLabel}</p>
         </div>
       </div>
-      <div className="text-right shrink-0 ml-3">
-        <p className="text-xs text-gray-500">every {entry.interval_days}d</p>
-        <p className="text-xs text-gray-400">{entry.repetitions}× reviewed</p>
+      <div className="flex items-center gap-3 shrink-0 ml-3">
+        <div className="text-right hidden sm:block">
+          <p className="text-xs text-gray-500">every {entry.interval_days}d</p>
+          <p className="text-xs text-gray-400">{entry.repetitions}× reviewed</p>
+        </div>
+        <Link
+          to={`/student/srs-drill/${entry.id}`}
+          className="text-xs font-semibold text-indigo-600 hover:text-white border border-indigo-200 rounded-full px-3 py-1 hover:bg-indigo-600 hover:border-indigo-600 transition-colors"
+        >
+          Practice
+        </Link>
       </div>
     </div>
   );

--- a/frontend_modern/src/features/student/SRSDrillPage.tsx
+++ b/frontend_modern/src/features/student/SRSDrillPage.tsx
@@ -1,0 +1,215 @@
+import { useMemo, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { QuestionCard } from './QuestionCard';
+import { useMarkReviewed, useSRSDrill, type SRSReviewResult } from './useSRSDrill';
+
+/**
+ * SRS practice drill flow:
+ * 1. Load chapter questions via /ai/spaced-repetition/{id}/review/
+ * 2. Student answers each subpart in a familiar QuestionCard
+ * 3. Submit POSTs {answers} to /mark-reviewed/ → server grades + updates SM-2
+ * 4. Result screen shows score and next review date
+ */
+export const SRSDrillPage = () => {
+  const { entryId } = useParams<{ entryId: string }>();
+  const navigate = useNavigate();
+  const parsedId = entryId ? parseInt(entryId, 10) : null;
+
+  const { data: drill, isLoading, isError } = useSRSDrill(parsedId);
+  const { mutate: markReviewed, isPending } = useMarkReviewed();
+
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [result, setResult] = useState<SRSReviewResult | null>(null);
+
+  const answeredCount = useMemo(
+    () => Object.values(answers).filter((v) => v && v.trim().length > 0).length,
+    [answers]
+  );
+  const totalSubparts = useMemo(
+    () => drill?.questions.reduce((sum, q) => sum + q.subparts.length, 0) ?? 0,
+    [drill]
+  );
+
+  const handleAnswerChange = (subpartId: number, value: string) => {
+    setAnswers((prev) => ({ ...prev, [String(subpartId)]: value }));
+  };
+
+  const handleSubmit = () => {
+    if (!drill || answeredCount === 0) return;
+    markReviewed(
+      { entryId: drill.entry_id, answers },
+      { onSuccess: (data) => setResult(data) }
+    );
+  };
+
+  if (isLoading) {
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-12 flex items-center justify-center">
+        <div className="flex flex-col items-center gap-3 text-gray-500">
+          <div className="h-10 w-10 rounded-full border-2 border-indigo-200 border-t-indigo-600 animate-spin" />
+          <p className="text-sm">Loading your review session…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (isError || !drill) {
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-12 text-center">
+        <div className="rounded-xl border border-gray-200 bg-white p-8">
+          <p className="text-base font-semibold text-gray-900 mb-2">
+            Review session not found
+          </p>
+          <p className="text-sm text-gray-500 mb-4">
+            This review may have been removed or is no longer available.
+          </p>
+          <Link
+            to="/student"
+            className="inline-block bg-indigo-600 text-white text-sm font-medium px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors"
+          >
+            Back to dashboard
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (result) {
+    const pct = Math.round(result.score * 100);
+    const passed = result.score >= 0.6;
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-10">
+        <div
+          className={`rounded-2xl border p-8 text-center ${
+            passed
+              ? 'border-green-200 bg-green-50'
+              : 'border-amber-200 bg-amber-50'
+          }`}
+        >
+          <div className="text-5xl mb-4" aria-hidden>
+            {passed ? '🎉' : '📚'}
+          </div>
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">
+            {passed ? 'Great review!' : 'Keep practicing!'}
+          </h2>
+          <p className="text-gray-700 mb-1">
+            You scored <span className="font-semibold">{pct}%</span> on{' '}
+            <span className="font-semibold">{drill.chapter_name}</span>
+          </p>
+          <p className="text-sm text-gray-500 mb-6">
+            {passed
+              ? `Next review scheduled for ${result.next_review_date}`
+              : 'Interval reset — see this chapter again tomorrow'}
+          </p>
+          <div className="flex flex-wrap gap-2 justify-center">
+            <button
+              type="button"
+              onClick={() => navigate('/student')}
+              className="bg-indigo-600 text-white px-5 py-2.5 rounded-lg text-sm font-medium hover:bg-indigo-700 transition-colors"
+            >
+              Back to Dashboard
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setAnswers({});
+                setResult(null);
+              }}
+              className="bg-white border border-gray-300 text-gray-700 px-5 py-2.5 rounded-lg text-sm font-medium hover:bg-gray-50 transition-colors"
+            >
+              Review again
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-6 sm:py-8">
+      <div className="mb-6">
+        <button
+          type="button"
+          onClick={() => navigate('/student')}
+          className="text-sm text-indigo-600 hover:text-indigo-800 mb-3 inline-flex items-center gap-1 transition-colors"
+        >
+          ← Back
+        </button>
+        <div className="flex items-center gap-3">
+          <span
+            className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-orange-100 text-2xl"
+            aria-hidden
+          >
+            🔁
+          </span>
+          <div className="min-w-0">
+            <h1 className="text-xl font-bold text-gray-900 truncate">
+              {drill.chapter_name}
+            </h1>
+            <p className="text-sm text-gray-500 truncate">
+              {drill.subject_name} · Spaced review
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {drill.questions.length === 0 ? (
+        <div className="rounded-xl border border-gray-200 bg-white p-8 text-center">
+          <div className="text-4xl mb-3" aria-hidden>
+            📭
+          </div>
+          <p className="text-base font-semibold text-gray-900 mb-1">
+            No review questions yet
+          </p>
+          <p className="text-sm text-gray-500 mb-5">
+            Your teacher hasn't added questions for {drill.chapter_name} yet.
+          </p>
+          <Link
+            to="/student"
+            className="inline-block bg-indigo-600 text-white text-sm font-medium px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors"
+          >
+            Back to dashboard
+          </Link>
+        </div>
+      ) : (
+        <>
+          <div className="mb-4 flex items-center justify-between text-xs text-gray-500">
+            <span>
+              {answeredCount} / {totalSubparts} answered
+            </span>
+            <span>{drill.questions.length} question{drill.questions.length !== 1 ? 's' : ''}</span>
+          </div>
+
+          <div className="space-y-4">
+            {drill.questions.map((question, idx) => (
+              <QuestionCard
+                key={question.id}
+                question={question}
+                questionNumber={idx + 1}
+                answers={answers}
+                onAnswerChange={handleAnswerChange}
+                isSubmitted={false}
+              />
+            ))}
+          </div>
+
+          <div className="mt-6 sticky bottom-4">
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={isPending || answeredCount === 0}
+              className="w-full bg-indigo-600 text-white px-8 py-3 rounded-xl font-semibold shadow-sm hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {isPending ? 'Submitting…' : 'Submit Review'}
+            </button>
+            {answeredCount === 0 && (
+              <p className="text-xs text-center text-gray-400 mt-2">
+                Answer at least one question to submit
+              </p>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/frontend_modern/src/features/student/useSRSDrill.ts
+++ b/frontend_modern/src/features/student/useSRSDrill.ts
@@ -1,0 +1,56 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+import type { Question } from '@/types/index';
+
+export interface SRSDrillData {
+  entry_id: number;
+  chapter_name: string;
+  subject_name: string;
+  questions: Question[];
+}
+
+export interface SRSReviewResult {
+  id: number;
+  knowledge_node: number;
+  chapter_name: string;
+  interval_days: number;
+  easiness_factor: number;
+  repetitions: number;
+  next_review_date: string;
+  last_reviewed_at: string | null;
+  score: number;
+}
+
+export const useSRSDrill = (entryId: number | null) =>
+  useQuery<SRSDrillData>({
+    queryKey: ['srs', 'drill', entryId],
+    queryFn: async () => {
+      const { data } = await apiClient.get<SRSDrillData>(
+        `/ai/spaced-repetition/${entryId}/review/`
+      );
+      return data;
+    },
+    enabled: entryId != null && !Number.isNaN(entryId),
+    staleTime: 0,
+  });
+
+export const useMarkReviewed = () => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    SRSReviewResult,
+    Error,
+    { entryId: number; answers: Record<string, string> }
+  >({
+    mutationFn: async ({ entryId, answers }) => {
+      const { data } = await apiClient.post<SRSReviewResult>(
+        `/ai/spaced-repetition/${entryId}/mark-reviewed/`,
+        { answers }
+      );
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['srs', 'due'] });
+      queryClient.invalidateQueries({ queryKey: ['srs', 'drill'] });
+    },
+  });
+};


### PR DESCRIPTION
## Classification
**New** — legacy had no spaced repetition.

## Why
The `DueForReviewPanel` already showed students which chapters were due for review, but the rows were inert — a learning platform that surfaces what to review without letting you review it is friction-generating, not habit-forming. This PR is the payoff that makes the existing SM-2 scheduler meaningful.

## What
**Backend** (`apps/ai/views.py`)
- `GET /api/v1/ai/spaced-repetition/{id}/review/` — returns up to 5 random active questions from the entry's chapter via the student-safe serializer (no `correct_answer` on the wire).
- `POST /api/v1/ai/spaced-repetition/{id}/mark-reviewed/` — accepts `{answers: {subpart_id: value}}` and grades server-side using the existing `core.tasks._grade_subpart` helper (handles Croupier shuffle reversal and `{{var}}` substitution). Also accepts a raw `{score: float}` as a fallback. Applies the SM-2 update inline.

**Frontend**
- `useSRSDrill` + `useMarkReviewed` hooks.
- `SRSDrillPage` with loading / empty / in-progress / result states. Reuses the existing `QuestionCard` so MCQ / numeric / fill_blank / multi_select are all already supported, including LaTeX.
- New route `/student/srs-drill/:entryId`.
- `DueForReviewPanel` rows now expose a **Practice** pill that links to the drill.

## Deviation from today's plan
Plan suggested client-side scoring (frontend compares `studentAnswer === correct_answer`). I moved this server-side instead so that `correct_answer` stays off the wire and Croupier shuffles still work correctly. A `{score}` body shape is still accepted as a fallback.

## Tests
- **11 new backend tests** in `apps/ai/tests/test_srs_drill_api.py` — payload shape, owner scoping, question cap (5), empty-chapter handling, success/failure SM-2 updates, server-side MCQ grading with Croupier shuffle, partial-credit numeric grading, invalid input.
- Full backend suite: **306 passed** (was 291).
- Frontend `type-check`, `lint`, `vitest --run`, and `vite build` all clean.

## How to verify
1. `cd backend && pytest openshiksha/apps/ai/tests/test_srs_drill_api.py -v`
2. `cd frontend_modern && npm run type-check && npm run lint && npm test -- --run && npm run build`
3. Manual: seed demo data, ensure a `SpacedRepetitionEntry` exists, log in as the student, click **Practice** on a Due-for-Review row, answer questions, submit → see result screen with score and next review date.