### PR TITLE
infra(ci): Playwright e2e scaffold + /design smoke test

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -199,9 +199,47 @@ jobs:
             - name: Build
               run: npm run build
 
+    frontend-e2e:
+        name: Frontend E2E (Playwright smoke)
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: frontend_modern
+        steps:
+            - name: Check out the repo
+              uses: actions/checkout@v4
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                node-version: '20'
+                cache: 'npm'
+                cache-dependency-path: frontend_modern/package-lock.json
+            - name: Install dependencies
+              run: npm ci
+            - name: Cache Playwright browsers
+              uses: actions/cache@v4
+              with:
+                path: ~/.cache/ms-playwright
+                key: playwright-${{ runner.os }}-${{ hashFiles('frontend_modern/package-lock.json') }}
+            - name: Install Playwright browsers
+              # `chromium` only — config uses a single chromium project. Add
+              # --with-deps so the runner has the required system libs.
+              run: npx playwright install --with-deps chromium
+            - name: Run Playwright smoke tests
+              # playwright.config.ts handles `vite build && vite preview` via
+              # its `webServer` block; no separate "build" step needed.
+              run: npm run test:e2e
+            - name: Upload Playwright HTML report on failure
+              uses: actions/upload-artifact@v4
+              if: failure()
+              with:
+                name: playwright-report
+                path: frontend_modern/playwright-report
+                retention-days: 14
+
     build-publish:
         name: Build & Publish
-        needs: [lint, typecheck, security, test, frontend]
+        needs: [lint, typecheck, security, test, frontend, frontend-e2e]
         # only run this on qa & prod branches
         if: github.ref == 'refs/heads/qa' || github.ref == 'refs/heads/prod'
         runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ frontend_modern/.turbo/
 frontend_modern/coverage/
 frontend_modern/.nyc_output/
 frontend_modern/.cache/
+frontend_modern/test-results/
+frontend_modern/playwright-report/
+frontend_modern/playwright/.cache/
 
 # Backend (Python / Django)
 backend/__pycache__/

--- a/docs/changes/2026-06-01-playwright-smoke.md
+++ b/docs/changes/2026-06-01-playwright-smoke.md
@@ -1,0 +1,37 @@
+# 2026-06-01 — Playwright e2e scaffold + `/design` smoke test
+
+## What changed
+- Added `frontend_modern/playwright.config.ts` (single chromium project, runs
+  against `vite preview` on :4173 — no backend dependency).
+- Added `frontend_modern/e2e/design.spec.ts`: smoke test that visits `/design`,
+  asserts the page returns 2xx, an `h1` renders, the `#FF6F00` brand-token
+  swatch is visible, and the browser console reports zero errors.
+- Added new CI job `frontend-e2e` to `.github/workflows/ci-cd.yaml`; gated
+  `build-publish` on it so a red e2e blocks deploy.
+- Updated `.gitignore` to exclude `test-results/`, `playwright-report/`, and
+  the playwright browser cache under `frontend_modern/`.
+
+## Why
+The V2 "Chalk & Unlock" design overhaul
+(`docs/initiatives/2026-design-system-v2.md`) requires every new primitive to
+land in the `/design` showcase. Until now there was no automated check that
+the showcase still rendered after a refactor — a broken token, a typo in a
+seed component, or a missing import would only surface when a human opened
+the page locally. The smoke test gives CI a single, fast signal that "the
+design system page still mounts and the brand token is on screen."
+
+The `@playwright/test` dep was already in `package.json` and the `test:e2e`
+script was already defined, but neither a config file nor any tests existed —
+this PR fills in the scaffold so future visual-regression / per-page smoke
+tests can be added in the same shape.
+
+## Scope notes
+- Single browser (chromium) — kept narrow on purpose; expand only when a
+  bug is found that needs cross-browser coverage.
+- No backend in the loop. When we add tests that hit Django, run them as a
+  separate Playwright `project` here and gate the matching CI job on a
+  Docker compose stack — do not bolt backend startup into this job.
+- Visual-regression (Playwright `toHaveScreenshot`) is intentionally NOT
+  enabled yet: font rendering on Linux CI differs from the Windows/macOS
+  workstations where baselines would be generated, and managing that drift
+  is its own initiative. Smoke first; pixel diffing later.

--- a/frontend_modern/e2e/design.spec.ts
+++ b/frontend_modern/e2e/design.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect, type ConsoleMessage } from '@playwright/test';
+
+// Smoke test for the living design-system showcase at /design.
+//
+// This is the only currently-public, backend-free route in the app, which
+// makes it the right anchor for our first e2e test. The V2 "Chalk & Unlock"
+// initiative (docs/initiatives/2026-design-system-v2.md) requires every new
+// primitive to be added to this page — so if /design crashes, the whole
+// design system has regressed and we want CI red.
+test.describe('/design — design system showcase', () => {
+  test('renders without console errors', async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (msg: ConsoleMessage) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+    page.on('pageerror', (err) => {
+      consoleErrors.push(err.message);
+    });
+
+    const response = await page.goto('/design');
+    expect(response?.ok(), 'GET /design should return 2xx').toBeTruthy();
+
+    // The showcase always renders an h1 with the system name. If this changes,
+    // update the assertion — but a missing h1 here usually means the page
+    // bailed before mount.
+    await expect(page.locator('h1').first()).toBeVisible();
+
+    // Brand orange anchor should appear somewhere on the page — every
+    // showcase build renders the token swatches.
+    await expect(page.getByText('#FF6F00', { exact: false }).first()).toBeVisible();
+
+    expect(consoleErrors, `console errors on /design:\n${consoleErrors.join('\n')}`).toEqual([]);
+  });
+});

--- a/frontend_modern/playwright.config.ts
+++ b/frontend_modern/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Playwright config for OpenShiksha frontend_modern.
+//
+// Scope (2026-06-01): purely client-side smoke tests against public routes
+// (e.g. /design). Tests must NOT depend on the Django backend — the CI job
+// only boots the Vite preview server, not the full Docker stack.
+//
+// When we add tests that need the backend, run them in a separate project
+// here and gate the matching CI job on a Docker compose stack.
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:4173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    // `vite preview` serves the production build on :4173. Using the built
+    // output (not `vite dev`) keeps the smoke test close to what users see.
+    command: 'npm run build && npm run preview -- --port 4173 --strictPort',
+    url: 'http://localhost:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/frontend_modern/vite.config.ts
+++ b/frontend_modern/vite.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
     globals: true,
     environment: 'happy-dom',
     setupFiles: ['./src/test-setup.ts'],
+    // Vitest runs unit tests only — Playwright owns e2e/ (see playwright.config.ts).
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    exclude: ['node_modules/**', 'dist/**', 'e2e/**'],
     alias: {
       '@': path.resolve(__dirname, './src'),
     },


### PR DESCRIPTION
## Summary
- Adds `frontend_modern/playwright.config.ts` (single chromium project, runs against `vite preview` on :4173 — no backend dependency).
- Adds `frontend_modern/e2e/design.spec.ts`: smoke test for `/design` — asserts 2xx, `h1` visible, brand `#FF6F00` swatch visible, **zero console errors**.
- Adds `frontend-e2e` CI job to `.github/workflows/ci-cd.yaml`; gates `build-publish` on it.
- Ignores `test-results/`, `playwright-report/`, and the playwright browser cache.

## Why
The V2 "Chalk & Unlock" initiative (`docs/initiatives/2026-design-system-v2.md`) requires every new primitive to land in the `/design` showcase, but until now no automation caught a broken page. `@playwright/test` and the `test:e2e` script were already in `package.json` with no config or tests — this PR fills in the scaffold so future per-page smoke tests follow the same shape. See `docs/changes/2026-06-01-playwright-smoke.md` for scope notes on visual-regression (deferred) and backend-bound tests (separate project, separate job when added).

## Test plan
- [ ] CI `frontend-e2e` job passes on this branch
- [ ] `build-publish` still gated correctly (only runs on qa/prod and only after the e2e job)
- [ ] Locally: `cd frontend_modern && npm run test:e2e` passes