### PR TITLE
fix(migrations): deduplicate core 0006 migration

### DIFF
--- a/backend/openshiksha/apps/core/migrations/0007_add_assignment_target_student.py
+++ b/backend/openshiksha/apps/core/migrations/0007_add_assignment_target_student.py
@@ -8,7 +8,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("core", "0005_add_student_streak_and_remedial_fields"),
+        ("core", "0006_add_question_subpart_image_url"),
     ]
 
     operations = [


### PR DESCRIPTION
## Summary
- Two PRs (#86, #87) merged on the same day each created `core/0006`, leaving two leaf nodes in the migration graph
- Renames `0006_add_assignment_target_student` → `0007_add_assignment_target_student` and updates its dependency from `0005` → `0006_add_question_subpart_image_url`
- Verified: `loader.graph.leaf_nodes('core')` returns a single leaf (`0007_add_assignment_target_student`)

## Classification
Fix — critical technical debt (blocking `manage.py migrate` from a fresh database)

## Test plan
- [x] Django system check passes (`manage.py check`)
- [x] Migration graph has single leaf node (verified programmatically)
- [x] 327 backend tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)