### PR TITLE
feat(core): inline-image extraction + renderer img http(s) allowlist (M7-06)

### DIFF
--- a/backend/openshiksha/apps/core/management/commands/import_cabinet_questions.py
+++ b/backend/openshiksha/apps/core/management/commands/import_cabinet_questions.py
@@ -70,6 +70,61 @@ _IMAGE_EXTS = (".png", ".jpg", ".jpeg", ".gif", ".svg")
 _CABINET_RAW_BASE = "https://raw.githubusercontent.com/openshiksha/openshiksha-cabinet/HEAD/questions/raw"
 
 
+# Cabinet's inline-image mechanisms inside HTML question/solution/hint bodies:
+#   - `#{8.gif}#` token (the actual format used by authors), and
+#   - a relative `<img src="x.png">` (defensive — none exist in the current bank
+#     but the rewrite is correct if any are added later).
+# Both resolve to an absolute raw.githubusercontent.com URL so the content is
+# self-hosted with no Cabinet microservice. Absolute http(s) srcs are untouched.
+_INLINE_IMG_TOKEN = re.compile(r"#\{([^{}#]+)\}#")
+_REL_IMG_SRC = re.compile(r'(<img\b[^>]*?\bsrc=")(?!https?://)([^"]+)(")', re.IGNORECASE)
+
+
+def _resolve_inline_filename(raw_dir, filename: str) -> "str | None":
+    """Return the chapter-relative subpath for an inline image filename, or None.
+
+    Mirrors ``_find_subpart_image``: checks a sibling of the JSON first, then the
+    ``img/`` subdirectory (Cabinet's two storage conventions).
+    """
+    if (raw_dir / filename).is_file():
+        return filename
+    if (raw_dir / "img" / filename).is_file():
+        return f"img/{filename}"
+    return None
+
+
+def rewrite_inline_images(text: str, raw_dir, chapter_base: str) -> str:
+    """Rewrite Cabinet inline image references to absolute raw-GitHub ``<img>`` tags.
+
+    - ``#{name.ext}#`` token  → ``<img src="<abs>" alt="name.ext">``
+    - relative ``<img src="x">`` → absolute ``<img src="<abs>">``
+
+    ``chapter_base`` is the raw URL prefix up to the chapter directory. A
+    reference that can't be resolved on disk is left untouched (so the importer
+    never invents a broken URL; the fidelity audit can flag the residual).
+    """
+    if not text:
+        return text or ""
+
+    def _token(m: "re.Match[str]") -> str:
+        fn = m.group(1).strip()
+        rel = _resolve_inline_filename(raw_dir, fn)
+        if rel is None:
+            return m.group(0)
+        return f'<img src="{chapter_base}/{rel}" alt="{fn}">'
+
+    def _relsrc(m: "re.Match[str]") -> str:
+        fn = m.group(2).strip()
+        rel = _resolve_inline_filename(raw_dir, fn)
+        if rel is None:
+            return m.group(0)
+        return f"{m.group(1)}{chapter_base}/{rel}{m.group(3)}"
+
+    text = _INLINE_IMG_TOKEN.sub(_token, text)
+    text = _REL_IMG_SRC.sub(_relsrc, text)
+    return text
+
+
 def _find_subpart_image(raw_dir, sp_id) -> "tuple[str, str] | None":
     """
     Locate the image (if any) belonging to a cabinet subpart.
@@ -419,11 +474,25 @@ class Command(BaseCommand):
         if not subpart_ids:
             raise ValueError("container has no subparts")
 
+        # Raw URL prefix up to this chapter's directory (M7-06 inline images).
+        chapter_base = (
+            f"{_CABINET_RAW_BASE}/{ids['board']}/{ids['school']}/{ids['standard']}/"
+            f"{ids['subject_id']}/{ids['chapter_id']}"
+        )
+
         converted = []
         for index, sp_id in enumerate(subpart_ids):
             sp_path = ids["raw_dir"] / f"{sp_id}.json"
             with open(sp_path, encoding="utf-8") as fh:
                 fields = convert_subpart(json.load(fh), index)
+
+            # M7-06: rewrite inline image references (`#{name}#` tokens / relative
+            # `<img src>`) embedded in the HTML body to absolute raw-GitHub URLs.
+            for field in ("question_text", "solution_text", "hint_text"):
+                rewritten = rewrite_inline_images(fields.get(field, ""), ids["raw_dir"], chapter_base)
+                if rewritten != fields.get(field, ""):
+                    stats["inline_images"] = stats.get("inline_images", 0) + 1
+                fields[field] = rewritten
 
             # Image discovery — attach a raw.githubusercontent.com URL if a
             # matching image file lives in the chapter's raw directory (either
@@ -431,10 +500,7 @@ class Command(BaseCommand):
             found = _find_subpart_image(ids["raw_dir"], sp_id)
             if found:
                 rel_path, _ext = found
-                fields["image_url"] = (
-                    f"{_CABINET_RAW_BASE}/{ids['board']}/{ids['school']}/{ids['standard']}/"
-                    f"{ids['subject_id']}/{ids['chapter_id']}/{rel_path}"
-                )
+                fields["image_url"] = f"{chapter_base}/{rel_path}"
                 stats["images"] = stats.get("images", 0) + 1
 
             converted.append(fields)
@@ -483,6 +549,7 @@ class Command(BaseCommand):
                 f"{prefix}imported={stats['imported']} updated={stats['updated']} "
                 f"skipped={stats['skipped']} "
                 f"new_subjects={stats['subjects']} new_chapters={stats['chapters']} "
-                f"images={stats.get('images', 0)} stems={stats.get('stems', 0)}"
+                f"images={stats.get('images', 0)} stems={stats.get('stems', 0)} "
+                f"inline_images={stats.get('inline_images', 0)}"
             )
         )

--- a/backend/openshiksha/apps/core/tests/fixtures/cabinet_sample/containers/CBSE/openshiksha/8/13/47/1006.json
+++ b/backend/openshiksha/apps/core/tests/fixtures/cabinet_sample/containers/CBSE/openshiksha/8/13/47/1006.json
@@ -1,0 +1,1 @@
+{"subparts": [2006], "hint": null}

--- a/backend/openshiksha/apps/core/tests/fixtures/cabinet_sample/raw/CBSE/openshiksha/8/13/47/2006.json
+++ b/backend/openshiksha/apps/core/tests/fixtures/cabinet_sample/raw/CBSE/openshiksha/8/13/47/2006.json
@@ -1,0 +1,9 @@
+{
+  "subpart_index": 0,
+  "type": 4,
+  "content": {"text": "Identify the organ shown: #{organ.png}#"},
+  "answer": "heart",
+  "variable_constraints": {},
+  "solution": {"text": "See the diagram."},
+  "hint": {"text": "It pumps blood."}
+}

--- a/backend/openshiksha/apps/core/tests/fixtures/cabinet_sample/raw/CBSE/openshiksha/8/13/47/img/organ.png
+++ b/backend/openshiksha/apps/core/tests/fixtures/cabinet_sample/raw/CBSE/openshiksha/8/13/47/img/organ.png
@@ -1,0 +1,1 @@
+PNGDATA

--- a/backend/openshiksha/apps/core/tests/test_import_cabinet.py
+++ b/backend/openshiksha/apps/core/tests/test_import_cabinet.py
@@ -15,6 +15,7 @@ from openshiksha.apps.core.management.commands.import_cabinet_questions import (
     convert_pow,
     convert_subpart,
     convert_tokens,
+    rewrite_inline_images,
 )
 from openshiksha.apps.core.models import Chapter, Question, QuestionSubpart, Subject
 
@@ -125,6 +126,47 @@ class TestSubpartConversion:
         assert out["correct_answer"] == {"type": "fill_blank", "answer": "mitochondria"}
 
 
+class TestInlineImageRewrite:
+    """M7-06: `rewrite_inline_images` resolves Cabinet inline references against
+    the chapter raw dir and rewrites them to absolute raw-GitHub `<img>` tags."""
+
+    BASE = "https://cdn.example/raw/CBSE/openshiksha/8/13/47"
+
+    def _raw_dir(self, tmp_path, *, sibling=None, nested=None):
+        if sibling:
+            (tmp_path / sibling).write_text("x")
+        if nested:
+            (tmp_path / "img").mkdir(exist_ok=True)
+            (tmp_path / "img" / nested).write_text("x")
+        return tmp_path
+
+    def test_token_resolves_to_img_subdir(self, tmp_path):
+        raw = self._raw_dir(tmp_path, nested="d.png")
+        out = rewrite_inline_images("see #{d.png}# here", raw, self.BASE)
+        assert out == f'see <img src="{self.BASE}/img/d.png" alt="d.png"> here'
+
+    def test_token_resolves_to_sibling(self, tmp_path):
+        raw = self._raw_dir(tmp_path, sibling="d.png")
+        out = rewrite_inline_images("#{d.png}#", raw, self.BASE)
+        assert out == f'<img src="{self.BASE}/d.png" alt="d.png">'
+
+    def test_unresolvable_token_left_untouched(self, tmp_path):
+        out = rewrite_inline_images("#{missing.png}#", tmp_path, self.BASE)
+        assert out == "#{missing.png}#"
+
+    def test_relative_img_src_rewritten(self, tmp_path):
+        raw = self._raw_dir(tmp_path, nested="d.png")
+        out = rewrite_inline_images('<img src="d.png">', raw, self.BASE)
+        assert out == f'<img src="{self.BASE}/img/d.png">'
+
+    def test_absolute_img_src_untouched(self, tmp_path):
+        out = rewrite_inline_images('<img src="https://x/y.png">', tmp_path, self.BASE)
+        assert out == '<img src="https://x/y.png">'
+
+    def test_empty_text(self, tmp_path):
+        assert rewrite_inline_images("", tmp_path, self.BASE) == ""
+
+
 # ── Management command (DB) ──────────────────────────────────────────────────
 
 
@@ -149,8 +191,8 @@ class TestImportCommand:
     def test_malformed_question_skipped(self):
         out, err = StringIO(), StringIO()
         call_command("import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=out, stderr=err)
-        # 4 valid questions import; the type-99 one is skipped.
-        assert Question.objects.count() == 4
+        # 5 valid questions import; the type-99 one is skipped.
+        assert Question.objects.count() == 5
         assert "skip" in err.getvalue()
 
     def test_idempotent_reimport(self):
@@ -158,7 +200,7 @@ class TestImportCommand:
             call_command(
                 "import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=StringIO(), stderr=StringIO()
             )
-        assert Question.objects.count() == 4
+        assert Question.objects.count() == 5
 
     def test_solution_and_hint_imported(self):
         call_command("import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=StringIO(), stderr=StringIO())
@@ -192,6 +234,15 @@ class TestImportCommand:
         call_command("import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=StringIO(), stderr=StringIO())
         sp = QuestionSubpart.objects.get(question__tags__name__endswith=":q1003")
         assert sp.image_url == ""
+
+    def test_inline_image_token_rewritten_to_absolute_img(self):
+        """M7-06: a `#{name}#` inline-image token in the HTML body becomes an
+        absolute raw.githubusercontent.com `<img>` tag."""
+        call_command("import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=StringIO(), stderr=StringIO())
+        sp = QuestionSubpart.objects.get(question__tags__name__endswith=":q1006")
+        assert "#{organ.png}#" not in sp.question_text
+        assert '<img src="https://raw.githubusercontent.com/openshiksha/openshiksha-cabinet/HEAD/' in sp.question_text
+        assert sp.question_text.rstrip().endswith('alt="organ.png">')
 
     def test_tags_are_chapter_scoped(self):
         """M7-05: tag must include the chapter PK so question_ids reused across

--- a/docs/changes/2026-06-01-m7-06-inline-images.md
+++ b/docs/changes/2026-06-01-m7-06-inline-images.md
@@ -1,0 +1,79 @@
+# M7-06 — Inline-image extraction in importer + renderer `<img>` allowlist
+
+## Summary
+
+Recovers inline images embedded in Cabinet HTML question/solution/hint bodies and
+hardens the renderer so only http(s) image sources survive.
+
+**Key data finding:** the entire Cabinet bank contains **zero** `<img src>` tags.
+Cabinet's actual inline-image mechanism is the `#{filename}#` token, and it is
+currently dropped — it leaks to the rendered output as the literal text
+`#{8.gif}#`. The original plan's `<img src>` premise didn't match the data; this
+PR ports the *real* format (the `#{}#` token) while still handling relative
+`<img src>` defensively for any future content.
+
+## Classification
+
+**Improve** — restores inline-image fidelity (the legacy Cabinet microservice
+resolved `#{}#` tokens; the modern importer had been silently dropping them) and
+self-hosts the content with no microservice.
+
+## Legacy files referenced
+
+- `cabinet/cabinet_api.py` — `build_image()` / the original `#{}#` token
+  resolution against the Cabinet filesystem.
+
+## What changed
+
+### Importer — `backend/openshiksha/apps/core/management/commands/import_cabinet_questions.py`
+- `rewrite_inline_images(text, raw_dir, chapter_base)` — rewrites:
+  - `#{name.ext}#` token → `<img src="<abs>" alt="name.ext">`
+  - relative `<img src="x">` → absolute `<img src="<abs>">`
+  - absolute http(s) `src` → untouched
+  - unresolvable reference → left as-is (never invents a broken URL; the fidelity
+    audit can flag the residual).
+- `_resolve_inline_filename()` resolves a filename against the chapter raw dir
+  (sibling first, then `img/` subdir), mirroring `_find_subpart_image`.
+- Wired into `_import_container` over `question_text`/`solution_text`/`hint_text`;
+  reused the new `chapter_base` to de-duplicate the sibling-image URL build.
+- New `inline_images` stat in the report line.
+
+### Renderer — `frontend_modern/src/shared/ui/renderRichContent.ts`
+- Added a `afterSanitizeAttributes` DOMPurify hook (registered once) that drops
+  any `<img src>` not matching `^https?://`. Blocks `data:` SVG XSS payloads and
+  guarantees no relative leftover resolves wrongly. `img`/`src` were already in
+  the allowlist.
+
+## Materialising on existing data
+
+The importer change only affects rows processed after it lands. The importer is
+idempotent (re-runs update existing Questions via the `cabinet:c<chap>:q<id>`
+tag), so the closing re-import step of the daily plan is what fixes live data.
+No one-off data migration — re-import is the single source of truth.
+
+## Tests
+
+### Backend — `test_import_cabinet.py`
+- `TestInlineImageRewrite` (6 pure tests): `#{}#` → img/ subdir, → sibling,
+  unresolvable left untouched, relative `<img src>` rewritten, absolute untouched,
+  empty text.
+- `test_inline_image_token_rewritten_to_absolute_img` (DB): new fixture question
+  1006 (`#{organ.png}#` + `img/organ.png`) imports with an absolute `<img>` tag
+  and no leftover token.
+- Updated `test_malformed_question_skipped` / `test_idempotent_reimport` for the
+  5th valid fixture question.
+
+### Frontend — `RichContent.test.tsx`
+- https/http src kept; relative src dropped; `data:` SVG src dropped.
+
+Full backend suite: **709 passed, 92.96%**. Frontend: type-check, lint, 21
+RichContent tests, and build all green.
+
+## Migration notes
+
+None — no schema change.
+
+## Next steps
+
+- PR 3: M7-03a per-subpart `subpart_type` (backend).
+- Closing re-import will materialise inline images on the live corpus.

--- a/frontend_modern/src/shared/ui/RichContent.test.tsx
+++ b/frontend_modern/src/shared/ui/RichContent.test.tsx
@@ -42,6 +42,29 @@ describe('renderRichContent', () => {
     expect(html).not.toContain('javascript:');
   });
 
+  // M7-06: only http(s) image srcs survive; everything else has its src dropped.
+  it('keeps https image src untouched', () => {
+    const html = renderRichContent('<img src="https://cdn.example/x.png" alt="x" />');
+    expect(html).toContain('src="https://cdn.example/x.png"');
+  });
+
+  it('keeps http image src untouched', () => {
+    const html = renderRichContent('<img src="http://cdn.example/x.png" alt="x" />');
+    expect(html).toContain('src="http://cdn.example/x.png"');
+  });
+
+  it('drops a relative image src (would resolve wrong / never set by importer)', () => {
+    const html = renderRichContent('<img src="diagram.png" alt="x" />');
+    expect(html).not.toContain('src="diagram.png"');
+  });
+
+  it('drops a data: image src (SVG XSS vector)', () => {
+    const html = renderRichContent(
+      '<img src="data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=" alt="x" />'
+    );
+    expect(html).not.toContain('data:image');
+  });
+
   it('keeps allowlisted tags (strong, em, sup, sub, img, ul/li, table)', () => {
     const html = renderRichContent(
       '<p><strong>A</strong> <em>b</em> H<sub>2</sub>O x<sup>2</sup></p>' +

--- a/frontend_modern/src/shared/ui/renderRichContent.ts
+++ b/frontend_modern/src/shared/ui/renderRichContent.ts
@@ -22,6 +22,24 @@ const ALLOWED_TAGS = [
 
 const ALLOWED_ATTR = ['href', 'src', 'alt', 'width', 'height', 'title', 'class', 'colspan', 'rowspan'];
 
+// M7-06: only http(s) image sources survive. Cabinet inline `<img>` paths are
+// rewritten to absolute raw.githubusercontent.com URLs at import time, so any
+// non-http(s) `src` (relative leftovers, `data:` SVG payloads, `javascript:`)
+// is an XSS vector or a guaranteed broken image — drop the attribute entirely.
+// Registered once at module load; DOMPurify hooks are process-global.
+const HTTP_SRC = /^https?:\/\//i;
+let imgSrcHookRegistered = false;
+function ensureImgSrcHook(): void {
+  if (imgSrcHookRegistered) return;
+  DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+    if (node.nodeName === 'IMG' && node.hasAttribute('src')) {
+      const src = node.getAttribute('src') ?? '';
+      if (!HTTP_SRC.test(src)) node.removeAttribute('src');
+    }
+  });
+  imgSrcHookRegistered = true;
+}
+
 // `exprGroup: 0` means feed the entire match to KaTeX (used for un-delimited
 // `\begin{X}…\end{X}` environments where the begin/end tokens are part of the
 // LaTeX source). `exprGroup: 1` strips the surrounding delimiter.
@@ -120,6 +138,7 @@ function injectMath(fragment: DocumentFragment): string {
 export function renderRichContent(text: string): string {
   if (!text) return '';
 
+  ensureImgSrcHook();
   const cleanHtml = DOMPurify.sanitize(text, {
     ALLOWED_TAGS,
     ALLOWED_ATTR,


### PR DESCRIPTION
## Classification: Improve

Closes **M7-06** of Cabinet Data Fidelity — recovers inline images embedded in Cabinet HTML bodies and hardens the renderer's `<img>` handling.

## Key data finding

The entire Cabinet bank contains **zero** `<img src>` tags. Cabinet's real inline-image mechanism is the `#{filename}#` token, which was being **dropped** — it leaked to rendered output as the literal text `#{8.gif}#`. The original plan's `<img src>` premise didn't match the data; this PR ports the *actual* format while still handling relative `<img src>` defensively.

## What

**Importer** (`import_cabinet_questions.py`):
- `rewrite_inline_images()` rewrites `#{name}#` tokens → `<img src="<abs>" alt="name">` and relative `<img src>` → absolute raw-GitHub URLs, resolving filenames against the chapter raw dir (sibling, then `img/` subdir). Absolute http(s) srcs untouched; unresolvable refs left as-is (never invents a broken URL).
- Applied to `question_text`/`solution_text`/`hint_text`; new `inline_images` stat.

**Renderer** (`renderRichContent.ts`):
- A registered-once DOMPurify `afterSanitizeAttributes` hook drops any `<img src>` not matching `^https?://` — blocks `data:` SVG XSS payloads and relative leftovers.

## Materialising on live data

Importer-only change; idempotent re-import (per the daily-plan closing gate) materialises images on the real corpus. No one-off migration.

## Legacy reference

`cabinet/cabinet_api.py` `build_image()` / `#{}#` token resolution.

## Tests

- Backend: `TestInlineImageRewrite` (6 pure) + DB test on new fixture Q1006 (`#{organ.png}#` + `img/organ.png`); updated two count assertions for the 5th valid fixture question. **709 passed, 92.96%**.
- Frontend: https/http src kept, relative + `data:` dropped. type-check, lint, build, 21 RichContent tests green.

## How to verify

```
python manage.py import_cabinet_questions --source <cabinet>/questions
# report line now includes inline_images=N
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)