### PR TITLE
feat(core): importer --report-unknowns + expression-coverage allowlist (M7-08)

### DIFF
--- a/backend/openshiksha/apps/api/croupier.py
+++ b/backend/openshiksha/apps/api/croupier.py
@@ -32,6 +32,7 @@ import math
 import operator as _op
 import random
 import re
+from fractions import Fraction
 from typing import Any, Callable
 
 # Keys assigned by position after shuffling
@@ -219,10 +220,15 @@ _SAFE_BIN_OPS: dict[type, Callable[[Any, Any], Any]] = {
 }
 _SAFE_UNARY_OPS: dict[type, Callable[[Any], Any]] = {ast.USub: _op.neg, ast.UAdd: _op.pos}
 
-# Named constants Cabinet authors reference directly.
+# Named constants Cabinet authors reference directly. ``pi`` / ``e`` aliases
+# match Python's ``math`` module convention; ``pi_val`` / ``e_val`` are the
+# original Cabinet author names. Both surface forms map to the same value so
+# either spelling evaluates safely.
 _SAFE_CONSTS: dict[str, float] = {
     "pi_val": math.pi,
     "e_val": math.e,
+    "pi": math.pi,
+    "e": math.e,
 }
 
 
@@ -248,6 +254,30 @@ _SAFE_FUNCS: dict[str, Callable[..., Any]] = {
     "int": int,
     "float": float,
     "pow": pow,
+    # M7-08: additional pure math helpers Cabinet authors reference.
+    "gcd": math.gcd,
+    "lcm": math.lcm,
+    "factorial": math.factorial,
+    "degrees": math.degrees,
+    "radians": math.radians,
+    "sin": math.sin,
+    "cos": math.cos,
+    "tan": math.tan,
+    "asin": math.asin,
+    "acos": math.acos,
+    "atan": math.atan,
+    "atan2": math.atan2,
+    "log": math.log,
+    "ln": math.log,  # Cabinet authors write `ln` for natural log.
+    "log10": math.log10,
+    "log2": math.log2,
+    "exp": math.exp,
+    # Pure, deterministic value constructors Cabinet expressions rely on:
+    # `Fraction(p, q)` for exact rationals and `str(...)` inside the legacy
+    # `Decimal(str(x))` idiom (Decimal is aliased to float). Both are
+    # side-effect-free and safe to expose to the AST evaluator.
+    "Fraction": Fraction,
+    "str": str,
 }
 
 

--- a/backend/openshiksha/apps/core/management/commands/import_cabinet_questions.py
+++ b/backend/openshiksha/apps/core/management/commands/import_cabinet_questions.py
@@ -31,13 +31,16 @@ Usage:
 
 from __future__ import annotations
 
+import ast
 import json
 import re
+from collections import Counter
 from pathlib import Path
 
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
+from openshiksha.apps.api.croupier import _SAFE_CONSTS, _SAFE_FUNCS
 from openshiksha.apps.core.models import (
     Chapter,
     Question,
@@ -303,6 +306,63 @@ def _lift_shared_stem(converted_subparts: list[dict]) -> str:
 
 
 # ─────────────────────────────────────────────────────────────
+# Expression coverage scan (M7-08)
+# ─────────────────────────────────────────────────────────────
+
+# Same token pattern as the runtime substituter (croupier._TOKEN_RE) — kept
+# here as a local copy so the scanner doesn't depend on a private name.
+_TOKEN_RE = re.compile(r"\{\{([^{}]+)\}\}")
+
+
+def _iter_expressions(subpart_fields: dict):
+    """Yield every ``{{...}}`` inner expression from a converted subpart.
+
+    Walks ``question_text``, ``solution_text``, ``hint_text``, each option's
+    ``text``, and the ``correct_answer.answer`` string(s). Bare-identifier
+    tokens are included — they're still names the scanner must classify.
+    """
+    for field in ("question_text", "solution_text", "hint_text"):
+        for m in _TOKEN_RE.finditer(subpart_fields.get(field) or ""):
+            yield m.group(1).strip()
+    for opt in subpart_fields.get("options") or []:
+        for m in _TOKEN_RE.finditer(opt.get("text") or ""):
+            yield m.group(1).strip()
+    correct = (subpart_fields.get("correct_answer") or {}).get("answer")
+    if isinstance(correct, str):
+        for m in _TOKEN_RE.finditer(correct):
+            yield m.group(1).strip()
+    elif isinstance(correct, list):
+        # multi_select: each entry is a key string, but defensive in case
+        # an expression token ever leaks in.
+        for entry in correct:
+            if isinstance(entry, str):
+                for m in _TOKEN_RE.finditer(entry):
+                    yield m.group(1).strip()
+
+
+def _collect_unknown_names(expr: str, declared_vars: set[str]) -> list[str]:
+    """Parse ``expr`` and return any ``ast.Name`` ids that are neither a
+    declared variable, an allowlisted constant, nor an allowlisted function.
+
+    A malformed expression yields an empty list — the caller already reports
+    such tokens separately as un-substituted.
+    """
+    try:
+        tree = ast.parse(expr, mode="eval")
+    except SyntaxError:
+        return []
+    unknown: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            name = node.id
+            if name in declared_vars or name in _SAFE_CONSTS or name in _SAFE_FUNCS:
+                continue
+            # Dunder names are never safe — surface them loudly.
+            unknown.append(name)
+    return unknown
+
+
+# ─────────────────────────────────────────────────────────────
 # Command
 # ─────────────────────────────────────────────────────────────
 
@@ -328,6 +388,16 @@ class Command(BaseCommand):
             action="store_true",
             help="Parse and convert everything but write nothing to the DB.",
         )
+        parser.add_argument(
+            "--report-unknowns",
+            action="store_true",
+            help=(
+                "Read-only scan: walk every {{...}} token across all subparts, "
+                "report identifiers not declared as sampled variables and not in "
+                "the croupier allowlist (_SAFE_CONSTS / _SAFE_FUNCS), then exit. "
+                "Writes nothing to the DB."
+            ),
+        )
 
     def handle(self, *args, **options):
         source = Path(options["source"])
@@ -339,6 +409,10 @@ class Command(BaseCommand):
         mapping = self._load_mapping(options.get("mapping"))
         limit = options.get("limit")
         dry_run = options.get("dry_run", False)
+
+        if options.get("report_unknowns"):
+            self._report_unknowns(containers_dir, raw_dir, limit)
+            return
 
         stats = {"imported": 0, "updated": 0, "skipped": 0, "subjects": 0, "chapters": 0, "images": 0}
         container_files = sorted(containers_dir.rglob("*.json"))
@@ -475,6 +549,50 @@ class Command(BaseCommand):
             QuestionSubpart.objects.create(question=question, **fields)
 
         return status
+
+    def _report_unknowns(self, containers_dir: Path, raw_root: Path, limit: int | None) -> None:
+        """M7-08: scan every cabinet token expression, surface un-allowlisted names.
+
+        Read-only, no DB writes. Skips containers that fail to parse — the
+        regular import already reports those as conversion errors.
+        """
+        counts: Counter[str] = Counter()
+        examples: dict[str, str] = {}
+        scanned = 0
+        skipped = 0
+
+        container_files = sorted(containers_dir.rglob("*.json"))
+        for container_path in container_files:
+            if limit is not None and scanned >= limit:
+                break
+            try:
+                ids = self._parse_path_ids(container_path, raw_root)
+                with open(container_path, encoding="utf-8") as fh:
+                    container = json.load(fh)
+                for index, sp_id in enumerate(container.get("subparts") or []):
+                    sp_path = ids["raw_dir"] / f"{sp_id}.json"
+                    with open(sp_path, encoding="utf-8") as fh:
+                        fields = convert_subpart(json.load(fh), index)
+                    declared = set((fields.get("variable_constraints") or {}).keys())
+                    for expr in _iter_expressions(fields):
+                        for name in _collect_unknown_names(expr, declared):
+                            counts[name] += 1
+                            examples.setdefault(name, expr)
+                scanned += 1
+            except Exception as exc:  # noqa: BLE001 — same tolerance as the import path
+                skipped += 1
+                self.stderr.write(self.style.WARNING(f"skip {container_path.name}: {exc}"))
+
+        self.stdout.write(f"scanned containers: {scanned}  skipped: {skipped}")
+        if not counts:
+            self.stdout.write(self.style.SUCCESS("no unknown identifiers — every token resolves."))
+            return
+
+        self.stdout.write(self.style.WARNING(f"unknown identifiers ({len(counts)} distinct):"))
+        # Sort by frequency desc, then name asc so the worst offenders surface first.
+        for name, count in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])):
+            self.stdout.write(f"  {name:<24} {count:>6}   e.g. {{{{ {examples[name]} }}}}")
+        self.stdout.write(f"total occurrences: {sum(counts.values())}")
 
     def _report(self, stats: dict, dry_run: bool) -> None:
         prefix = "[DRY RUN] " if dry_run else ""

--- a/backend/openshiksha/apps/core/tests/test_cabinet_expr.py
+++ b/backend/openshiksha/apps/core/tests/test_cabinet_expr.py
@@ -1,0 +1,122 @@
+"""M7-08: tests for the importer's expression-coverage scan and the extended
+croupier allowlist that drives the unknown-name count toward a stable set.
+
+The scanner is read-only: it walks every ``{{...}}`` token across all subparts
+and reports identifiers that are neither declared sampled variables, allowlisted
+constants (``_SAFE_CONSTS``), nor allowlisted functions (``_SAFE_FUNCS``).
+"""
+
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from django.core.management import call_command
+
+from openshiksha.apps.api.croupier import _SAFE_CONSTS, _SAFE_FUNCS, safe_eval_expr
+from openshiksha.apps.core.management.commands.import_cabinet_questions import _collect_unknown_names, _iter_expressions
+from openshiksha.apps.core.models import Question
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "cabinet_sample"
+SOURCE = str(FIXTURE_DIR)
+
+
+# ── Unknown-name collection ───────────────────────────────────────────────────
+
+
+class TestCollectUnknownNames:
+    def test_declared_variable_is_known(self):
+        assert _collect_unknown_names("a + b", declared_vars={"a", "b"}) == []
+
+    def test_allowlisted_constant_is_known(self):
+        # pi_val / e_val are in _SAFE_CONSTS.
+        assert _collect_unknown_names("pi_val * r * r", declared_vars={"r"}) == []
+
+    def test_allowlisted_function_is_known(self):
+        assert _collect_unknown_names("trunc(a * b, 2)", declared_vars={"a", "b"}) == []
+
+    def test_undeclared_name_is_unknown(self):
+        assert _collect_unknown_names("a + zzz", declared_vars={"a"}) == ["zzz"]
+
+    def test_function_name_not_in_allowlist_is_unknown(self):
+        # ``bogus`` is neither a declared var nor an allowlisted callable.
+        assert _collect_unknown_names("bogus(a)", declared_vars={"a"}) == ["bogus"]
+
+    def test_malformed_expression_yields_nothing(self):
+        assert _collect_unknown_names("a + + ", declared_vars={"a"}) == []
+
+    def test_newly_allowlisted_helpers_are_known(self):
+        # The M7-08 additions: gcd / lcm / factorial / trig / log should all
+        # be recognised so they never appear in the unknowns report.
+        for expr in ("gcd(a, b)", "lcm(a, b)", "factorial(a)", "sin(radians(a))", "log10(a)"):
+            assert _collect_unknown_names(expr, declared_vars={"a", "b"}) == [], expr
+
+
+class TestIterExpressions:
+    def test_collects_tokens_from_all_fields(self):
+        fields = {
+            "question_text": "value is {{a}}",
+            "solution_text": "because {{b + 1}}",
+            "hint_text": "recall {{c}}",
+            "options": [{"key": "A", "text": "{{d}}"}],
+            "correct_answer": {"type": "numeric", "answer": "{{a + d}}"},
+        }
+        exprs = list(_iter_expressions(fields))
+        assert "a" in exprs
+        assert "b + 1" in exprs
+        assert "c" in exprs
+        assert "d" in exprs
+        assert "a + d" in exprs
+
+    def test_no_tokens_returns_empty(self):
+        fields = {"question_text": "plain text, no tokens", "correct_answer": {"answer": "5"}}
+        assert list(_iter_expressions(fields)) == []
+
+
+# ── Extended allowlist (croupier) ─────────────────────────────────────────────
+
+
+class TestExtendedAllowlist:
+    def test_new_constants_present(self):
+        assert "pi" in _SAFE_CONSTS and "e" in _SAFE_CONSTS
+
+    def test_new_functions_present(self):
+        for name in ("gcd", "lcm", "factorial", "degrees", "radians", "log", "exp", "sin", "cos"):
+            assert name in _SAFE_FUNCS, name
+
+    def test_gcd_evaluates(self):
+        assert safe_eval_expr("gcd(a, b)", {"a": 12, "b": 8}) == 4.0
+
+    def test_factorial_evaluates(self):
+        assert safe_eval_expr("factorial(a)", {"a": 5}) == 120.0
+
+    def test_pi_constant_evaluates(self):
+        assert abs(safe_eval_expr("pi", {}) - 3.14159) < 0.001
+
+
+# ── Command --report-unknowns (read-only) ─────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestReportUnknownsCommand:
+    def test_writes_nothing_to_db(self):
+        out = StringIO()
+        call_command(
+            "import_cabinet_questions",
+            source=SOURCE,
+            report_unknowns=True,
+            stdout=out,
+            stderr=StringIO(),
+        )
+        assert Question.objects.count() == 0
+
+    def test_reports_scan_summary(self):
+        out = StringIO()
+        call_command(
+            "import_cabinet_questions",
+            source=SOURCE,
+            report_unknowns=True,
+            stdout=out,
+            stderr=StringIO(),
+        )
+        assert "scanned containers" in out.getvalue()

--- a/docs/changes/2026-06-01-m7-08-expression-coverage.md
+++ b/docs/changes/2026-06-01-m7-08-expression-coverage.md
@@ -1,0 +1,82 @@
+# M7-08 — Importer `--report-unknowns` + expression-coverage triage
+
+## Summary
+
+Adds a **read-only** `--report-unknowns` flag to `import_cabinet_questions` that
+walks every `{{...}}` token across all cabinet subparts and reports identifiers
+that are neither declared sampled variables, allowlisted constants
+(`_SAFE_CONSTS`), nor allowlisted functions (`_SAFE_FUNCS`). The flag writes
+nothing to the DB. Triaging its output extended the croupier allowlist with a set
+of safe, pure math helpers so the "unknown function" count collapses to a stable
+residual that is purely a *data* issue (undeclared variables), not a missing
+capability.
+
+## Classification
+
+**Improve** — makes the `safe_eval_expr` allowlist's coverage *observable*
+instead of failing silently, and closes the gap for legitimate math helpers.
+
+## Legacy files referenced
+
+- `croupier/constraints.py` — original (unrestricted) Python `eval` of author
+  expressions; modern `safe_eval_expr` replaced it with an AST allowlist.
+- `cabinet/cabinet_api.py` — original token/expression render path.
+
+## What changed
+
+### `backend/openshiksha/apps/api/croupier.py`
+- `_SAFE_CONSTS`: added `pi` / `e` aliases (alongside the existing Cabinet-author
+  spellings `pi_val` / `e_val`).
+- `_SAFE_FUNCS`: added pure, deterministic math helpers — `gcd`, `lcm`,
+  `factorial`, `degrees`, `radians`, trig (`sin`/`cos`/`tan`/`asin`/`acos`/
+  `atan`/`atan2`), logs (`log`, `ln`, `log10`, `log2`), `exp`, plus the value
+  constructors `Fraction` (exact rationals) and `str` (used inside the legacy
+  `Decimal(str(x))` idiom; `Decimal` is aliased to `float`).
+- All additions are side-effect-free; no I/O, no mutation, no attribute access.
+  The AST evaluator's existing guards (rejecting attribute access, non-allowlisted
+  calls, comprehensions, dunder names) are reused unchanged.
+
+### `backend/openshiksha/apps/core/management/commands/import_cabinet_questions.py`
+- New `--report-unknowns` flag (read-only; early-returns after the scan).
+- `_iter_expressions()` — yields every `{{...}}` inner expression from a converted
+  subpart (`question_text`, `solution_text`, `hint_text`, option texts,
+  `correct_answer.answer`).
+- `_collect_unknown_names()` — parses each expression and returns `ast.Name` ids
+  not covered by declared vars / `_SAFE_CONSTS` / `_SAFE_FUNCS`. Malformed
+  expressions yield nothing (already reported elsewhere as conversion errors).
+- `_report_unknowns()` — scans all containers, prints a frequency-sorted
+  `name → count` table with an example token, plus scanned/skipped totals.
+
+## Scan output against the real bank (646 containers)
+
+Before allowlist extension: **17 distinct** unknown names (1841 occurrences).
+After: **14 distinct** (1417 occurrences) — the resolved names were `str`,
+`Fraction`, `ln`.
+
+The 14 residual names are **all undeclared variables** referenced in expressions
+but absent from those subparts' `variable_constraints` (`j`, `k`, `l`, `m`, `n`,
+`o`, `o1`, `o2`, `l2`, `m1`, `i`, `a`, `b`, and `temp`). These leave their tokens
+un-substituted at render time — a **content/data** defect, not an allowlist gap.
+This is the stable residual the audit (PR 5) should track; it is out of scope for
+this allowlist PR.
+
+## Tests
+
+`backend/openshiksha/apps/core/tests/test_cabinet_expr.py` (new, 16 tests):
+- `_collect_unknown_names` classification (declared var / const / func / unknown /
+  malformed / newly-allowlisted helpers).
+- `_iter_expressions` collects tokens from every field.
+- Extended allowlist present + evaluates (`gcd`, `factorial`, `pi`).
+- `--report-unknowns` command writes nothing to the DB and prints a scan summary.
+
+All 47 cabinet-expr + croupier tests pass; full suite 718 passed, 92.94% coverage.
+
+## Migration notes
+
+None — no schema change.
+
+## Next steps
+
+- PR 2: M7-06 inline-image extraction.
+- The 14 undeclared-variable findings feed the PR 5 `audit_cabinet_fidelity`
+  guard (un-substituted token detection).


### PR DESCRIPTION
## Classification: Improve

Closes **M7-08** of the Cabinet Data Fidelity initiative — makes the `safe_eval_expr` allowlist's coverage *observable* instead of failing silently.

## What

A read-only `--report-unknowns` flag on `import_cabinet_questions` that walks every `{{...}}` token across all cabinet subparts (`question_text`, `solution_text`, `hint_text`, option texts, `correct_answer.answer`) and reports identifiers that are neither declared sampled variables, allowlisted constants (`_SAFE_CONSTS`), nor allowlisted functions (`_SAFE_FUNCS`). Writes nothing to the DB.

Triaging its output against the real bank extended the croupier allowlist with safe, pure, deterministic math helpers:
- Constants: `pi`/`e` aliases (alongside Cabinet's `pi_val`/`e_val`).
- Functions: `gcd`, `lcm`, `factorial`, `degrees`, `radians`, trig, `log`/`ln`/`log10`/`log2`, `exp`, plus value constructors `Fraction` and `str` (for the legacy `Decimal(str(x))` idiom).

## Scan result (646 real containers)

- Before: **17 distinct** unknown names (1841 occ).
- After: **14 distinct** (1417 occ) — resolved `str`, `Fraction`, `ln`.

The 14 residual names are **all undeclared variables** (`j`/`k`/`l`/`m`/`n`/`o`/`temp`/…) referenced in expressions but absent from `variable_constraints` — a content/data defect, not an allowlist gap. This stable residual is what the PR 5 `audit_cabinet_fidelity` guard will track.

## Legacy reference

`croupier/constraints.py` (original unrestricted `eval`), `cabinet/cabinet_api.py`.

## Tests

`backend/openshiksha/apps/core/tests/test_cabinet_expr.py` (16 tests): unknown-name classification, expression iteration, extended-allowlist presence + evaluation, and the read-only `--report-unknowns` command path. Full suite: **718 passed, 92.94% coverage**.

## How to verify

```
python manage.py import_cabinet_questions --source <cabinet>/questions --report-unknowns
```
Prints a frequency-sorted `name → count` table; writes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)