### PR TITLE
ci: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  # Backend Python dependencies
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    target-branch: "modernization"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "backend"
+    commit-message:
+      prefix: "deps"
+
+  # Frontend npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/frontend_modern"
+    schedule:
+      interval: "weekly"
+    target-branch: "modernization"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "frontend"
+    commit-message:
+      prefix: "deps"
+
+  # GitHub Actions workflow dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    target-branch: "modernization"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to enable automated dependency update PRs.
- **pip** (`/backend`): weekly, targeting `modernization`
- **npm** (`/frontend_modern`): weekly, targeting `modernization`
- **github-actions** (`/`): monthly, targeting `modernization`

Each ecosystem gets descriptive labels and a commit-message prefix. This surfaces security fixes automatically and prevents dependency rot. Note: GitHub currently reports 116 Dependabot vulnerability alerts on the default branch, so enabling update PRs is timely.

## Test plan
- [x] YAML validated with `yaml.safe_load`
- [x] Confirmed `backend/requirements.txt` and `frontend_modern/package.json` exist at the configured directories
- [ ] Merge and confirm Dependabot opens PRs on its next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)