### PR TITLE
ci: post backend coverage summary as sticky PR comment

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -76,6 +76,9 @@ jobs:
         name: Test
         runs-on: ubuntu-latest
         # No external services needed — tests use SQLite in-memory and LocMemCache
+        permissions:
+            contents: read
+            pull-requests: write
         steps:
             - name: Check out the repo
               uses: actions/checkout@v4
@@ -123,6 +126,42 @@ jobs:
                 name: coverage-report
                 path: backend/coverage.xml
                 retention-days: 14
+            - name: Post coverage summary on PR
+              # Push-triggered workflow: look up the PR for this branch (if any) and
+              # post / update a sticky coverage summary so it shows in code review
+              # without opening the artifact zip.
+              if: github.ref != 'refs/heads/modernization' && github.ref != 'refs/heads/qa' && github.ref != 'refs/heads/prod'
+              working-directory: backend
+              env:
+                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                PR_NUMBER=$(gh pr list --head "${{ github.ref_name }}" --json number --jq '.[0].number // empty')
+                if [ -z "$PR_NUMBER" ]; then
+                  echo "No open PR for branch ${{ github.ref_name }}; skipping coverage comment."
+                  exit 0
+                fi
+                {
+                  echo "## Backend coverage"
+                  echo ""
+                  echo "<!-- backend-coverage-comment -->"
+                  echo ""
+                  echo '```'
+                  python -m coverage report
+                  echo '```'
+                  echo ""
+                  echo "_Threshold: 90% (enforced by \`--cov-fail-under\` in pytest.ini). Commit ${{ github.sha }}._"
+                } > coverage_comment.md
+                # Find a prior comment from this workflow by its hidden marker and edit it; otherwise create.
+                EXISTING=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+                  --jq '.[] | select(.body | contains("<!-- backend-coverage-comment -->")) | .id' | head -n1)
+                if [ -n "$EXISTING" ]; then
+                  gh api --method PATCH "repos/${{ github.repository }}/issues/comments/${EXISTING}" \
+                    -f body="$(cat coverage_comment.md)" >/dev/null
+                  echo "Updated existing coverage comment ${EXISTING} on PR #${PR_NUMBER}."
+                else
+                  gh pr comment "$PR_NUMBER" --body-file coverage_comment.md
+                  echo "Posted new coverage comment on PR #${PR_NUMBER}."
+                fi
 
     frontend:
         name: Frontend (Lint, Types, Tests)


### PR DESCRIPTION
## Summary
- After the backend pytest step, looks up an open PR for the current branch and posts a coverage summary as a sticky comment so reviewers can see coverage without downloading the artifact.
- Uses a hidden HTML marker (`<!-- backend-coverage-comment -->`) to find the prior bot comment and PATCH it via the issues API, so each push refreshes the same comment instead of stacking new ones.
- Skipped on `modernization`/`qa`/`prod` and on pushes that have no associated PR. Grants the `test` job `pull-requests: write` so the default `GITHUB_TOKEN` can comment.

## Why this PR
Backlog item #2 (PR coverage comment). Coverage threshold is already enforced at 90% in `pytest.ini`, and `coverage.xml` is uploaded as an artifact, but neither surfaces the per-file numbers in code review. This makes them visible inline.

## Test plan
- [ ] Once merged into `modernization`, open a follow-up PR off it and confirm a coverage comment is posted on the PR by `github-actions[bot]`.
- [ ] Push a second commit and confirm the existing comment is updated in-place (no duplicate comments).
- [ ] Confirm push to `modernization` itself does not attempt to comment (no PR lookup error in CI logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)