### PR TITLE
fix(core): chapter-scope Cabinet tag to recover collided questions (M7-05)

### DIFF
--- a/backend/openshiksha/apps/core/management/commands/import_cabinet_questions.py
+++ b/backend/openshiksha/apps/core/management/commands/import_cabinet_questions.py
@@ -395,8 +395,14 @@ class Command(BaseCommand):
         q_type = converted[0]["_question_type"]
         standard, subject, chapter = self._resolve_taxonomy(ids, mapping, stats)
 
+        # M7-05: the cabinet tag must be unique per *imported* question, not per
+        # raw cabinet question_id. Several chapters share the same numeric
+        # question_id (1.json appears in dozens of chapter folders), so the
+        # legacy `cabinet:<id>` tag collapsed 33 distinct questions into one.
+        # Scope the tag by chapter PK to restore identity.
         cabinet_tag, _ = QuestionTag.objects.get_or_create(
-            name=f"cabinet:{ids['question_id']}", defaults={"tag_type": "special"}
+            name=f"cabinet:c{chapter.id}:q{ids['question_id']}",
+            defaults={"tag_type": "special"},
         )
 
         existing = Question.objects.filter(tags=cabinet_tag).first()

--- a/backend/openshiksha/apps/core/migrations/0013_cabinet_tag_path.py
+++ b/backend/openshiksha/apps/core/migrations/0013_cabinet_tag_path.py
@@ -1,0 +1,84 @@
+"""Data migration: rewrite legacy `cabinet:<question_id>` tags to the
+chapter-scoped path `cabinet:c<chapter_id>:q<question_id>` (M7-05).
+
+The legacy importer named every cabinet tag `cabinet:<question_id>` using only
+the raw question-file basename, which collided across chapters that happened
+to share an ID (e.g. `1.json` lives in dozens of chapter folders). The result
+was 33 distinct source questions collapsed into one row with one tag.
+
+This migration rewrites each existing `cabinet:<N>` tag to
+`cabinet:c<chapter_id>:q<N>` using the first attached question's chapter FK,
+so the surviving row gets a unique, chapter-scoped tag. On re-import after
+this migration, the formerly-colliding questions will get *new* tags (because
+the importer now generates the chapter-scoped name), so the 33 originally-
+dropped questions reappear as fresh rows.
+
+Reversible: `reverse_code` rewrites the new form back to the legacy form,
+which may re-introduce collisions if a previous run dropped them — that's
+acceptable because reversing a destructive collision recovery is also
+destructive. The migration logs a count of rewritten tags via stdout.
+"""
+
+import re
+
+from django.db import migrations
+
+_LEGACY_RE = re.compile(r"^cabinet:([^:]+)$")
+_NEW_RE = re.compile(r"^cabinet:c\d+:q(.+)$")
+
+
+def rewrite_to_chapter_scoped(apps, schema_editor):
+    QuestionTag = apps.get_model("core", "QuestionTag")
+    rewritten = 0
+    skipped_orphan = 0
+    skipped_collision = 0
+
+    legacy = list(QuestionTag.objects.filter(name__startswith="cabinet:"))
+    for tag in legacy:
+        m = _LEGACY_RE.match(tag.name)
+        if not m:
+            # Already chapter-scoped or some other cabinet:* tag — skip.
+            continue
+        question_id = m.group(1)
+        first_q = tag.questions.first()
+        if first_q is None:
+            skipped_orphan += 1
+            continue
+        new_name = f"cabinet:c{first_q.chapter_id}:q{question_id}"
+        if QuestionTag.objects.filter(name=new_name).exists():
+            skipped_collision += 1
+            continue
+        tag.name = new_name
+        tag.save(update_fields=["name"])
+        rewritten += 1
+
+    print(
+        f"  cabinet_tag_path: rewrote {rewritten}, skipped_orphan={skipped_orphan}, "
+        f"skipped_collision={skipped_collision}"
+    )
+
+
+def revert_to_legacy(apps, schema_editor):
+    QuestionTag = apps.get_model("core", "QuestionTag")
+    reverted = 0
+    for tag in QuestionTag.objects.filter(name__startswith="cabinet:c"):
+        m = _NEW_RE.match(tag.name)
+        if not m:
+            continue
+        legacy_name = f"cabinet:{m.group(1)}"
+        if QuestionTag.objects.filter(name=legacy_name).exists():
+            continue
+        tag.name = legacy_name
+        tag.save(update_fields=["name"])
+        reverted += 1
+    print(f"  cabinet_tag_path (reverse): reverted {reverted}")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0012_user_email_reminders_opt_out_assignmentreminder"),
+    ]
+
+    operations = [
+        migrations.RunPython(rewrite_to_chapter_scoped, reverse_code=revert_to_legacy),
+    ]

--- a/backend/openshiksha/apps/core/tests/test_cabinet_tag_migration.py
+++ b/backend/openshiksha/apps/core/tests/test_cabinet_tag_migration.py
@@ -1,0 +1,77 @@
+"""Tests for the M7-05 cabinet tag-path data migration.
+
+The migration module name starts with a digit (`0013_cabinet_tag_path`) which
+Python's import system rejects. We test the data-rewrite logic via Django's
+`migration_executor` running the migration against a real test DB instead of
+importing the functions directly.
+"""
+
+import pytest
+
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+
+from openshiksha.apps.core.models import Chapter, Question, QuestionTag, QuestionType, Standard, Subject
+
+
+def _make_chapter(name, std_num=9, subject_name="Mathematics"):
+    standard, _ = Standard.objects.get_or_create(number=std_num)
+    subject, _ = Subject.objects.get_or_create(name=subject_name)
+    return Chapter.objects.create(name=name, subject=subject, standard=standard)
+
+
+def _make_question(chapter):
+    return Question.objects.create(
+        standard=chapter.standard,
+        subject=chapter.subject,
+        chapter=chapter,
+        question_type=QuestionType.NUMERIC,
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+class TestCabinetTagPathMigration:
+    """Forward-migrate, then backward-migrate, asserting the rename round-trips."""
+
+    PREVIOUS = ("core", "0012_user_email_reminders_opt_out_assignmentreminder")
+    TARGET = ("core", "0013_cabinet_tag_path")
+
+    def _migrate_to(self, migration):
+        executor = MigrationExecutor(connection)
+        executor.migrate([migration])
+        # The migration framework caches the project state; reset it for clean
+        # subsequent operations.
+        executor.loader.build_graph()
+
+    def test_forward_rewrites_legacy_tag_with_chapter_scope(self):
+        # Set up: state at PREVIOUS migration with a legacy-named tag.
+        self._migrate_to(self.PREVIOUS)
+        chapter = _make_chapter("Polynomials")
+        question = _make_question(chapter)
+        tag = QuestionTag.objects.create(name="cabinet:1001", tag_type="special")
+        question.tags.add(tag)
+
+        # Apply target migration.
+        self._migrate_to(self.TARGET)
+        tag.refresh_from_db()
+        assert tag.name == f"cabinet:c{chapter.id}:q1001"
+
+    def test_reverse_round_trip(self):
+        self._migrate_to(self.PREVIOUS)
+        chapter = _make_chapter("Polynomials")
+        question = _make_question(chapter)
+        tag = QuestionTag.objects.create(name="cabinet:1001", tag_type="special")
+        question.tags.add(tag)
+
+        self._migrate_to(self.TARGET)
+        self._migrate_to(self.PREVIOUS)
+        tag.refresh_from_db()
+        assert tag.name == "cabinet:1001"
+
+    def test_orphan_legacy_tag_left_alone(self):
+        self._migrate_to(self.PREVIOUS)
+        tag = QuestionTag.objects.create(name="cabinet:9999", tag_type="special")
+
+        self._migrate_to(self.TARGET)
+        tag.refresh_from_db()
+        assert tag.name == "cabinet:9999"

--- a/backend/openshiksha/apps/core/tests/test_import_cabinet.py
+++ b/backend/openshiksha/apps/core/tests/test_import_cabinet.py
@@ -162,13 +162,13 @@ class TestImportCommand:
 
     def test_solution_and_hint_imported(self):
         call_command("import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=StringIO(), stderr=StringIO())
-        sp = QuestionSubpart.objects.get(question__tags__name="cabinet:1004")
+        sp = QuestionSubpart.objects.get(question__tags__name__endswith=":q1004")
         assert sp.solution_text
         assert sp.hint_text
 
     def test_tokens_converted_in_content(self):
         call_command("import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=StringIO(), stderr=StringIO())
-        sp = QuestionSubpart.objects.get(question__tags__name="cabinet:1001")
+        sp = QuestionSubpart.objects.get(question__tags__name__endswith=":q1001")
         assert "{{a}}" in sp.question_text
         assert "_{a}_" not in sp.question_text
 
@@ -181,7 +181,7 @@ class TestImportCommand:
     def test_image_url_set_when_sibling_file_present(self):
         """A sibling <subpart>.png file under raw/.../<chapter>/ is attached as a raw.githubusercontent.com URL."""
         call_command("import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=StringIO(), stderr=StringIO())
-        sp = QuestionSubpart.objects.get(question__tags__name="cabinet:1001")
+        sp = QuestionSubpart.objects.get(question__tags__name__endswith=":q1001")
         assert sp.image_url.startswith(
             "https://raw.githubusercontent.com/openshiksha/openshiksha-cabinet/HEAD/questions/raw/"
         )
@@ -190,5 +190,18 @@ class TestImportCommand:
     def test_image_url_empty_when_no_sibling_file(self):
         """A subpart with no sibling image file keeps image_url empty (the default)."""
         call_command("import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=StringIO(), stderr=StringIO())
-        sp = QuestionSubpart.objects.get(question__tags__name="cabinet:1003")
+        sp = QuestionSubpart.objects.get(question__tags__name__endswith=":q1003")
         assert sp.image_url == ""
+
+    def test_tags_are_chapter_scoped(self):
+        """M7-05: tag must include the chapter PK so question_ids reused across
+        chapters (e.g. `1.json` in many chapter folders) don't collapse."""
+        call_command("import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=StringIO(), stderr=StringIO())
+        from openshiksha.apps.core.models import QuestionTag
+
+        cabinet_tags = QuestionTag.objects.filter(name__startswith="cabinet:")
+        for tag in cabinet_tags:
+            # New form: cabinet:c<chapter_id>:q<question_id>
+            assert ":c" in tag.name and ":q" in tag.name, tag.name
+            # Each tag should be attached to exactly one Question.
+            assert tag.questions.count() == 1

--- a/docs/changes/2026-05-31-tag-collision.md
+++ b/docs/changes/2026-05-31-tag-collision.md
@@ -1,0 +1,67 @@
+# 2026-05-31 — Cabinet tag collision fix (M7-05)
+
+## Summary
+
+Scope the Cabinet importer tag by chapter so questions that share a raw
+`question_id` across different chapter folders no longer collapse into a single
+row. The legacy tag `cabinet:<question_id>` collided across 33 questions; the
+new tag `cabinet:c<chapter_id>:q<question_id>` is unique per imported Question.
+
+A reversible data migration rewrites every existing legacy tag to the new
+form, joining via the first attached Question's chapter FK. After the
+migration lands, re-running the importer recovers the previously-dropped 33
+questions as fresh rows (their tags are now in chapter folders the old
+collision had hidden).
+
+## Classification
+
+**Improve** — tag-naming convention change + idempotent data migration.
+
+## Files touched
+
+- `apps/core/management/commands/import_cabinet_questions.py` — tag format
+  updated to `cabinet:c{chapter.id}:q{question_id}` with an explanatory
+  comment pointing at the collision case.
+- `apps/core/migrations/0013_cabinet_tag_path.py` — `RunPython` data migration
+  with both forward (`cabinet:<N>` → `cabinet:c<chapter_id>:q<N>`) and reverse
+  (round-trip back) functions. Skips orphan tags (no attached Question) and
+  collision targets (existing scoped tag). Logs counts via stdout.
+- `apps/core/tests/test_import_cabinet.py` — existing 4 lookups that used the
+  legacy `cabinet:1001` form now use `name__endswith=":q1001"`; new
+  `test_tags_are_chapter_scoped` asserts every cabinet tag has the new shape
+  and is attached to exactly one Question.
+- `apps/core/tests/test_cabinet_tag_migration.py` — 3 migration tests using
+  `MigrationExecutor` to run the migration forward / backward / forward-on-
+  orphan against a real test DB.
+
+## What changed and why
+
+- The legacy importer used only the raw question-file basename (`1.json` →
+  `cabinet:1`). The same basename appears in dozens of chapter folders in the
+  Cabinet repo, so `get_or_create` returned the same tag on every import,
+  collapsing distinct questions into one row.
+- The new tag includes the modern `Chapter.pk` (always unique). Using a
+  modern FK rather than the legacy `<board>/<school>/<standard>/<subject>/
+  <chapter>` path keeps the tag short and stable across re-imports (the same
+  chapter row is reused).
+- The migration is forward + reverse safe; logs `rewrote / skipped_orphan /
+  skipped_collision` counts so production rollouts have an audit trail.
+
+## Tests
+
+- `pytest apps/core/tests/test_import_cabinet.py` → 32 passing.
+- `pytest apps/core/tests/test_cabinet_tag_migration.py` → 3 passing.
+- `pytest apps/core/tests/` (full core suite) → 177 passing.
+- Django `check` clean.
+
+## Migration notes
+
+Run order on prod: `manage.py migrate core 0013_cabinet_tag_path` (rewrites
+tags), then `manage.py import_cabinet_questions --source <repo>` (re-imports;
+formerly-collided 33 questions land as new rows).
+
+## Next steps
+
+- M7-03 per-subpart type + grader dispatch (final PR in this batch).
+- After import, re-run `infer_taxonomy_names --apply` if the import created
+  new placeholder chapters/subjects.


### PR DESCRIPTION
## Summary

Scope the Cabinet importer tag by chapter so questions that share a raw `question_id` across different chapter folders no longer collapse into a single row. The legacy `cabinet:<question_id>` tag collided across 33 questions; the new `cabinet:c<chapter_id>:q<question_id>` is unique per imported Question.

## Classification

**Improve** — tag-naming convention change + idempotent data migration.

## Changes

- `import_cabinet_questions.py` — tag becomes `cabinet:c{chapter.id}:q{question_id}` (modern Chapter PK; unique per imported Question).
- Migration `0013_cabinet_tag_path` — reversible `RunPython` that rewrites every existing `cabinet:<N>` tag to the chapter-scoped form via each tag's first attached `Question.chapter_id`. Skips orphan tags + collision targets; logs `rewrote/skipped_orphan/skipped_collision` counts.
- Test refactor — existing 4 lookups by `cabinet:1001` now use `name__endswith=":q1001"`; new `test_tags_are_chapter_scoped` asserts shape + uniqueness.
- New `test_cabinet_tag_migration.py` — 3 `MigrationExecutor`-based tests (forward, reverse round-trip, orphan-untouched).

## Note on PR #115 conflict

Both this PR and #119 (M7-09 taxonomy) add files under `apps/core/`, but no overlap. This PR's migration is `0013_cabinet_tag_path`; PR #120 (M7-07 stem) also creates a `0013_*` migration locally — whichever lands second will need to be renumbered to `0014_*` (trivial rebase).

## Test plan

- [x] `pytest apps/core/tests/test_cabinet_tag_migration.py` → 3 passing
- [x] `pytest apps/core/tests/test_import_cabinet.py` → 32 passing
- [x] `pytest apps/core/tests/` full core → 177 passing
- [x] Django `check` clean
- [ ] Manual on staging: `manage.py migrate core 0013_cabinet_tag_path` then re-run `import_cabinet_questions` — confirm Question.count() grows by ~33 (the recovered collisions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)