### PR TITLE
ci: raise coverage threshold from 40% to 90%

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -101,6 +101,8 @@ jobs:
                 DJANGO_SETTINGS_MODULE: openshiksha.settings.test
                 SECRET_KEY: test-secret-key-not-for-production
             - name: Run Tests
+              # Coverage threshold (--cov-fail-under) is enforced via pytest.ini addopts.
+              # Currently set to 90%; measured at 91.6% as of 2026-05-26.
               run: python -m pytest
               working-directory: backend
               env:

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -3,4 +3,4 @@ DJANGO_SETTINGS_MODULE = openshiksha.settings.test
 python_files = tests/test_*.py
 python_classes = Test*
 python_functions = test_*
-addopts = -v --tb=short --cov=openshiksha --cov-report=term-missing --cov-report=xml --cov-fail-under=40
+addopts = -v --tb=short --cov=openshiksha --cov-report=term-missing --cov-report=xml --cov-fail-under=90


### PR DESCRIPTION
## Summary
- Coverage threshold in `pytest.ini` raised from the placeholder `40` to `90`
- Current measured coverage is 91.6% (2026-05-26), leaving ~1.6% buffer for natural variation
- Added a comment in `ci-cd.yaml` pointing reviewers to `pytest.ini` as the source of truth for the threshold

## Why now
The threshold was set at 40% as a placeholder when coverage reporting was first added. Actual coverage has since grown to 91.6%, so the gate was providing no protection against regressions.

## Test plan
- [ ] CI `test` job should pass (current coverage 91.6% > new threshold 90%)
- [ ] Dropping coverage below 90% on a future PR should cause CI to fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)