### PR TITLE
Parent Intelligence Dashboard — Frontend (/parent/insights)

### DIFF
--- a/docs/changes/2026-05-29-parent-insights-frontend.md
+++ b/docs/changes/2026-05-29-parent-insights-frontend.md
@@ -1,0 +1,87 @@
+# Parent Intelligence Dashboard — Frontend
+
+**Date**: 2026-05-29
+**Classification**: New (surfaces the backend shipped in PR #107)
+**Branch**: `feat/2026-05-29-parent-insights-frontend` (based on `modernization`)
+
+## Summary
+
+Surfaces the Parent Intelligence Dashboard backend (`apps/ai` —
+`ParentProgressSummary`, narrative + alerts + suggested home activities) as a
+new `/parent/insights/:childId` page. Parents can read this week's narrative,
+see urgent/attention/info alerts, work through suggested home activities, and
+trigger an on-demand regeneration when no summary exists yet. A child-picker
+landing route (`/parent/insights`) auto-redirects single-child parents to their
+child's page; multi-child parents get a chooser. A "View Insights →" CTA was
+added to each child's Overview header on the existing parent dashboard.
+
+## What changed (frontend only — no backend churn)
+
+- `useParentSummary.ts` — `useLatestParentSummary(childId)` (handles 404 →
+  `null`) + `useGenerateParentSummary()` (invalidates `latest` on success).
+  Local TypeScript interfaces mirror `ParentProgressSummarySerializer`.
+- `components/NarrativeCard.tsx` — narrative paragraph, week range,
+  `model_used` chip, plus a 4-tile stat row (questions, active days, avg
+  score, week-over-week delta with semantic colour).
+- `components/AlertsPanel.tsx` — severity-styled cards
+  (urgent = red, attention = amber, info = blue), renders nothing on empty
+  array (no "no alerts" filler).
+- `components/HomeActivitiesPanel.tsx` — chapter/title/description cards
+  with a celebratory emerald variant detected from the activity title.
+- `ParentInsightsPage.tsx` — loading skeleton, success view, error retry,
+  empty state with a primary "Generate this week's summary" CTA + a small
+  "Regenerate" button in the success view. Refetches 1.5s after the
+  `generate/` POST so eager-mode dev still picks up the new row.
+- `ParentInsightsLandingPage.tsx` — child picker; 1-child parents are
+  redirected immediately.
+- `ParentDashboard.tsx` — new "View Insights →" entry-point beside each
+  child's Overview header.
+- Routes registered under the `PARENT` role guard:
+  - `/parent/insights` → landing/picker
+  - `/parent/insights/:childId` → insights page
+
+## Decisions
+
+- **Button, not third tab**, for the entry point on the parent dashboard
+  — insights is a *destination page*, not another lens on the same
+  proficiency chart.
+- **404 → `null`, not error**: a parent with no summary yet is the
+  expected first-visit state; the page renders an empty-state CTA in
+  place of an error fallback.
+- **Refetch on a 1.5s delay** after `generate/` POST: the endpoint returns
+  `202` and queues a Celery task; in dev (`CELERY_TASK_ALWAYS_EAGER`) the
+  row is ready by then; in prod the user can press "Regenerate" again if
+  the first attempt was still in flight.
+- **Celebrate-variant detection** is heuristic on the title rather than a
+  new field (backend has no `kind` discriminator).
+
+## Tests
+
+- `AlertsPanel.test.tsx` — empty array renders nothing; severity attribute
+  set per card.
+- `HomeActivitiesPanel.test.tsx` — empty array renders nothing; title +
+  description + chapter rendered; celebrate variant marked.
+
+`tsc`, `eslint`, `vite build`, and the AI backend test suite (`pytest
+openshiksha/apps/ai/`) all green.
+
+## How to verify
+
+1. Log in as a parent with at least one child.
+2. Visit `/parent` — each child's Overview header now shows
+   **View Insights →**.
+3. Click it → land on `/parent/insights/<childId>`. With no existing
+   summary, see the empty state. Click **Generate this week's summary**.
+4. The page refetches; the narrative, alerts, and home-activity cards
+   render with the deterministic stub summary even without an LLM key.
+5. Visit `/parent/insights` directly — single-child parents are
+   redirected; multi-child parents see a picker.
+
+## Next steps
+
+- Wire a Celery beat schedule for Monday-morning auto-generation (the
+  task already exists — `generate_parent_progress_summary`).
+- Pair the page with a Monday-morning email summary using the existing
+  `emails.py` pipeline.
+- i18n: expose an `en | hi` toggle on the page header once a global
+  language switcher lands.

--- a/frontend_modern/src/App.tsx
+++ b/frontend_modern/src/App.tsx
@@ -22,6 +22,8 @@ import { CreateProblemSetPage } from './features/teacher/CreateProblemSetPage';
 import { TeacherAssignmentDetailPage } from './features/teacher/TeacherAssignmentDetailPage';
 import { QuestionBankPage } from './features/teacher/QuestionBankPage';
 import { ParentDashboard } from './features/parent/ParentDashboard';
+import { ParentInsightsPage } from './features/parent/ParentInsightsPage';
+import { ParentInsightsLandingPage } from './features/parent/ParentInsightsLandingPage';
 import { AdminDashboard } from './features/admin/AdminDashboard';
 import { ClassroomManagePage } from './features/admin/ClassroomManagePage';
 import { UserRole } from './types/index';
@@ -232,6 +234,28 @@ function App() {
             <ProtectedRoute>
               <AppShell>
                 <ParentDashboard />
+              </AppShell>
+            </ProtectedRoute>
+          }
+        />
+
+        <Route
+          path="/parent/insights"
+          element={
+            <ProtectedRoute allowedRoles={[UserRole.PARENT]}>
+              <AppShell>
+                <ParentInsightsLandingPage />
+              </AppShell>
+            </ProtectedRoute>
+          }
+        />
+
+        <Route
+          path="/parent/insights/:childId"
+          element={
+            <ProtectedRoute allowedRoles={[UserRole.PARENT]}>
+              <AppShell>
+                <ParentInsightsPage />
               </AppShell>
             </ProtectedRoute>
           }

--- a/frontend_modern/src/features/parent/ParentDashboard.tsx
+++ b/frontend_modern/src/features/parent/ParentDashboard.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useChildren } from './useChildren';
 import { useChildProficiency } from './useChildProficiency';
 import { useChildAssignments } from './useChildAssignments';
@@ -230,13 +231,21 @@ export const ParentDashboard = () => {
 
       {selectedChild && (
         <>
-          <div className="mb-4">
-            <h2 className="text-lg font-semibold text-gray-800">
-              {selectedChild.first_name || selectedChild.username}'s Overview
-            </h2>
-            {selectedChild.grade != null && (
-              <p className="text-sm text-gray-500">Grade {selectedChild.grade}</p>
-            )}
+          <div className="mb-4 flex items-start justify-between gap-3 flex-wrap">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-800">
+                {selectedChild.first_name || selectedChild.username}'s Overview
+              </h2>
+              {selectedChild.grade != null && (
+                <p className="text-sm text-gray-500">Grade {selectedChild.grade}</p>
+              )}
+            </div>
+            <Link
+              to={`/parent/insights/${selectedChild.id}`}
+              className="shrink-0 px-3 py-2 text-sm font-semibold rounded-lg bg-indigo-50 text-indigo-700 hover:bg-indigo-100 transition-colors"
+            >
+              View Insights →
+            </Link>
           </div>
 
           {/* Tab switcher */}

--- a/frontend_modern/src/features/parent/ParentInsightsLandingPage.tsx
+++ b/frontend_modern/src/features/parent/ParentInsightsLandingPage.tsx
@@ -1,0 +1,62 @@
+import { useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
+import { useChildren } from './useChildren';
+
+export const ParentInsightsLandingPage = () => {
+  const { data: children, isLoading } = useChildren();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (children && children.length === 1) {
+      navigate(`/parent/insights/${children[0].id}`, { replace: true });
+    }
+  }, [children, navigate]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-64">
+        <LoadingSpinner size="lg" />
+      </div>
+    );
+  }
+
+  if (!children || children.length === 0) {
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold text-gray-900 mb-2">Insights</h1>
+        <div className="text-center py-16 bg-white rounded-xl border border-gray-200">
+          <p className="text-gray-500 font-medium">No children linked to your account</p>
+          <p className="text-sm text-gray-400 mt-1">
+            Ask the school admin to link your children's accounts.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold text-gray-900">Insights</h1>
+      <p className="text-sm text-gray-500 mt-1">Choose a child to view their weekly summary.</p>
+
+      <div className="mt-6 grid gap-3 sm:grid-cols-2">
+        {children.map((child) => (
+          <Link
+            key={child.id}
+            to={`/parent/insights/${child.id}`}
+            className="rounded-xl border border-gray-200 bg-white p-5 hover:border-indigo-300 hover:shadow-sm transition-all"
+          >
+            <p className="font-semibold text-gray-900">
+              {child.first_name || child.username}
+            </p>
+            {child.grade != null && (
+              <p className="text-sm text-gray-500 mt-1">Grade {child.grade}</p>
+            )}
+            <p className="text-sm text-indigo-600 font-medium mt-3">Open insights →</p>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/frontend_modern/src/features/parent/ParentInsightsPage.tsx
+++ b/frontend_modern/src/features/parent/ParentInsightsPage.tsx
@@ -1,0 +1,136 @@
+import { useParams, Link } from 'react-router-dom';
+import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
+import { useChildren } from './useChildren';
+import { useLatestParentSummary, useGenerateParentSummary } from './useParentSummary';
+import { NarrativeCard } from './components/NarrativeCard';
+import { AlertsPanel } from './components/AlertsPanel';
+import { HomeActivitiesPanel } from './components/HomeActivitiesPanel';
+
+export const ParentInsightsPage = () => {
+  const params = useParams<{ childId: string }>();
+  const childId = Number(params.childId);
+  const validChildId = Number.isFinite(childId) && childId > 0 ? childId : undefined;
+
+  const { data: children } = useChildren();
+  const child = children?.find((c) => c.id === validChildId);
+
+  const {
+    data: summary,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useLatestParentSummary(validChildId);
+  const generate = useGenerateParentSummary();
+
+  const handleGenerate = () => {
+    if (!validChildId) return;
+    generate.mutate(
+      { child_id: validChildId, language: 'en' },
+      {
+        onSuccess: () => {
+          // Backend queues a Celery task; in eager mode the summary is ready immediately.
+          // Refetch after a short pause to pick up either case.
+          setTimeout(() => refetch(), 1500);
+        },
+      },
+    );
+  };
+
+  if (!validChildId) {
+    return (
+      <div className="max-w-3xl mx-auto px-4 py-8">
+        <div className="text-center py-16 bg-white rounded-xl border border-gray-200">
+          <p className="text-gray-500 font-medium">No child selected</p>
+          <Link to="/parent/insights" className="text-indigo-600 text-sm font-medium mt-2 inline-block">
+            Pick a child
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+      <header className="flex items-start justify-between gap-3 flex-wrap">
+        <div>
+          <Link
+            to="/parent"
+            className="text-sm text-indigo-600 font-medium hover:underline"
+          >
+            ← Back to dashboard
+          </Link>
+          <h1 className="text-2xl font-bold text-gray-900 mt-1">
+            {child ? `${child.first_name || child.username}'s Insights` : 'Insights'}
+          </h1>
+          <p className="text-sm text-gray-500 mt-1">
+            A weekly progress narrative, alerts, and suggested home activities.
+          </p>
+        </div>
+      </header>
+
+      {isLoading && (
+        <div className="rounded-xl border border-gray-200 bg-white p-6">
+          <div className="flex items-center justify-center py-8">
+            <LoadingSpinner />
+          </div>
+        </div>
+      )}
+
+      {!isLoading && isError && (
+        <div className="rounded-xl border border-red-200 bg-red-50 p-5">
+          <p className="font-semibold text-red-800">Couldn't load the summary</p>
+          <p className="text-sm text-red-700 mt-1">
+            {(error as { message?: string })?.message || 'Please try again in a moment.'}
+          </p>
+          <button
+            onClick={() => refetch()}
+            className="mt-3 px-3 py-1.5 text-sm font-medium rounded-md bg-red-600 text-white hover:bg-red-700"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {!isLoading && !isError && !summary && (
+        <div className="rounded-xl border border-gray-200 bg-white p-6 text-center">
+          <p className="font-semibold text-gray-900">No summary yet</p>
+          <p className="text-sm text-gray-500 mt-1 max-w-md mx-auto">
+            We haven't generated a weekly summary for this child yet. Tap below to create one now —
+            it usually takes about 30 seconds.
+          </p>
+          <button
+            onClick={handleGenerate}
+            disabled={generate.isPending}
+            className="mt-4 px-4 py-2 text-sm font-semibold rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 disabled:bg-indigo-300 disabled:cursor-not-allowed transition-colors"
+          >
+            {generate.isPending ? 'Generating…' : "Generate this week's summary"}
+          </button>
+          {generate.isError && (
+            <p className="text-sm text-red-600 mt-3">
+              Generation failed. Please try again.
+            </p>
+          )}
+        </div>
+      )}
+
+      {!isLoading && !isError && summary && (
+        <>
+          <NarrativeCard summary={summary} />
+          <AlertsPanel alerts={summary.alerts} />
+          <HomeActivitiesPanel activities={summary.home_activities} />
+
+          <div className="flex justify-end">
+            <button
+              onClick={handleGenerate}
+              disabled={generate.isPending}
+              className="px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 disabled:opacity-60 transition-colors"
+            >
+              {generate.isPending ? 'Regenerating…' : 'Regenerate'}
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/frontend_modern/src/features/parent/components/AlertsPanel.test.tsx
+++ b/frontend_modern/src/features/parent/components/AlertsPanel.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { AlertsPanel } from './AlertsPanel';
+import type { ParentAlert } from '../useParentSummary';
+
+describe('AlertsPanel', () => {
+  it('renders nothing when alerts array is empty', () => {
+    const { container } = render(<AlertsPanel alerts={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders one card per alert with severity attribute', () => {
+    const alerts: ParentAlert[] = [
+      { severity: 'urgent', label: 'No practice in 10 days', detail: 'Aanya has not opened a question in 10 days.' },
+      { severity: 'attention', label: 'Score dropped 15%', detail: 'Average score fell from 78% to 63%.' },
+      { severity: 'info', label: 'New chapter unlocked', detail: 'Polynomials is now available.' },
+    ];
+    render(<AlertsPanel alerts={alerts} />);
+    expect(screen.getByText('No practice in 10 days')).toBeDefined();
+    expect(screen.getByText('Score dropped 15%')).toBeDefined();
+    expect(screen.getByText('New chapter unlocked')).toBeDefined();
+
+    const cards = document.querySelectorAll('[data-severity]');
+    expect(cards.length).toBe(3);
+    expect(cards[0].getAttribute('data-severity')).toBe('urgent');
+    expect(cards[1].getAttribute('data-severity')).toBe('attention');
+    expect(cards[2].getAttribute('data-severity')).toBe('info');
+  });
+});

--- a/frontend_modern/src/features/parent/components/AlertsPanel.tsx
+++ b/frontend_modern/src/features/parent/components/AlertsPanel.tsx
@@ -1,0 +1,57 @@
+import type { ParentAlert } from '../useParentSummary';
+
+const SEVERITY_STYLES: Record<ParentAlert['severity'], { card: string; chip: string; label: string }> = {
+  urgent: {
+    card: 'border-red-200 bg-red-50',
+    chip: 'bg-red-100 text-red-700',
+    label: 'Urgent',
+  },
+  attention: {
+    card: 'border-amber-200 bg-amber-50',
+    chip: 'bg-amber-100 text-amber-800',
+    label: 'Attention',
+  },
+  info: {
+    card: 'border-blue-200 bg-blue-50',
+    chip: 'bg-blue-100 text-blue-700',
+    label: 'Info',
+  },
+};
+
+interface Props {
+  alerts: ParentAlert[];
+}
+
+export const AlertsPanel = ({ alerts }: Props) => {
+  if (!alerts || alerts.length === 0) return null;
+
+  return (
+    <section aria-label="Alerts" className="space-y-3">
+      <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">Alerts</h3>
+      <div className="space-y-2">
+        {alerts.map((alert, idx) => {
+          const styles = SEVERITY_STYLES[alert.severity] ?? SEVERITY_STYLES.info;
+          return (
+            <div
+              key={`${alert.label}-${idx}`}
+              data-severity={alert.severity}
+              className={`rounded-xl border p-4 ${styles.card}`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="font-semibold text-gray-900">{alert.label}</p>
+                  <p className="text-sm text-gray-700 mt-1">{alert.detail}</p>
+                </div>
+                <span
+                  className={`shrink-0 text-xs font-semibold px-2 py-1 rounded-full ${styles.chip}`}
+                >
+                  {styles.label}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+};

--- a/frontend_modern/src/features/parent/components/HomeActivitiesPanel.test.tsx
+++ b/frontend_modern/src/features/parent/components/HomeActivitiesPanel.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { HomeActivitiesPanel } from './HomeActivitiesPanel';
+import type { HomeActivity } from '../useParentSummary';
+
+describe('HomeActivitiesPanel', () => {
+  it('renders nothing when activities are empty', () => {
+    const { container } = render(<HomeActivitiesPanel activities={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders title, description, and chapter name per activity', () => {
+    const activities: HomeActivity[] = [
+      {
+        title: 'Practice long division',
+        description: '15 minutes together on long division worksheets.',
+        chapter_name: 'Division',
+      },
+    ];
+    render(<HomeActivitiesPanel activities={activities} />);
+    expect(screen.getByText('Practice long division')).toBeDefined();
+    expect(screen.getByText('15 minutes together on long division worksheets.')).toBeDefined();
+    expect(screen.getByText('Division')).toBeDefined();
+  });
+
+  it('marks celebratory activities with data-celebrate', () => {
+    const activities: HomeActivity[] = [
+      { title: 'Great work this week!', description: 'Keep up the streak.', chapter_name: 'Algebra' },
+    ];
+    render(<HomeActivitiesPanel activities={activities} />);
+    const card = document.querySelector('[data-celebrate]');
+    expect(card).not.toBeNull();
+  });
+});

--- a/frontend_modern/src/features/parent/components/HomeActivitiesPanel.tsx
+++ b/frontend_modern/src/features/parent/components/HomeActivitiesPanel.tsx
@@ -1,0 +1,43 @@
+import type { HomeActivity } from '../useParentSummary';
+
+interface Props {
+  activities: HomeActivity[];
+}
+
+const isCelebrate = (a: HomeActivity) => /great|keep it up|celebrate|well done|nice work/i.test(a.title);
+
+export const HomeActivitiesPanel = ({ activities }: Props) => {
+  if (!activities || activities.length === 0) return null;
+
+  return (
+    <section aria-label="Home Activities" className="space-y-3">
+      <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+        Try this week at home
+      </h3>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {activities.map((activity, idx) => {
+          const celebrate = isCelebrate(activity);
+          return (
+            <div
+              key={`${activity.title}-${idx}`}
+              data-celebrate={celebrate || undefined}
+              className={`rounded-xl border p-4 ${
+                celebrate ? 'border-emerald-200 bg-emerald-50' : 'border-gray-200 bg-white'
+              }`}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <p className="font-semibold text-gray-900">{activity.title}</p>
+                {activity.chapter_name && (
+                  <span className="shrink-0 text-xs font-medium px-2 py-1 rounded-full bg-indigo-50 text-indigo-700">
+                    {activity.chapter_name}
+                  </span>
+                )}
+              </div>
+              <p className="text-sm text-gray-700 mt-2 leading-relaxed">{activity.description}</p>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+};

--- a/frontend_modern/src/features/parent/components/NarrativeCard.tsx
+++ b/frontend_modern/src/features/parent/components/NarrativeCard.tsx
@@ -1,0 +1,65 @@
+import type { ParentProgressSummary } from '../useParentSummary';
+
+interface Props {
+  summary: ParentProgressSummary;
+}
+
+const formatDate = (iso: string): string => {
+  try {
+    return new Date(iso).toLocaleDateString('en-IN', { day: 'numeric', month: 'short', year: 'numeric' });
+  } catch {
+    return iso;
+  }
+};
+
+const StatTile = ({ label, value }: { label: string; value: string }) => (
+  <div className="rounded-lg bg-gray-50 px-3 py-2">
+    <p className="text-xs text-gray-500 font-medium">{label}</p>
+    <p className="text-base font-semibold text-gray-900 mt-0.5">{value}</p>
+  </div>
+);
+
+export const NarrativeCard = ({ summary }: Props) => {
+  const weekRange = `${formatDate(summary.week_start)} – ${formatDate(summary.week_end)}`;
+  const deltaPct = Math.round(summary.score_delta * 100);
+  const deltaSign = summary.score_delta > 0 ? '+' : '';
+  const deltaColor =
+    summary.score_delta > 0.01
+      ? 'text-emerald-700 bg-emerald-50'
+      : summary.score_delta < -0.01
+        ? 'text-red-700 bg-red-50'
+        : 'text-gray-700 bg-gray-100';
+
+  return (
+    <article className="rounded-xl border border-gray-200 bg-white p-5 sm:p-6">
+      <div className="flex items-start justify-between gap-3 flex-wrap">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-gray-500 font-medium">
+            Weekly summary · {summary.child_name}
+          </p>
+          <p className="text-sm text-gray-500 mt-1">{weekRange}</p>
+        </div>
+        <span className="shrink-0 text-xs font-medium px-2 py-1 rounded-full bg-indigo-50 text-indigo-700">
+          {summary.model_used}
+        </span>
+      </div>
+
+      <p className="mt-4 text-gray-800 leading-relaxed whitespace-pre-line">
+        {summary.summary_text}
+      </p>
+
+      <div className="mt-5 grid grid-cols-2 sm:grid-cols-4 gap-2">
+        <StatTile label="Questions" value={String(summary.ticks_recorded)} />
+        <StatTile label="Active days" value={`${summary.active_days} / 7`} />
+        <StatTile label="Avg score" value={`${Math.round(summary.avg_score * 100)}%`} />
+        <div className={`rounded-lg px-3 py-2 ${deltaColor}`}>
+          <p className="text-xs font-medium opacity-80">Vs last week</p>
+          <p className="text-base font-semibold mt-0.5">
+            {deltaSign}
+            {deltaPct}%
+          </p>
+        </div>
+      </div>
+    </article>
+  );
+};

--- a/frontend_modern/src/features/parent/useParentSummary.ts
+++ b/frontend_modern/src/features/parent/useParentSummary.ts
@@ -1,0 +1,83 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+
+export interface ParentAlert {
+  severity: 'info' | 'attention' | 'urgent';
+  label: string;
+  detail: string;
+}
+
+export interface HomeActivity {
+  title: string;
+  description: string;
+  chapter_name?: string;
+}
+
+export interface WeakStrongChapter {
+  chapter_id: number;
+  chapter_name: string;
+  avg_score: number;
+  tick_count: number;
+}
+
+export interface ParentProgressSummary {
+  id: number;
+  parent: number;
+  child: number;
+  child_username: string;
+  child_name: string;
+  week_start: string;
+  week_end: string;
+  summary_text: string;
+  language: 'en' | 'hi';
+  ticks_recorded: number;
+  active_days: number;
+  avg_score: number;
+  score_delta: number;
+  weak_chapters: WeakStrongChapter[];
+  strong_chapters: WeakStrongChapter[];
+  home_activities: HomeActivity[];
+  alerts: ParentAlert[];
+  has_urgent_alert: boolean;
+  model_used: string;
+  generated_at: string;
+}
+
+export const useLatestParentSummary = (childId: number | undefined) =>
+  useQuery<ParentProgressSummary | null>({
+    queryKey: ['parent', 'summary', 'latest', childId],
+    queryFn: async () => {
+      try {
+        const { data } = await apiClient.get<ParentProgressSummary>(
+          `/ai/parent-summaries/latest/?child=${childId}`,
+        );
+        return data;
+      } catch (err: unknown) {
+        const status = (err as { response?: { status?: number } })?.response?.status;
+        if (status === 404) return null;
+        throw err;
+      }
+    },
+    enabled: Number.isFinite(childId),
+    staleTime: 60 * 1000,
+  });
+
+interface GenerateParams {
+  child_id: number;
+  language?: 'en' | 'hi';
+}
+
+export const useGenerateParentSummary = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: GenerateParams) => {
+      const { data } = await apiClient.post('/ai/parent-summaries/generate/', payload);
+      return data;
+    },
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({
+        queryKey: ['parent', 'summary', 'latest', vars.child_id],
+      });
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- New `/parent/insights/:childId` page consuming the `/api/v1/ai/parent-summaries/` backend shipped in #107: weekly narrative, alerts (urgent/attention/info), suggested home activities, and an on-demand **Generate this week's summary** CTA when no summary exists.
- New `/parent/insights` landing route: child picker for multi-child parents, auto-redirect for single-child parents.
- **View Insights →** entry-point on each child's Overview header in the existing parent dashboard.

## Classification
**New** — surfaces the just-shipped backend; no API, model, or migration changes.

## What's in the diff
- `useParentSummary.ts` — `useLatestParentSummary` (404 → `null`) + `useGenerateParentSummary` (invalidates `latest` on success).
- `components/NarrativeCard.tsx` — week range, `model_used` chip, 4-tile stat row (questions, active days, avg score, semantic-coloured week-over-week delta).
- `components/AlertsPanel.tsx` — severity-styled cards; empty array renders nothing.
- `components/HomeActivitiesPanel.tsx` — chapter/title/description cards + emerald celebrate variant.
- `ParentInsightsPage.tsx` — loading skeleton, error retry, empty-state CTA, success view with a small Regenerate action. Refetches 1.5s after `generate/` to pick up eager-mode runs.
- `ParentInsightsLandingPage.tsx` — picker + single-child redirect.
- `ParentDashboard.tsx` — View Insights → CTA per child.
- `App.tsx` — two new routes under the `PARENT` role guard.

## Tests
- `AlertsPanel.test.tsx` — empty array renders nothing; severity attribute set per card.
- `HomeActivitiesPanel.test.tsx` — empty array renders nothing; title + description + chapter rendered; celebrate variant marked.
- `tsc`, `eslint`, `vite build` green. Backend `pytest openshiksha/apps/ai/` green (233 passed).

## How to verify
1. Log in as a parent with at least one child.
2. On `/parent`, click **View Insights →** on any child's Overview header.
3. With no summary yet, see the empty state. Click **Generate this week's summary**.
4. Page refetches; narrative + alerts + home-activity cards render (stub model works without an LLM key).
5. Visit `/parent/insights` directly — single-child parents redirect to their child; multi-child parents see the picker.

## Notes
- Decision: button (destination), not a third tab. Insights is a separate view, not another lens on proficiency.
- Heuristic celebrate-variant on title — backend has no `kind` field.
- i18n: `language: en` only this round; toggle deferred until a global language switcher exists.

Doc: `docs/changes/2026-05-29-parent-insights-frontend.md`.