### PR TITLE
feat(ui): detect un-delimited LaTeX environments in RichContent (M7-04)

### DIFF
--- a/docs/changes/2026-05-31-richcontent-env.md
+++ b/docs/changes/2026-05-31-richcontent-env.md
@@ -1,0 +1,59 @@
+# 2026-05-31 — RichContent un-delimited environment detection (M7-04)
+
+## Summary
+
+Teach the shared `<RichContent />` primitive to recognise un-delimited LaTeX
+environments (`\begin{X}…\end{X}`) as block math and route them through KaTeX
+in `displayMode`. Without this, Cabinet content that uses raw `\begin{array}`
+tables (the entire Q3 salary-table family from the 2026-05-30 visual audit)
+rendered as literal `\begin{array}{c|lcr}` text on the page.
+
+## Classification
+
+Improve — extends M7-01 (`RichContent`, PR #114) and stays inside the same
+sanitise → KaTeX pipeline.
+
+## Files touched
+
+- `frontend_modern/src/shared/ui/renderRichContent.ts` — add `ENV_RE` first in
+  the delimiter table with `exprGroup: 0` (feed the whole match, `\begin` and
+  `\end` included, to KaTeX).
+- `frontend_modern/src/shared/ui/RichContent.test.tsx` — five new tests:
+  `\begin{array}` typesets as block math, env wins over inner `$`-style
+  delimiters, truncated `\begin{` doesn't crash, `<div>…\(…\)…</div>` nested
+  case, `<table>` + inline KaTeX render side-by-side.
+
+## What changed and why
+
+- The renderer previously only matched the four `$`/`\(`/`$$`/`\[` delimiter
+  pairs. Cabinet content for tables and aligned equations ships the bare
+  `\begin{array}` form (no surrounding `$$`), so those regions emerged on the
+  page as raw LaTeX source.
+- The new regex is `/\\begin\{([a-zA-Z*]+)\}[\s\S]*?\\end\{\1\}/g`: non-greedy,
+  with a back-reference to the opening env name. Cabinet envs don't nest, so
+  this is safe across the 644-question corpus. Truncated openers are simply
+  unmatched and pass through as escaped text — no crash.
+- The env rule is listed **first** in `DELIMITERS` so its hits are added to the
+  `findMath()` array before `$…$` etc. The existing cursor-based merge then
+  skips overlapping inner `$` matches automatically.
+- `exprGroup: 0` is new: env hits feed the *entire* match (begin + body + end)
+  to KaTeX; the existing `$…$` family keep `exprGroup: 1` so they strip the
+  delimiters.
+
+## Tests
+
+`npm test src/shared/ui/RichContent.test.tsx` — 17 passing (12 prior + 5 new).
+`npm run type-check`, `npm run lint`, `npm run build` all clean.
+
+## Skeleton (M1-06 carry-over)
+
+`shared/ui/Skeleton.tsx` and its `index.ts` export are already on
+`modernization` (landed alongside M7-01). No code change required; consumers
+will adopt as new loading surfaces appear in the V2 dashboards.
+
+## Next steps
+
+- M7-09 `infer_taxonomy_names` management command (next PR in this batch).
+- M7-07 shared stem field + importer lift.
+- M7-05 tag-collision fix.
+- M7-03 per-subpart type + grader dispatch.

--- a/frontend_modern/src/shared/ui/RichContent.test.tsx
+++ b/frontend_modern/src/shared/ui/RichContent.test.tsx
@@ -67,6 +67,52 @@ describe('renderRichContent', () => {
     expect(html).toContain('class="katex"');
   });
 
+  it('renders an un-delimited \\begin{array}…\\end{array} environment as block math', () => {
+    const fixture =
+      'Consider the table \\begin{array}{c|lcr} a & b & c & d \\\\ \\hline 1 & 2 & 3 & 4 \\end{array} above.';
+    const html = renderRichContent(fixture);
+    expect(html).toContain('katex-display');
+    expect(html).not.toContain('\\begin{array}');
+    expect(html).not.toContain('\\end{array}');
+  });
+
+  it('treats the env as a single math chunk even when it contains inner $-like chars', () => {
+    // The `&` separators and `\\` row breaks must not be partially eaten by the
+    // `$…$` delimiter regex — the env wraps the whole region.
+    const fixture = 'X \\begin{array}{cc} \\$1 & 2 \\\\ 3 & 4 \\end{array} Y';
+    const html = renderRichContent(fixture);
+    expect(html).toContain('katex-display');
+    // No raw begin/end tokens leak as text.
+    expect(html).not.toMatch(/\\begin\{array\}/);
+    expect(html).not.toMatch(/\\end\{array\}/);
+  });
+
+  it('does not crash on a truncated \\begin{ with no matching \\end', () => {
+    expect(() =>
+      renderRichContent('Truncated: \\begin{array}{c} 1 & 2 with no closer.')
+    ).not.toThrow();
+    const html = renderRichContent('Truncated: \\begin{array}{c} 1 & 2 with no closer.');
+    // The bare tokens stay as escaped text (no katex render); important is no crash.
+    expect(html).toContain('Truncated');
+  });
+
+  it('renders nested HTML wrapping inline LaTeX (the Cabinet `<div>…\\(…\\)…</div>` case)', () => {
+    const html = renderRichContent('<div>Value is \\(2x+3\\) here.</div>');
+    expect(html).toContain('<div>');
+    expect(html).toContain('class="katex"');
+    expect(html).not.toContain('\\(2x+3\\)');
+  });
+
+  it('renders an HTML <table> alongside inline KaTeX without leaking either', () => {
+    const fixture =
+      '<table><tr><td>Salary</td><td>$\\frac{a}{b}$</td></tr></table>';
+    const html = renderRichContent(fixture);
+    expect(html).toContain('<table>');
+    expect(html).toContain('<td>Salary</td>');
+    expect(html).toContain('class="katex"');
+    expect(html).not.toContain('$\\frac');
+  });
+
   it('renders a Cabinet-style fragment with HTML + inline LaTeX', () => {
     const fixture =
       '<p>Find <strong>x</strong> such that \\(2x + 3 = 11\\).</p>' +

--- a/frontend_modern/src/shared/ui/renderRichContent.ts
+++ b/frontend_modern/src/shared/ui/renderRichContent.ts
@@ -22,11 +22,19 @@ const ALLOWED_TAGS = [
 
 const ALLOWED_ATTR = ['href', 'src', 'alt', 'width', 'height', 'title', 'class', 'colspan', 'rowspan'];
 
-const DELIMITERS: Array<{ re: RegExp; block: boolean }> = [
-  { re: /\$\$([\s\S]+?)\$\$/g, block: true },
-  { re: /\\\[([\s\S]+?)\\\]/g, block: true },
-  { re: /\\\(([\s\S]+?)\\\)/g, block: false },
-  { re: /(?<!\$)\$([^$\n]+?)\$(?!\$)/g, block: false },
+// `exprGroup: 0` means feed the entire match to KaTeX (used for un-delimited
+// `\begin{X}…\end{X}` environments where the begin/end tokens are part of the
+// LaTeX source). `exprGroup: 1` strips the surrounding delimiter.
+const DELIMITERS: Array<{ re: RegExp; block: boolean; exprGroup: 0 | 1 }> = [
+  // Un-delimited LaTeX environments — listed first so an env embedded in a
+  // paragraph wins over any inner `$…$` partial matches.
+  // Non-greedy `[\s\S]*?` + back-reference to the opening name; Cabinet
+  // environments don't nest so this is safe across the corpus.
+  { re: /\\begin\{([a-zA-Z*]+)\}[\s\S]*?\\end\{\1\}/g, block: true, exprGroup: 0 },
+  { re: /\$\$([\s\S]+?)\$\$/g, block: true, exprGroup: 1 },
+  { re: /\\\[([\s\S]+?)\\\]/g, block: true, exprGroup: 1 },
+  { re: /\\\(([\s\S]+?)\\\)/g, block: false, exprGroup: 1 },
+  { re: /(?<!\$)\$([^$\n]+?)\$(?!\$)/g, block: false, exprGroup: 1 },
 ];
 
 interface MathHit {
@@ -38,11 +46,12 @@ interface MathHit {
 
 function findMath(source: string): MathHit[] {
   const hits: MathHit[] = [];
-  for (const { re, block } of DELIMITERS) {
+  for (const { re, block, exprGroup } of DELIMITERS) {
     re.lastIndex = 0;
     let m: RegExpExecArray | null;
     while ((m = re.exec(source)) !== null) {
-      hits.push({ start: m.index, end: m.index + m[0].length, expr: m[1], block });
+      const expr = exprGroup === 0 ? m[0] : m[1];
+      hits.push({ start: m.index, end: m.index + m[0].length, expr, block });
     }
   }
   hits.sort((a, b) => a.start - b.start);


### PR DESCRIPTION
## Summary

Teach the shared `<RichContent />` primitive to recognise un-delimited LaTeX environments (`\begin{X}…\end{X}`) as block math and route them through KaTeX in `displayMode`.

Without this, Cabinet content that uses raw `\begin{array}` tables (the Q3 salary-table family from the 2026-05-30 visual audit) rendered as literal `\begin{array}{c|lcr}` text.

## Classification

**Improve** — extends M7-01 (`RichContent`, #114). Top initiative: [Cabinet Data Fidelity](../blob/modernization/docs/initiatives/cabinet-data-fidelity.md), sub-issue M7-04.

## Changes

- `renderRichContent.ts`: new `ENV_RE` (`/\begin\{([a-zA-Z*]+)\}[\s\S]*?\end\{\1\}/g`) listed first in the delimiter table with `exprGroup: 0` (feeds the whole match to KaTeX). Non-greedy with a back-reference to the opening name; Cabinet envs don't nest.
- `RichContent.test.tsx`: 5 new tests — `\begin{array}` typesets as block math; env wins over inner `$`-style delimiters; truncated `\begin{` doesn't crash; `<div>…\(…\)…</div>` nested case; `<table>` + inline KaTeX side-by-side.

## Test plan

- [x] `npm test src/shared/ui/RichContent.test.tsx` → 17 passing
- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [ ] Manual: log in as `student_demo`, open the salary-table question — table typesets, no raw `\begin{}` leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)