### PR TITLE
feat(frontend): School Admin UI (P4 frontend)

### DIFF
--- a/docs/changes/2026-05-28-school-admin-frontend.md
+++ b/docs/changes/2026-05-28-school-admin-frontend.md
@@ -1,0 +1,65 @@
+# School Admin frontend (P4 frontend)
+
+**Date**: 2026-05-28
+**Classification**: Improve (legacy school structure was managed only via Django admin; this is a role-guarded admin product UI)
+**Branch**: `feat/2026-05-28-school-admin-frontend` (based on `modernization`)
+
+## Summary
+
+The `/admin` product surface that consumes the P4 backend School Admin API. A
+school admin can now run their school from the UI instead of Django admin:
+view a school summary, create/archive classrooms, manage classroom rosters,
+and create subject rooms (assign a teacher + enroll students) — all hard-scoped
+to their own school by the backend.
+
+This is the frontend half of P4; the backend (`IsSchoolAdmin`, `ClassRoomViewSet`,
+admin `SubjectRoomViewSet` write path, enrollment-picker endpoints) ships separately
+on `feat/2026-05-28-school-admin-api`.
+
+## What was added
+
+**Routing & guard**
+- `ProtectedRoute` gained an optional `allowedRoles` prop — users without the role
+  are redirected to their default landing (`/`).
+- New routes `/admin` and `/admin/classrooms/:id`, both guarded to `UserRole.ADMIN`.
+- `App.tsx` default landing for `admin` role is now `/admin` (previously fell through
+  to `/student`).
+- Navbar shows a "School Admin" link (desktop + mobile) for admins.
+
+**Feature (`src/features/admin/`)**
+- `useAdminSummary` — `GET /classrooms/summary/` (dashboard counts).
+- `useClassrooms` — list (with `?include_inactive`), retrieve, create, update,
+  soft-delete (archive), and enroll/unenroll mutations.
+- `useSchoolPeople` — `GET /users/school-teachers/` and `/users/school-students/`
+  for the teacher-assignment and enrollment pickers.
+- `useAdminSubjectRooms` — list (admin sees own-school rooms), create, enroll/unenroll.
+- `AdminDashboard` — summary cards, classroom list, inline "New Classroom" form,
+  "Show archived" toggle, archive action.
+- `ClassroomManagePage` — classroom roster management + subject-room list/create/
+  enrollment for a single classroom.
+- `EnrollStudentsModal` — reusable searchable student picker used for both classroom
+  and subject-room enroll/unenroll; surfaces the API's validate-and-report
+  `invalid_ids` ("N skipped").
+
+## Tests
+
+`EnrollStudentsModal.test.tsx` — 5 tests (render, search filter, disabled-until-selected,
+onAction payload, invalid-id reporting). Full FE suite: **16 passed**. `tsc --noEmit`
+and production `vite build` both clean; lint clean.
+
+## Known limitations / follow-ups
+
+- The backend `ClassRoomSerializer` exposes `student_count` but not the enrolled
+  student list, so the roster UI works from the full school-students list (enroll/
+  remove by selection) rather than showing current members. Exposing a roster field
+  is a natural backend follow-up for a richer UI.
+- Standard options reuse the existing synthetic `useStandards` (1–12), consistent with
+  the teacher authoring UI; there is no `/standards/` endpoint yet.
+- Not browser-verified against a live API in this session — the P4 backend lives on a
+  separate unmerged branch. Type-check, build, and unit tests pass against the known
+  API contract.
+
+## Next steps
+
+- Merge order: P4 backend PR first, then this FE PR (FE calls those endpoints).
+- Optional: bulk CSV enrollment importer on top of the enroll action.

--- a/frontend_modern/src/App.tsx
+++ b/frontend_modern/src/App.tsx
@@ -22,6 +22,9 @@ import { CreateProblemSetPage } from './features/teacher/CreateProblemSetPage';
 import { TeacherAssignmentDetailPage } from './features/teacher/TeacherAssignmentDetailPage';
 import { QuestionBankPage } from './features/teacher/QuestionBankPage';
 import { ParentDashboard } from './features/parent/ParentDashboard';
+import { AdminDashboard } from './features/admin/AdminDashboard';
+import { ClassroomManagePage } from './features/admin/ClassroomManagePage';
+import { UserRole } from './types/index';
 import { LoadingSpinner } from './shared/components/LoadingSpinner';
 
 const NotFound = () => (
@@ -44,6 +47,7 @@ function App() {
   const defaultPath = isAuthenticated
     ? user?.role === 'teacher' ? '/teacher'
     : user?.role === 'parent' ? '/parent'
+    : user?.role === 'admin' ? '/admin'
     : user?.role === 'open_student' ? '/student/browse'
     : '/student'
     : '/login';
@@ -228,6 +232,28 @@ function App() {
             <ProtectedRoute>
               <AppShell>
                 <ParentDashboard />
+              </AppShell>
+            </ProtectedRoute>
+          }
+        />
+
+        <Route
+          path="/admin"
+          element={
+            <ProtectedRoute allowedRoles={[UserRole.ADMIN]}>
+              <AppShell>
+                <AdminDashboard />
+              </AppShell>
+            </ProtectedRoute>
+          }
+        />
+
+        <Route
+          path="/admin/classrooms/:id"
+          element={
+            <ProtectedRoute allowedRoles={[UserRole.ADMIN]}>
+              <AppShell>
+                <ClassroomManagePage />
               </AppShell>
             </ProtectedRoute>
           }

--- a/frontend_modern/src/features/admin/AdminDashboard.tsx
+++ b/frontend_modern/src/features/admin/AdminDashboard.tsx
@@ -1,0 +1,263 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
+import { useStandards } from '@/features/teacher/useStandards';
+import { useAdminSummary } from './useAdminSummary';
+import { useSchoolTeachers } from './useSchoolPeople';
+import {
+  useClassrooms,
+  useCreateClassroom,
+  useDeleteClassroom,
+  type Classroom,
+} from './useClassrooms';
+
+const defaultAcademicYear = (): string => {
+  const now = new Date();
+  // Indian academic year runs ~Apr–Mar; before April belongs to the prior year's intake.
+  const startYear = now.getMonth() >= 3 ? now.getFullYear() : now.getFullYear() - 1;
+  return `${startYear}-${String((startYear + 1) % 100).padStart(2, '0')}`;
+};
+
+const SummaryCard = ({ label, value }: { label: string; value: number }) => (
+  <div className="bg-white rounded-xl border border-gray-200 p-5">
+    <p className="text-2xl font-bold text-gray-900">{value}</p>
+    <p className="text-sm text-gray-500 mt-1">{label}</p>
+  </div>
+);
+
+const NewClassroomForm = ({ onDone }: { onDone: () => void }) => {
+  const { data: standards } = useStandards();
+  const { data: teachers } = useSchoolTeachers();
+  const createClassroom = useCreateClassroom();
+
+  const [standard, setStandard] = useState<number | ''>('');
+  const [division, setDivision] = useState('');
+  const [academicYear, setAcademicYear] = useState(defaultAcademicYear());
+  const [classTeacher, setClassTeacher] = useState<number | ''>('');
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (standard === '' || !division.trim() || !academicYear.trim()) {
+      setError('Standard, division, and academic year are required.');
+      return;
+    }
+    createClassroom.mutate(
+      {
+        standard: Number(standard),
+        division: division.trim(),
+        academic_year: academicYear.trim(),
+        class_teacher: classTeacher === '' ? null : Number(classTeacher),
+      },
+      {
+        onSuccess: onDone,
+        onError: (err: unknown) => {
+          const detail =
+            (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail ??
+            'Could not create classroom. Check for duplicates.';
+          setError(detail);
+        },
+      }
+    );
+  };
+
+  return (
+    <form onSubmit={submit} className="bg-white rounded-xl border border-gray-200 p-5 space-y-4">
+      <h3 className="font-semibold text-gray-900">New Classroom</h3>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <label className="block">
+          <span className="text-sm font-medium text-gray-700">Standard</span>
+          <select
+            value={standard}
+            onChange={(e) => setStandard(e.target.value === '' ? '' : Number(e.target.value))}
+            className="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          >
+            <option value="">Select…</option>
+            {standards?.map((s) => (
+              <option key={s.id} value={s.id}>
+                Grade {s.number}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block">
+          <span className="text-sm font-medium text-gray-700">Division</span>
+          <input
+            type="text"
+            value={division}
+            onChange={(e) => setDivision(e.target.value)}
+            placeholder="A"
+            className="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-medium text-gray-700">Academic Year</span>
+          <input
+            type="text"
+            value={academicYear}
+            onChange={(e) => setAcademicYear(e.target.value)}
+            placeholder="2026-27"
+            className="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-medium text-gray-700">Class Teacher (optional)</span>
+          <select
+            value={classTeacher}
+            onChange={(e) => setClassTeacher(e.target.value === '' ? '' : Number(e.target.value))}
+            className="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          >
+            <option value="">None</option>
+            {teachers?.map((t) => (
+              <option key={t.id} value={t.id}>
+                {t.full_name}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onDone}
+          className="px-4 py-2 rounded-lg text-sm font-medium border border-gray-300 text-gray-700 hover:bg-gray-50 transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={createClassroom.isPending}
+          className="px-4 py-2 rounded-lg text-sm font-medium bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+        >
+          {createClassroom.isPending ? 'Creating…' : 'Create'}
+        </button>
+      </div>
+    </form>
+  );
+};
+
+const ClassroomRow = ({ classroom }: { classroom: Classroom }) => {
+  const navigate = useNavigate();
+  const deleteClassroom = useDeleteClassroom();
+
+  const onDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (
+      window.confirm(
+        `Deactivate Grade ${classroom.standard_number}-${classroom.division}? It will be archived, not deleted.`
+      )
+    ) {
+      deleteClassroom.mutate(classroom.id);
+    }
+  };
+
+  return (
+    <div
+      className={`bg-white rounded-xl border border-gray-200 p-4 cursor-pointer hover:border-indigo-300 transition-colors ${
+        !classroom.is_active ? 'opacity-60' : ''
+      }`}
+      onClick={() => navigate(`/admin/classrooms/${classroom.id}`)}
+    >
+      <div className="flex items-center justify-between gap-4">
+        <div className="min-w-0">
+          <p className="font-semibold text-gray-900">
+            Grade {classroom.standard_number}-{classroom.division}
+            {!classroom.is_active && (
+              <span className="ml-2 text-xs font-medium text-gray-400">(archived)</span>
+            )}
+          </p>
+          <p className="text-sm text-gray-500 mt-0.5">
+            {classroom.class_teacher_name ?? 'No class teacher'} · {classroom.academic_year}
+          </p>
+        </div>
+        <div className="text-right shrink-0 flex items-center gap-4">
+          <p className="text-sm font-medium text-gray-700">
+            {classroom.student_count} student{classroom.student_count !== 1 ? 's' : ''}
+          </p>
+          {classroom.is_active && (
+            <button
+              onClick={onDelete}
+              disabled={deleteClassroom.isPending}
+              className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50"
+            >
+              Archive
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const AdminDashboard = () => {
+  const { data: summary, isLoading: summaryLoading } = useAdminSummary();
+  const [includeInactive, setIncludeInactive] = useState(false);
+  const { data: classrooms, isLoading: classroomsLoading } = useClassrooms(includeInactive);
+  const [showForm, setShowForm] = useState(false);
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8 space-y-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">
+            {summary?.school.name ?? 'School Admin'}
+          </h1>
+          <p className="text-sm text-gray-500 mt-1">Manage classrooms, enrollment, and subject rooms.</p>
+        </div>
+        <button
+          onClick={() => setShowForm((v) => !v)}
+          className="bg-indigo-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-indigo-700 transition-colors"
+        >
+          + New Classroom
+        </button>
+      </div>
+
+      {summaryLoading ? (
+        <div className="flex justify-center py-6">
+          <LoadingSpinner size="lg" />
+        </div>
+      ) : summary ? (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          <SummaryCard label="Classrooms" value={summary.classroom_count} />
+          <SummaryCard label="Teachers" value={summary.teacher_count} />
+          <SummaryCard label="Students" value={summary.student_count} />
+          <SummaryCard label="Subject Rooms" value={summary.active_subject_rooms} />
+        </div>
+      ) : null}
+
+      {showForm && <NewClassroomForm onDone={() => setShowForm(false)} />}
+
+      <section>
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-lg font-semibold text-gray-800">Classrooms</h2>
+          <label className="flex items-center gap-2 text-sm text-gray-500 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={includeInactive}
+              onChange={(e) => setIncludeInactive(e.target.checked)}
+              className="w-4 h-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+            />
+            Show archived
+          </label>
+        </div>
+        {classroomsLoading ? (
+          <div className="flex justify-center py-8">
+            <LoadingSpinner size="lg" />
+          </div>
+        ) : !classrooms || classrooms.length === 0 ? (
+          <div className="text-center py-8 text-gray-400 bg-white rounded-xl border border-gray-200">
+            <p className="text-sm">No classrooms yet. Create one to start onboarding your school.</p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {classrooms.map((c) => (
+              <ClassroomRow key={c.id} classroom={c} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+};

--- a/frontend_modern/src/features/admin/ClassroomManagePage.tsx
+++ b/frontend_modern/src/features/admin/ClassroomManagePage.tsx
@@ -1,0 +1,255 @@
+import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
+import { useSubjects } from '@/features/teacher/useSubjects';
+import { useClassroom, useClassroomEnrollment } from './useClassrooms';
+import { useSchoolStudents, useSchoolTeachers } from './useSchoolPeople';
+import {
+  useAdminSubjectRooms,
+  useCreateSubjectRoom,
+  useSubjectRoomEnrollment,
+  type AdminSubjectRoom,
+} from './useAdminSubjectRooms';
+import { EnrollStudentsModal } from './EnrollStudentsModal';
+
+const NewSubjectRoomForm = ({
+  classroomId,
+  onDone,
+}: {
+  classroomId: number;
+  onDone: () => void;
+}) => {
+  const { data: subjects } = useSubjects();
+  const { data: teachers } = useSchoolTeachers();
+  const createRoom = useCreateSubjectRoom();
+  const [subject, setSubject] = useState<number | ''>('');
+  const [teacher, setTeacher] = useState<number | ''>('');
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (subject === '' || teacher === '') {
+      setError('Subject and teacher are required.');
+      return;
+    }
+    createRoom.mutate(
+      { classroom: classroomId, subject: Number(subject), teacher: Number(teacher) },
+      {
+        onSuccess: onDone,
+        onError: (err: unknown) => {
+          const data = (err as { response?: { data?: Record<string, unknown> } })?.response?.data;
+          const msg =
+            (data?.detail as string) ||
+            (Array.isArray(data?.non_field_errors)
+              ? (data!.non_field_errors as string[])[0]
+              : null) ||
+            'Could not create subject room. A room for this subject may already exist.';
+          setError(msg);
+        },
+      }
+    );
+  };
+
+  return (
+    <form onSubmit={submit} className="bg-gray-50 rounded-xl border border-gray-200 p-4 space-y-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <label className="block">
+          <span className="text-sm font-medium text-gray-700">Subject</span>
+          <select
+            value={subject}
+            onChange={(e) => setSubject(e.target.value === '' ? '' : Number(e.target.value))}
+            className="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          >
+            <option value="">Select subject…</option>
+            {subjects?.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block">
+          <span className="text-sm font-medium text-gray-700">Teacher</span>
+          <select
+            value={teacher}
+            onChange={(e) => setTeacher(e.target.value === '' ? '' : Number(e.target.value))}
+            className="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          >
+            <option value="">Select teacher…</option>
+            {teachers?.map((t) => (
+              <option key={t.id} value={t.id}>
+                {t.full_name}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onDone}
+          className="px-3 py-1.5 rounded-lg text-sm font-medium border border-gray-300 text-gray-700 hover:bg-white transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={createRoom.isPending}
+          className="px-3 py-1.5 rounded-lg text-sm font-medium bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+        >
+          {createRoom.isPending ? 'Creating…' : 'Create Subject Room'}
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export const ClassroomManagePage = () => {
+  const { id } = useParams<{ id: string }>();
+  const classroomId = Number(id);
+  const navigate = useNavigate();
+
+  const { data: classroom, isLoading } = useClassroom(classroomId);
+  const { data: allRooms, isLoading: roomsLoading } = useAdminSubjectRooms();
+  const { data: students } = useSchoolStudents();
+  const classroomEnrollment = useClassroomEnrollment();
+  const subjectRoomEnrollment = useSubjectRoomEnrollment();
+
+  const [showRoster, setShowRoster] = useState(false);
+  const [showNewRoom, setShowNewRoom] = useState(false);
+  const [enrollingRoom, setEnrollingRoom] = useState<AdminSubjectRoom | null>(null);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-16">
+        <LoadingSpinner size="lg" />
+      </div>
+    );
+  }
+
+  if (!classroom) {
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-16 text-center text-gray-500">
+        <p>Classroom not found.</p>
+        <button onClick={() => navigate('/admin')} className="mt-3 text-sm text-indigo-600 hover:underline">
+          Back to dashboard
+        </button>
+      </div>
+    );
+  }
+
+  const rooms = (allRooms ?? []).filter((r) => r.classroom === classroomId);
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8 space-y-8">
+      <button onClick={() => navigate('/admin')} className="text-sm text-indigo-600 hover:underline">
+        ← Back to dashboard
+      </button>
+
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">
+          Grade {classroom.standard_number}-{classroom.division}
+        </h1>
+        <p className="text-sm text-gray-500 mt-1">
+          {classroom.class_teacher_name ?? 'No class teacher'} · {classroom.academic_year} ·{' '}
+          {classroom.student_count} student{classroom.student_count !== 1 ? 's' : ''}
+        </p>
+      </div>
+
+      <section>
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-lg font-semibold text-gray-800">Roster</h2>
+          <button
+            onClick={() => setShowRoster(true)}
+            className="text-sm text-indigo-600 hover:underline"
+          >
+            Manage students
+          </button>
+        </div>
+        <div className="bg-white rounded-xl border border-gray-200 p-5 text-sm text-gray-600">
+          {classroom.student_count} student{classroom.student_count !== 1 ? 's' : ''} enrolled in this
+          classroom. Use “Manage students” to enroll or remove students.
+        </div>
+      </section>
+
+      <section>
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-lg font-semibold text-gray-800">Subject Rooms</h2>
+          <button
+            onClick={() => setShowNewRoom((v) => !v)}
+            className="text-sm text-indigo-600 hover:underline"
+          >
+            + Add subject room
+          </button>
+        </div>
+
+        {showNewRoom && (
+          <div className="mb-3">
+            <NewSubjectRoomForm classroomId={classroomId} onDone={() => setShowNewRoom(false)} />
+          </div>
+        )}
+
+        {roomsLoading ? (
+          <div className="flex justify-center py-6">
+            <LoadingSpinner size="lg" />
+          </div>
+        ) : rooms.length === 0 ? (
+          <div className="text-center py-8 text-gray-400 bg-white rounded-xl border border-gray-200">
+            <p className="text-sm">No subject rooms yet. Add one to assign a teacher and students.</p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {rooms.map((room) => (
+              <div
+                key={room.id}
+                className="bg-white rounded-xl border border-gray-200 p-4 flex items-center justify-between"
+              >
+                <div>
+                  <p className="font-semibold text-gray-900">{room.subject_name}</p>
+                  <p className="text-sm text-gray-500 mt-0.5">{room.teacher_name}</p>
+                </div>
+                <div className="text-right flex items-center gap-4">
+                  <p className="text-sm font-medium text-gray-700">
+                    {room.student_count} student{room.student_count !== 1 ? 's' : ''}
+                  </p>
+                  <button
+                    onClick={() => setEnrollingRoom(room)}
+                    className="text-xs text-indigo-600 hover:underline"
+                  >
+                    Manage students
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {showRoster && (
+        <EnrollStudentsModal
+          title={`Roster — Grade ${classroom.standard_number}-${classroom.division}`}
+          students={students ?? []}
+          isPending={classroomEnrollment.isPending}
+          onAction={(studentIds, action) =>
+            classroomEnrollment.mutateAsync({ id: classroomId, studentIds, action })
+          }
+          onClose={() => setShowRoster(false)}
+        />
+      )}
+
+      {enrollingRoom && (
+        <EnrollStudentsModal
+          title={`${enrollingRoom.subject_name} — students`}
+          students={students ?? []}
+          isPending={subjectRoomEnrollment.isPending}
+          onAction={(studentIds, action) =>
+            subjectRoomEnrollment.mutateAsync({ id: enrollingRoom.id, studentIds, action })
+          }
+          onClose={() => setEnrollingRoom(null)}
+        />
+      )}
+    </div>
+  );
+};

--- a/frontend_modern/src/features/admin/EnrollStudentsModal.test.tsx
+++ b/frontend_modern/src/features/admin/EnrollStudentsModal.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { EnrollStudentsModal } from './EnrollStudentsModal';
+import type { SchoolPerson } from './useSchoolPeople';
+
+const students: SchoolPerson[] = [
+  { id: 1, full_name: 'Aarav Sharma', email: 'aarav@test.example' },
+  { id: 2, full_name: 'Diya Patel', email: 'diya@test.example' },
+  { id: 3, full_name: 'Rohan Gupta', email: 'rohan@test.example' },
+];
+
+const makeProps = (overrides = {}) => ({
+  title: 'Roster — Grade 7-A',
+  students,
+  isPending: false,
+  onAction: vi.fn().mockResolvedValue({ enrolled: [1], invalid_ids: [], student_count: 1 }),
+  onClose: vi.fn(),
+  ...overrides,
+});
+
+describe('EnrollStudentsModal', () => {
+  it('renders all students and the title', () => {
+    render(<EnrollStudentsModal {...makeProps()} />);
+    expect(screen.getByText('Roster — Grade 7-A')).toBeDefined();
+    expect(screen.getByText('Aarav Sharma')).toBeDefined();
+    expect(screen.getByText('Diya Patel')).toBeDefined();
+  });
+
+  it('filters students by search query', () => {
+    render(<EnrollStudentsModal {...makeProps()} />);
+    fireEvent.change(screen.getByPlaceholderText(/search students/i), {
+      target: { value: 'diya' },
+    });
+    expect(screen.getByText('Diya Patel')).toBeDefined();
+    expect(screen.queryByText('Aarav Sharma')).toBeNull();
+  });
+
+  it('enroll/remove buttons are disabled until a student is selected', () => {
+    render(<EnrollStudentsModal {...makeProps()} />);
+    const enrollBtn = screen.getByRole('button', { name: 'Enroll' });
+    expect(enrollBtn.hasAttribute('disabled')).toBe(true);
+    fireEvent.click(screen.getByLabelText(/aarav sharma/i, { selector: 'input' }));
+    expect(enrollBtn.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('calls onAction with selected ids and "enroll"', async () => {
+    const props = makeProps();
+    render(<EnrollStudentsModal {...props} />);
+    fireEvent.click(screen.getByLabelText(/aarav sharma/i, { selector: 'input' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Enroll' }));
+    await waitFor(() => expect(props.onAction).toHaveBeenCalledWith([1], 'enroll'));
+  });
+
+  it('reports skipped invalid ids in the result message', async () => {
+    const props = makeProps({
+      onAction: vi.fn().mockResolvedValue({ enrolled: [1], invalid_ids: [99], student_count: 1 }),
+    });
+    render(<EnrollStudentsModal {...props} />);
+    fireEvent.click(screen.getByLabelText(/aarav sharma/i, { selector: 'input' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Enroll' }));
+    await waitFor(() => expect(screen.getByText(/1 skipped/i)).toBeDefined());
+  });
+});

--- a/frontend_modern/src/features/admin/EnrollStudentsModal.tsx
+++ b/frontend_modern/src/features/admin/EnrollStudentsModal.tsx
@@ -1,0 +1,146 @@
+import { useMemo, useState } from 'react';
+import type { SchoolPerson } from './useSchoolPeople';
+import type { EnrollmentResult } from './useClassrooms';
+
+interface EnrollStudentsModalProps {
+  title: string;
+  students: SchoolPerson[];
+  isPending: boolean;
+  onAction: (studentIds: number[], action: 'enroll' | 'unenroll') => Promise<EnrollmentResult>;
+  onClose: () => void;
+}
+
+export const EnrollStudentsModal = ({
+  title,
+  students,
+  isPending,
+  onAction,
+  onClose,
+}: EnrollStudentsModalProps) => {
+  const [search, setSearch] = useState('');
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [result, setResult] = useState<{ action: string; count: number; invalid: number } | null>(
+    null
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return students;
+    return students.filter(
+      (s) => s.full_name.toLowerCase().includes(q) || s.email.toLowerCase().includes(q)
+    );
+  }, [students, search]);
+
+  const toggle = (id: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const run = async (action: 'enroll' | 'unenroll') => {
+    if (selected.size === 0) return;
+    setError(null);
+    try {
+      const res = await onAction(Array.from(selected), action);
+      const changed = action === 'enroll' ? res.enrolled ?? [] : res.unenrolled ?? [];
+      setResult({ action, count: changed.length, invalid: res.invalid_ids.length });
+      setSelected(new Set());
+    } catch {
+      setError('Something went wrong. Please try again.');
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/40 p-4">
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-lg max-h-[85vh] flex flex-col">
+        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100">
+          <h3 className="font-semibold text-gray-900">{title}</h3>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 transition-colors"
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="px-5 py-3 border-b border-gray-100">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search students by name or email…"
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-2">
+          {filtered.length === 0 ? (
+            <p className="text-sm text-gray-400 py-6 text-center">No students found.</p>
+          ) : (
+            <ul className="divide-y divide-gray-100">
+              {filtered.map((s) => (
+                <li key={s.id}>
+                  <label className="flex items-center gap-3 py-2.5 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={selected.has(s.id)}
+                      onChange={() => toggle(s.id)}
+                      className="w-4 h-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                    />
+                    <span className="min-w-0">
+                      <span className="block text-sm font-medium text-gray-900 truncate">
+                        {s.full_name}
+                      </span>
+                      <span className="block text-xs text-gray-500 truncate">{s.email}</span>
+                    </span>
+                  </label>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {(result || error) && (
+          <div className="px-5 py-2 text-sm border-t border-gray-100">
+            {error ? (
+              <span className="text-red-600">{error}</span>
+            ) : (
+              <span className="text-gray-600">
+                {result!.count} student{result!.count !== 1 ? 's' : ''} {result!.action}ed
+                {result!.invalid > 0 && ` · ${result!.invalid} skipped (invalid)`}
+              </span>
+            )}
+          </div>
+        )}
+
+        <div className="flex items-center justify-end gap-2 px-5 py-4 border-t border-gray-100">
+          <span className="text-xs text-gray-500 mr-auto">{selected.size} selected</span>
+          <button
+            onClick={() => run('unenroll')}
+            disabled={isPending || selected.size === 0}
+            className="px-4 py-2 rounded-lg text-sm font-medium border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:opacity-50 transition-colors"
+          >
+            Remove
+          </button>
+          <button
+            onClick={() => run('enroll')}
+            disabled={isPending || selected.size === 0}
+            className="px-4 py-2 rounded-lg text-sm font-medium bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+          >
+            Enroll
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend_modern/src/features/admin/useAdminSubjectRooms.ts
+++ b/frontend_modern/src/features/admin/useAdminSubjectRooms.ts
@@ -1,0 +1,72 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+import type { PaginatedResponse } from '@/types/index';
+import type { EnrollmentResult } from './useClassrooms';
+
+export interface AdminSubjectRoom {
+  id: number;
+  classroom: number;
+  classroom_display: string;
+  subject: number;
+  subject_name: string;
+  teacher: number;
+  teacher_name: string;
+  is_active: boolean;
+  student_count: number;
+  created_at: string;
+}
+
+export interface SubjectRoomWriteInput {
+  classroom: number;
+  subject: number;
+  teacher: number;
+}
+
+const fetchSubjectRooms = async (): Promise<AdminSubjectRoom[]> => {
+  const response = await apiClient.get<PaginatedResponse<AdminSubjectRoom>>('/subject-rooms/');
+  return response.data.results;
+};
+
+export const useAdminSubjectRooms = () =>
+  useQuery<AdminSubjectRoom[]>({
+    queryKey: ['admin', 'subject-rooms'],
+    queryFn: fetchSubjectRooms,
+    staleTime: 60 * 1000,
+  });
+
+export const useCreateSubjectRoom = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: SubjectRoomWriteInput) => {
+      const response = await apiClient.post<AdminSubjectRoom>('/subject-rooms/', data);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'subject-rooms'] });
+      queryClient.invalidateQueries({ queryKey: ['admin', 'summary'] });
+    },
+  });
+};
+
+export const useSubjectRoomEnrollment = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      id,
+      studentIds,
+      action,
+    }: {
+      id: number;
+      studentIds: number[];
+      action: 'enroll' | 'unenroll';
+    }) => {
+      const response = await apiClient.post<EnrollmentResult>(`/subject-rooms/${id}/${action}/`, {
+        student_ids: studentIds,
+      });
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'subject-rooms'] });
+    },
+  });
+};

--- a/frontend_modern/src/features/admin/useAdminSummary.ts
+++ b/frontend_modern/src/features/admin/useAdminSummary.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+
+export interface AdminSchoolSummary {
+  school: { id: number; name: string };
+  classroom_count: number;
+  teacher_count: number;
+  student_count: number;
+  active_subject_rooms: number;
+}
+
+const fetchSummary = async (): Promise<AdminSchoolSummary> => {
+  const response = await apiClient.get<AdminSchoolSummary>('/classrooms/summary/');
+  return response.data;
+};
+
+export const useAdminSummary = () => {
+  return useQuery<AdminSchoolSummary>({
+    queryKey: ['admin', 'summary'],
+    queryFn: fetchSummary,
+    staleTime: 60 * 1000,
+  });
+};

--- a/frontend_modern/src/features/admin/useClassrooms.ts
+++ b/frontend_modern/src/features/admin/useClassrooms.ts
@@ -1,0 +1,122 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+import type { PaginatedResponse } from '@/types/index';
+
+export interface Classroom {
+  id: number;
+  school: number;
+  standard: number;
+  standard_number: number;
+  division: string;
+  class_teacher: number | null;
+  class_teacher_name: string | null;
+  academic_year: string;
+  is_active: boolean;
+  student_count: number;
+  created_at: string;
+}
+
+export interface ClassroomWriteInput {
+  standard: number;
+  division: string;
+  class_teacher?: number | null;
+  academic_year: string;
+}
+
+export interface EnrollmentResult {
+  enrolled?: number[];
+  unenrolled?: number[];
+  invalid_ids: number[];
+  student_count: number;
+}
+
+const fetchClassrooms = async (includeInactive: boolean): Promise<Classroom[]> => {
+  const response = await apiClient.get<PaginatedResponse<Classroom>>('/classrooms/', {
+    params: includeInactive ? { include_inactive: 'true' } : undefined,
+  });
+  return response.data.results;
+};
+
+const fetchClassroom = async (id: number): Promise<Classroom> => {
+  const response = await apiClient.get<Classroom>(`/classrooms/${id}/`);
+  return response.data;
+};
+
+export const useClassrooms = (includeInactive = false) =>
+  useQuery<Classroom[]>({
+    queryKey: ['admin', 'classrooms', { includeInactive }],
+    queryFn: () => fetchClassrooms(includeInactive),
+    staleTime: 60 * 1000,
+  });
+
+export const useClassroom = (id: number) =>
+  useQuery<Classroom>({
+    queryKey: ['admin', 'classroom', id],
+    queryFn: () => fetchClassroom(id),
+    staleTime: 60 * 1000,
+  });
+
+export const useCreateClassroom = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: ClassroomWriteInput) => {
+      const response = await apiClient.post<Classroom>('/classrooms/', data);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'classrooms'] });
+      queryClient.invalidateQueries({ queryKey: ['admin', 'summary'] });
+    },
+  });
+};
+
+export const useUpdateClassroom = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, data }: { id: number; data: Partial<ClassroomWriteInput> }) => {
+      const response = await apiClient.patch<Classroom>(`/classrooms/${id}/`, data);
+      return response.data;
+    },
+    onSuccess: (updated) => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'classrooms'] });
+      queryClient.invalidateQueries({ queryKey: ['admin', 'classroom', updated.id] });
+    },
+  });
+};
+
+export const useDeleteClassroom = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: number) => {
+      await apiClient.delete(`/classrooms/${id}/`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'classrooms'] });
+      queryClient.invalidateQueries({ queryKey: ['admin', 'summary'] });
+    },
+  });
+};
+
+export const useClassroomEnrollment = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      id,
+      studentIds,
+      action,
+    }: {
+      id: number;
+      studentIds: number[];
+      action: 'enroll' | 'unenroll';
+    }) => {
+      const response = await apiClient.post<EnrollmentResult>(`/classrooms/${id}/${action}/`, {
+        student_ids: studentIds,
+      });
+      return response.data;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'classroom', variables.id] });
+      queryClient.invalidateQueries({ queryKey: ['admin', 'classrooms'] });
+    },
+  });
+};

--- a/frontend_modern/src/features/admin/useSchoolPeople.ts
+++ b/frontend_modern/src/features/admin/useSchoolPeople.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+
+export interface SchoolPerson {
+  id: number;
+  full_name: string;
+  email: string;
+}
+
+const fetchTeachers = async (): Promise<SchoolPerson[]> => {
+  const response = await apiClient.get<SchoolPerson[]>('/users/school-teachers/');
+  return response.data;
+};
+
+const fetchStudents = async (): Promise<SchoolPerson[]> => {
+  const response = await apiClient.get<SchoolPerson[]>('/users/school-students/');
+  return response.data;
+};
+
+export const useSchoolTeachers = () =>
+  useQuery<SchoolPerson[]>({
+    queryKey: ['admin', 'school-teachers'],
+    queryFn: fetchTeachers,
+    staleTime: 5 * 60 * 1000,
+  });
+
+export const useSchoolStudents = () =>
+  useQuery<SchoolPerson[]>({
+    queryKey: ['admin', 'school-students'],
+    queryFn: fetchStudents,
+    staleTime: 5 * 60 * 1000,
+  });

--- a/frontend_modern/src/features/layout/Navbar.tsx
+++ b/frontend_modern/src/features/layout/Navbar.tsx
@@ -46,6 +46,7 @@ export const Navbar = () => {
   const isStudent = user?.role === UserRole.STUDENT || user?.role === UserRole.OPEN_STUDENT;
   const isTeacher = user?.role === UserRole.TEACHER;
   const isParent = user?.role === UserRole.PARENT;
+  const isAdmin = user?.role === UserRole.ADMIN;
 
   return (
     <nav className="bg-white border-b border-gray-200 sticky top-0 z-20">
@@ -97,6 +98,11 @@ export const Navbar = () => {
               {isParent && (
                 <NavLink to="/parent" active={location.pathname.startsWith('/parent')}>
                   Dashboard
+                </NavLink>
+              )}
+              {isAdmin && (
+                <NavLink to="/admin" active={location.pathname.startsWith('/admin')}>
+                  School Admin
                 </NavLink>
               )}
             </div>
@@ -198,6 +204,7 @@ export const Navbar = () => {
               </>
             )}
             {isParent && <MobileNavLink to="/parent">Dashboard</MobileNavLink>}
+            {isAdmin && <MobileNavLink to="/admin">School Admin</MobileNavLink>}
 
             {/* Profile + Sign out */}
             <div className="pt-2 border-t border-gray-100 mt-2 space-y-1">

--- a/frontend_modern/src/features/layout/ProtectedRoute.tsx
+++ b/frontend_modern/src/features/layout/ProtectedRoute.tsx
@@ -1,13 +1,15 @@
 import { Navigate } from 'react-router-dom';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
+import type { UserRole } from '@/types/index';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
+  allowedRoles?: UserRole[];
 }
 
-export const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
-  const { isAuthenticated, isLoading } = useAuth();
+export const ProtectedRoute = ({ children, allowedRoles }: ProtectedRouteProps) => {
+  const { isAuthenticated, isLoading, user } = useAuth();
 
   if (isLoading) {
     return (
@@ -19,6 +21,11 @@ export const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />;
+  }
+
+  // Role-restricted route: send users without the required role back to their default landing.
+  if (allowedRoles && user && !allowedRoles.includes(user.role)) {
+    return <Navigate to="/" replace />;
   }
 
   return <>{children}</>;


### PR DESCRIPTION
## Summary
The `/admin` product surface consuming the P4 School Admin API. A school admin can now run their school from the UI instead of Django admin: school summary, classroom CRUD + archive, roster management, and subject-room create/enroll — all role-guarded to admins.

- `ProtectedRoute` gains `allowedRoles`; `/admin` + `/admin/classrooms/:id` guarded to the ADMIN role; admin default-landing + Navbar entry
- `features/admin/`: summary, classroom, subject-room, and people hooks; `AdminDashboard`, `ClassroomManagePage`, reusable `EnrollStudentsModal`
- Enrollment surfaces the API's validate-and-report `invalid_ids` ("N skipped")

The P4 backend API (`IsSchoolAdmin`, `ClassRoomViewSet`, admin `SubjectRoomViewSet`, enrollment-picker endpoints) is already merged into `modernization` (#103), so this PR is self-contained — no merge-order dependency.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vite build` clean; ESLint clean
- [x] 16 FE unit tests pass (5 new for `EnrollStudentsModal`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)