### PR TITLE
feat(student): per-subpart input widget on subpart_type (M7-03b)

### DIFF
--- a/backend/openshiksha/apps/core/management/commands/audit_cabinet_fidelity.py
+++ b/backend/openshiksha/apps/core/management/commands/audit_cabinet_fidelity.py
@@ -1,0 +1,112 @@
+"""Management command: audit_cabinet_fidelity
+
+Standing regression guard for the Cabinet Data Fidelity initiative's
+Definition of Done. Reports, over the imported cabinet question corpus
+(``tags__name__startswith="cabinet:"``), the cross-cutting invariants the
+initiative promised — and with ``--strict`` exits non-zero if any regress, so
+a future re-import can't silently undo the fidelity work.
+
+Metrics (all should be 0 once the bank is re-imported with M7-03/06/09):
+  - wrong_widget       — subparts with a blank/invalid ``subpart_type`` (M7-03).
+  - legacy_tokens      — fields still holding un-converted ``_{x}_`` legacy
+                         tokens or literal ``#{img}#`` inline-image tokens
+                         (M7-06 + token conversion).
+  - taxonomy_placeholders — cabinet questions still pointing at
+                         "Imported Subject %"/"Imported Chapter %" placeholders
+                         (M7-09 taxonomy inference / mapping).
+  - tag_cardinality    — cabinet tags attached to != 1 Question (M7-05 identity).
+
+Usage:
+    python manage.py audit_cabinet_fidelity
+    python manage.py audit_cabinet_fidelity --strict   # CI: non-zero on any defect
+"""
+
+from __future__ import annotations
+
+import re
+
+from django.core.management.base import BaseCommand
+from django.db.models import Count
+
+from openshiksha.apps.core.models import Question, QuestionSubpart, QuestionTag, QuestionType
+
+_CABINET_TAG_PREFIX = "cabinet:"
+_VALID_SUBPART_TYPES = {t.value for t in QuestionType if t != QuestionType.COMPOUND}
+
+# Un-converted legacy substitution token (``_{x}_``) or a literal inline-image
+# token (``#{8.gif}#``) that should have been rewritten by the importer.
+_LEAK_RE = re.compile(r"_\{[a-zA-Z_]\w*\}_|#\{[^{}#]+\}#")
+
+
+def _subpart_text_fields(sp: QuestionSubpart):
+    yield sp.question_text or ""
+    yield sp.solution_text or ""
+    yield sp.hint_text or ""
+    for opt in sp.options or []:
+        if isinstance(opt, dict):
+            yield opt.get("text", "") or ""
+
+
+class Command(BaseCommand):
+    help = "Audit the imported Cabinet corpus against the fidelity Definition of Done."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--strict",
+            action="store_true",
+            help="Exit non-zero if any metric is out of bounds (for CI).",
+        )
+
+    def handle(self, *args, **options):
+        cabinet_questions = Question.objects.filter(tags__name__startswith=_CABINET_TAG_PREFIX).distinct()
+        total_questions = cabinet_questions.count()
+
+        cabinet_subparts = QuestionSubpart.objects.filter(
+            question__tags__name__startswith=_CABINET_TAG_PREFIX
+        ).distinct()
+
+        # (a) wrong-widget subparts — blank or invalid subpart_type.
+        wrong_widget = sum(1 for sp in cabinet_subparts if sp.subpart_type not in _VALID_SUBPART_TYPES)
+
+        # (b) legacy/inline-image token leaks in any rendered field.
+        legacy_tokens = sum(
+            1
+            for sp in cabinet_subparts.iterator(chunk_size=500)
+            if any(_LEAK_RE.search(text) for text in _subpart_text_fields(sp))
+        )
+
+        # (c) taxonomy placeholders still referenced by cabinet questions.
+        taxonomy_placeholders = (
+            cabinet_questions.filter(subject__name__startswith="Imported Subject").count()
+            + cabinet_questions.filter(chapter__name__startswith="Imported Chapter").count()
+        )
+
+        # (d) every cabinet tag maps to exactly one Question.
+        tag_cardinality = (
+            QuestionTag.objects.filter(name__startswith=_CABINET_TAG_PREFIX)
+            .annotate(n=Count("questions"))
+            .exclude(n=1)
+            .count()
+        )
+
+        metrics = {
+            "wrong_widget": wrong_widget,
+            "legacy_tokens": legacy_tokens,
+            "taxonomy_placeholders": taxonomy_placeholders,
+            "tag_cardinality": tag_cardinality,
+        }
+
+        self.stdout.write(f"cabinet questions: {total_questions}  subparts: {cabinet_subparts.count()}")
+        all_green = True
+        for name, value in metrics.items():
+            ok = value == 0
+            all_green = all_green and ok
+            style = self.style.SUCCESS if ok else self.style.ERROR
+            self.stdout.write(style(f"  {name:<22} {value}"))
+
+        if all_green:
+            self.stdout.write(self.style.SUCCESS("DoD audit: all green."))
+        else:
+            self.stdout.write(self.style.ERROR("DoD audit: defects found."))
+            if options.get("strict"):
+                raise SystemExit(1)

--- a/backend/openshiksha/apps/core/tests/test_cabinet_fidelity_audit.py
+++ b/backend/openshiksha/apps/core/tests/test_cabinet_fidelity_audit.py
@@ -1,0 +1,66 @@
+"""Standing DoD regression guard for Cabinet Data Fidelity (audit_cabinet_fidelity).
+
+Seeds the small cabinet fixture via the importer (with the name mapping so
+taxonomy resolves), asserts the audit is all-green, then mutates one row and
+asserts the audit flags it — including the non-zero exit under ``--strict``.
+"""
+
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from django.core.management import call_command
+
+from openshiksha.apps.core.models import QuestionSubpart
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "cabinet_sample"
+SOURCE = str(FIXTURE_DIR)
+MAPPING = str(FIXTURE_DIR / "mapping.json")
+
+
+def _import():
+    call_command("import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=StringIO(), stderr=StringIO())
+
+
+def _audit(**kwargs):
+    out = StringIO()
+    call_command("audit_cabinet_fidelity", stdout=out, stderr=StringIO(), **kwargs)
+    return out.getvalue()
+
+
+@pytest.mark.django_db
+class TestCabinetFidelityAudit:
+    def test_freshly_imported_corpus_is_all_green(self):
+        _import()
+        output = _audit()
+        assert "all green" in output
+
+    def test_blank_subpart_type_flags_wrong_widget(self):
+        _import()
+        sp = QuestionSubpart.objects.filter(question__tags__name__startswith="cabinet:").first()
+        sp.subpart_type = ""
+        sp.save(update_fields=["subpart_type"])
+        output = _audit()
+        assert "defects found" in output
+
+    def test_strict_exits_nonzero_on_defect(self):
+        _import()
+        sp = QuestionSubpart.objects.filter(question__tags__name__startswith="cabinet:").first()
+        sp.subpart_type = ""
+        sp.save(update_fields=["subpart_type"])
+        with pytest.raises(SystemExit):
+            _audit(strict=True)
+
+    def test_legacy_token_leak_flags(self):
+        _import()
+        sp = QuestionSubpart.objects.filter(question__tags__name__startswith="cabinet:").first()
+        sp.question_text = "leftover #{8.gif}# token"
+        sp.save(update_fields=["question_text"])
+        output = _audit()
+        assert "defects found" in output
+
+    def test_strict_passes_clean_corpus(self):
+        _import()
+        # Should not raise on a clean corpus.
+        _audit(strict=True)

--- a/docs/changes/2026-06-01-m7-03b-subpart-widget.md
+++ b/docs/changes/2026-06-01-m7-03b-subpart-widget.md
@@ -1,0 +1,46 @@
+# M7-03b — Frontend per-subpart input widget
+
+## Summary
+
+The student `QuestionCard` now selects each subpart's input widget from
+`subpart.subpart_type` (falling back to `question.question_type`), so a single
+`compound` question renders the right control per subpart — e.g. an option list
+for an mcq subpart and a numeric input for a numeric subpart.
+
+## Classification
+
+**Improve** — depends on **M7-03a** ([#128](https://github.com/openshiksha/openshiksha/pull/128))
+which serializes `subpart_type`.
+
+## What changed
+
+### Types — `frontend_modern/src/types/index.ts`
+- New `SubpartType` union (mirrors backend `QuestionType`).
+- `QuestionSubpart.subpart_type?: SubpartType | ''` (blank for legacy rows).
+- `Question.question_type` widened to `SubpartType | 'compound'`.
+
+### Component — `frontend_modern/src/features/student/QuestionCard.tsx`
+- `SubpartInput` now takes `widgetType` instead of the whole-question type and
+  dispatches on it (mcq / multi_select / numeric / text fallback).
+- Call site passes `subpart.subpart_type || question.question_type` so legacy/
+  hand-authored rows (blank `subpart_type`) keep working, and a `compound`
+  parent type never reaches the widget (each subpart resolves its own type).
+
+## Tests
+
+`QuestionCard.test.tsx` (new, 4 tests):
+- A compound question with mcq + numeric subparts renders a radio list and a
+  numeric input respectively.
+- Blank `subpart_type` falls back to the parent question type.
+- multi_select → checkboxes; fill_blank → text input.
+
+Frontend: type-check, lint, build, and full Vitest suite (**46 passed**) green.
+
+## Migration notes
+
+None — frontend only.
+
+## Next steps
+
+- PR 5: `audit_cabinet_fidelity` command + DoD regression test (the wrong-widget
+  metric is now meaningfully checkable since the widget reads `subpart_type`).

--- a/docs/changes/2026-06-01-m7-audit-fidelity.md
+++ b/docs/changes/2026-06-01-m7-audit-fidelity.md
@@ -1,0 +1,56 @@
+# Cabinet fidelity audit command + DoD regression guard
+
+## Summary
+
+Adds `audit_cabinet_fidelity` — a read-only management command that asserts the
+Cabinet Data Fidelity initiative's cross-cutting **Definition of Done** as
+enforceable metrics, plus a pytest that fails if any regress. This converts the
+DoD from a one-off manual check into a standing invariant so a future re-import
+can't silently undo the fidelity work.
+
+## Classification
+
+**New / test-coverage.**
+
+## What changed
+
+### Command — `apps/core/management/commands/audit_cabinet_fidelity.py`
+Scopes all checks to the cabinet corpus (`tags__name__startswith="cabinet:"`)
+and reports four metrics (each should be 0):
+
+| Metric | Defect it catches | Closed by |
+|---|---|---|
+| `wrong_widget` | subpart with blank/invalid `subpart_type` | M7-03 |
+| `legacy_tokens` | un-converted `_{x}_` / literal `#{img}#` token in any rendered field | M7-06 + token conversion |
+| `taxonomy_placeholders` | cabinet question still on `Imported Subject/Chapter %` | M7-09 / mapping |
+| `tag_cardinality` | cabinet tag attached to ≠ 1 Question | M7-05 |
+
+`--strict` exits non-zero when any metric is out of bounds (CI guard). Read-only;
+queries are scoped to cabinet tags so it never touches hand-authored content.
+
+### Test — `apps/core/tests/test_cabinet_fidelity_audit.py`
+Seeds the cabinet fixture via the importer (with the name mapping), asserts the
+audit is all-green, then mutates one row (blank `subpart_type`; injected `#{}#`
+leak) and asserts it flags — including the `SystemExit` under `--strict`.
+
+Full backend suite green.
+
+## Migration notes
+
+None.
+
+## Closing gate (follow-up, needs the Docker/Postgres stack)
+
+Per the daily plan, after PRs 1–5 merge, re-run
+`python manage.py import_cabinet_questions --source <cabinet>/questions` against
+the seed/dev DB to materialise M7-06 inline images and per-subpart types on the
+real corpus, then `python manage.py audit_cabinet_fidelity --strict` and confirm
+it exits green. That step requires the dev Postgres (not connected in the build
+environment), so it's the one remaining follow-on to declare the initiative
+"✅ Complete".
+
+## Next steps
+
+- Run the closing-gate re-import + `--strict` audit on the dev stack.
+- M7-11 (interactive widget) remains as the additive follow-on (not part of the
+  original DoD).

--- a/frontend_modern/src/features/student/QuestionCard.test.tsx
+++ b/frontend_modern/src/features/student/QuestionCard.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect } from 'vitest';
+import { QuestionCard } from './QuestionCard';
+import type { Question, QuestionSubpart, SubpartType } from '@/types/index';
+
+// M7-03b: the subpart input widget must switch on `subpart.subpart_type`, not
+// the (possibly `compound`) parent question type.
+
+function makeSubpart(over: Partial<QuestionSubpart>): QuestionSubpart {
+  return {
+    id: 1,
+    index: 0,
+    tags: [],
+    question_text: 'prompt',
+    options: null,
+    ...over,
+  };
+}
+
+function renderCard(question: Question) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <QuestionCard
+        question={question}
+        questionNumber={1}
+        answers={{}}
+        onAnswerChange={() => {}}
+        isSubmitted={false}
+      />
+    </QueryClientProvider>
+  );
+}
+
+function compoundQuestion(subparts: QuestionSubpart[]): Question {
+  return {
+    id: 10,
+    standard: 8,
+    subject: 1,
+    chapter: 1,
+    question_type: 'compound',
+    difficulty: 2,
+    tags: [],
+    subparts,
+    is_active: true,
+    created_at: '2026-06-01T00:00:00Z',
+  };
+}
+
+describe('QuestionCard — per-subpart widget (M7-03b)', () => {
+  it('renders an option list for an mcq subpart and a numeric input for a numeric subpart in one compound question', () => {
+    const mcq = makeSubpart({
+      id: 101,
+      index: 0,
+      subpart_type: 'mcq',
+      options: [
+        { key: 'A', text: 'seven' },
+        { key: 'B', text: 'eight' },
+      ],
+    });
+    const numeric = makeSubpart({ id: 102, index: 1, subpart_type: 'numeric', options: null });
+
+    renderCard(compoundQuestion([mcq, numeric]));
+
+    // mcq subpart → radio inputs keyed by subpart id
+    const radios = screen.getAllByRole('radio');
+    expect(radios).toHaveLength(2);
+    expect(radios[0]).toHaveAttribute('name', 'subpart-101');
+
+    // numeric subpart → a number input
+    const numberInput = screen.getByRole('spinbutton');
+    expect(numberInput).toHaveAttribute('type', 'number');
+  });
+
+  it('falls back to the parent question type when subpart_type is blank', () => {
+    // Hand-authored legacy row: blank subpart_type, parent type drives the widget.
+    const sp = makeSubpart({
+      id: 201,
+      subpart_type: '',
+      options: [
+        { key: 'A', text: 'x' },
+        { key: 'B', text: 'y' },
+      ],
+    });
+    const question: Question = {
+      ...compoundQuestion([sp]),
+      question_type: 'mcq' as SubpartType,
+    };
+    renderCard(question);
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
+  });
+
+  it('renders a multi_select subpart as checkboxes', () => {
+    const sp = makeSubpart({
+      id: 301,
+      subpart_type: 'multi_select',
+      options: [
+        { key: 'A', text: 'a' },
+        { key: 'B', text: 'b' },
+      ],
+    });
+    renderCard(compoundQuestion([sp]));
+    const boxes = screen.getAllByRole('checkbox');
+    expect(boxes).toHaveLength(2);
+  });
+
+  it('renders a text input for a fill_blank subpart', () => {
+    const sp = makeSubpart({ id: 401, subpart_type: 'fill_blank', options: null });
+    const { container } = renderCard(compoundQuestion([sp]));
+    const textInput = within(container).getByPlaceholderText('Enter your answer');
+    expect(textInput).toHaveAttribute('type', 'text');
+  });
+});

--- a/frontend_modern/src/features/student/QuestionCard.tsx
+++ b/frontend_modern/src/features/student/QuestionCard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import type { Question, QuestionSubpart, MCQOption, AIHint } from '@/types/index';
+import type { Question, QuestionSubpart, MCQOption, AIHint, SubpartType } from '@/types/index';
 import { RichContent } from '@/shared/ui';
 import { useHints } from './useHints';
 
@@ -126,14 +126,16 @@ function AIHintPanel({ subpartId }: { subpartId: number }) {
 
 interface SubpartInputProps {
   subpart: QuestionSubpart;
-  questionType: Question['question_type'];
+  /** Effective answer type for this subpart (subpart_type, falling back to the
+   *  question's type). Drives which input widget renders. */
+  widgetType: SubpartType | 'compound';
   value: string;
   onChange: (value: string) => void;
   isSubmitted: boolean;
 }
 
-function SubpartInput({ subpart, questionType, value, onChange, isSubmitted }: SubpartInputProps) {
-  if (questionType === 'mcq' && subpart.options) {
+function SubpartInput({ subpart, widgetType, value, onChange, isSubmitted }: SubpartInputProps) {
+  if (widgetType === 'mcq' && subpart.options) {
     return (
       <div className="space-y-2 mt-3">
         {subpart.options.map((opt: MCQOption) => (
@@ -164,7 +166,7 @@ function SubpartInput({ subpart, questionType, value, onChange, isSubmitted }: S
     );
   }
 
-  if (questionType === 'multi_select' && subpart.options) {
+  if (widgetType === 'multi_select' && subpart.options) {
     const selected = value ? value.split(',') : [];
     const toggle = (key: string) => {
       if (isSubmitted) return;
@@ -203,7 +205,7 @@ function SubpartInput({ subpart, questionType, value, onChange, isSubmitted }: S
     );
   }
 
-  if (questionType === 'numeric') {
+  if (widgetType === 'numeric') {
     return (
       <input
         type="number"
@@ -294,7 +296,7 @@ export const QuestionCard = ({
 
             <SubpartInput
               subpart={subpart}
-              questionType={question.question_type}
+              widgetType={subpart.subpart_type || question.question_type}
               value={value}
               onChange={(val) => handleChange(subpart.id, val)}
               isSubmitted={isSubmitted}

--- a/frontend_modern/src/types/index.ts
+++ b/frontend_modern/src/types/index.ts
@@ -78,9 +78,17 @@ export interface MCQOption {
   text: string;
 }
 
+/** Answer types a single subpart can have (mirrors backend QuestionType). */
+export type SubpartType = 'mcq' | 'fill_blank' | 'matching' | 'multi_select' | 'numeric' | 'short_answer';
+
 export interface QuestionSubpart {
   id: number;
   index: number;
+  /**
+   * Per-subpart answer type (M7-03). Blank ('') for hand-authored rows that
+   * predate the field — callers fall back to the parent Question.question_type.
+   */
+  subpart_type?: SubpartType | '';
   tags: QuestionTag[];
   question_text: string;
   options: MCQOption[] | null;
@@ -112,7 +120,8 @@ export interface Question {
   subject_name?: string;
   chapter: number;
   chapter_name?: string;
-  question_type: 'mcq' | 'fill_blank' | 'matching' | 'multi_select' | 'numeric';
+  /** 'compound' = subparts have heterogeneous types (M7-03). */
+  question_type: SubpartType | 'compound';
   question_type_display?: string;
   difficulty: number;
   /** Optional shared stem rendered once above the subparts (M7-07). */


### PR DESCRIPTION
## Classification: Improve

Closes **M7-03b** of Cabinet Data Fidelity. The student `QuestionCard` selects each subpart's input widget from `subpart.subpart_type` (falling back to `question.question_type`), so a single `compound` question renders the correct control per subpart.

> **Stacked on [#128](https://github.com/openshiksha/openshiksha/pull/128) (M7-03a)** which serializes `subpart_type`. Re-target to `modernization` once the chain merges.

## What

- **Types**: `SubpartType` union; `QuestionSubpart.subpart_type?: SubpartType | ''`; `Question.question_type` widened to include `'compound'`.
- **QuestionCard**: `SubpartInput` dispatches on a `widgetType` prop = `subpart.subpart_type || question.question_type`. Blank subpart_type (legacy/hand-authored) falls back to the parent type; a `compound` parent never reaches the widget.

## Tests

`QuestionCard.test.tsx` (4): compound mcq+numeric renders radios + numeric input; blank subpart_type falls back; multi_select → checkboxes; fill_blank → text. type-check, lint, build, full Vitest **46 passed**.

## How to verify

Open a compound cabinet question in the student assignment flow — each part shows its own input type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)