### PR TITLE
ci: detect missing migrations in test job

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -94,6 +94,15 @@ jobs:
               env:
                 DJANGO_SETTINGS_MODULE: openshiksha.settings.test
                 SECRET_KEY: test-secret-key-not-for-production
+            - name: Check for missing migrations
+              # Fails if a model was changed without a matching migration.
+              # `makemigrations --check` (not `migrate --check`) is what detects
+              # model/migration drift; --dry-run avoids writing any files.
+              run: python manage.py makemigrations --check --dry-run
+              working-directory: backend
+              env:
+                DJANGO_SETTINGS_MODULE: openshiksha.settings.test
+                SECRET_KEY: test-secret-key-not-for-production
             - name: Run migrations
               run: python manage.py migrate
               working-directory: backend


### PR DESCRIPTION
## Summary
- Adds a **Check for missing migrations** step to the `test` job in `ci-cd.yaml`, running `python manage.py makemigrations --check --dry-run`.
- CI now fails fast if a developer changes a model without generating the matching migration.
- Step is inserted after the Django system check and before migrations run.

## Notes
- The backlog item suggested `migrate --check`, but that only detects *unapplied* migrations against the DB — it does **not** catch a model change that lacks a migration file. `makemigrations --check --dry-run` is the correct command for the stated goal (catching missing migrations), so that's what's used. `--dry-run` ensures no files are written in CI.
- Verified locally: `makemigrations --check --dry-run` reports "No changes detected" on the current `modernization` branch, so this won't break existing CI.

## Test plan
- [ ] CI `test` job passes on this branch (no missing migrations currently).
- [ ] Confirm the new step appears between "Run Django system check" and "Run migrations".

🤖 Generated with [Claude Code](https://claude.com/claude-code)