### PR TITLE
feat(core): audit_cabinet_fidelity DoD regression guard (M7 close)

### DIFF
--- a/backend/openshiksha/apps/core/management/commands/audit_cabinet_fidelity.py
+++ b/backend/openshiksha/apps/core/management/commands/audit_cabinet_fidelity.py
@@ -1,0 +1,112 @@
+"""Management command: audit_cabinet_fidelity
+
+Standing regression guard for the Cabinet Data Fidelity initiative's
+Definition of Done. Reports, over the imported cabinet question corpus
+(``tags__name__startswith="cabinet:"``), the cross-cutting invariants the
+initiative promised — and with ``--strict`` exits non-zero if any regress, so
+a future re-import can't silently undo the fidelity work.
+
+Metrics (all should be 0 once the bank is re-imported with M7-03/06/09):
+  - wrong_widget       — subparts with a blank/invalid ``subpart_type`` (M7-03).
+  - legacy_tokens      — fields still holding un-converted ``_{x}_`` legacy
+                         tokens or literal ``#{img}#`` inline-image tokens
+                         (M7-06 + token conversion).
+  - taxonomy_placeholders — cabinet questions still pointing at
+                         "Imported Subject %"/"Imported Chapter %" placeholders
+                         (M7-09 taxonomy inference / mapping).
+  - tag_cardinality    — cabinet tags attached to != 1 Question (M7-05 identity).
+
+Usage:
+    python manage.py audit_cabinet_fidelity
+    python manage.py audit_cabinet_fidelity --strict   # CI: non-zero on any defect
+"""
+
+from __future__ import annotations
+
+import re
+
+from django.core.management.base import BaseCommand
+from django.db.models import Count
+
+from openshiksha.apps.core.models import Question, QuestionSubpart, QuestionTag, QuestionType
+
+_CABINET_TAG_PREFIX = "cabinet:"
+_VALID_SUBPART_TYPES = {t.value for t in QuestionType if t != QuestionType.COMPOUND}
+
+# Un-converted legacy substitution token (``_{x}_``) or a literal inline-image
+# token (``#{8.gif}#``) that should have been rewritten by the importer.
+_LEAK_RE = re.compile(r"_\{[a-zA-Z_]\w*\}_|#\{[^{}#]+\}#")
+
+
+def _subpart_text_fields(sp: QuestionSubpart):
+    yield sp.question_text or ""
+    yield sp.solution_text or ""
+    yield sp.hint_text or ""
+    for opt in sp.options or []:
+        if isinstance(opt, dict):
+            yield opt.get("text", "") or ""
+
+
+class Command(BaseCommand):
+    help = "Audit the imported Cabinet corpus against the fidelity Definition of Done."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--strict",
+            action="store_true",
+            help="Exit non-zero if any metric is out of bounds (for CI).",
+        )
+
+    def handle(self, *args, **options):
+        cabinet_questions = Question.objects.filter(tags__name__startswith=_CABINET_TAG_PREFIX).distinct()
+        total_questions = cabinet_questions.count()
+
+        cabinet_subparts = QuestionSubpart.objects.filter(
+            question__tags__name__startswith=_CABINET_TAG_PREFIX
+        ).distinct()
+
+        # (a) wrong-widget subparts — blank or invalid subpart_type.
+        wrong_widget = sum(1 for sp in cabinet_subparts if sp.subpart_type not in _VALID_SUBPART_TYPES)
+
+        # (b) legacy/inline-image token leaks in any rendered field.
+        legacy_tokens = sum(
+            1
+            for sp in cabinet_subparts.iterator(chunk_size=500)
+            if any(_LEAK_RE.search(text) for text in _subpart_text_fields(sp))
+        )
+
+        # (c) taxonomy placeholders still referenced by cabinet questions.
+        taxonomy_placeholders = (
+            cabinet_questions.filter(subject__name__startswith="Imported Subject").count()
+            + cabinet_questions.filter(chapter__name__startswith="Imported Chapter").count()
+        )
+
+        # (d) every cabinet tag maps to exactly one Question.
+        tag_cardinality = (
+            QuestionTag.objects.filter(name__startswith=_CABINET_TAG_PREFIX)
+            .annotate(n=Count("questions"))
+            .exclude(n=1)
+            .count()
+        )
+
+        metrics = {
+            "wrong_widget": wrong_widget,
+            "legacy_tokens": legacy_tokens,
+            "taxonomy_placeholders": taxonomy_placeholders,
+            "tag_cardinality": tag_cardinality,
+        }
+
+        self.stdout.write(f"cabinet questions: {total_questions}  subparts: {cabinet_subparts.count()}")
+        all_green = True
+        for name, value in metrics.items():
+            ok = value == 0
+            all_green = all_green and ok
+            style = self.style.SUCCESS if ok else self.style.ERROR
+            self.stdout.write(style(f"  {name:<22} {value}"))
+
+        if all_green:
+            self.stdout.write(self.style.SUCCESS("DoD audit: all green."))
+        else:
+            self.stdout.write(self.style.ERROR("DoD audit: defects found."))
+            if options.get("strict"):
+                raise SystemExit(1)

--- a/backend/openshiksha/apps/core/tests/test_cabinet_fidelity_audit.py
+++ b/backend/openshiksha/apps/core/tests/test_cabinet_fidelity_audit.py
@@ -1,0 +1,66 @@
+"""Standing DoD regression guard for Cabinet Data Fidelity (audit_cabinet_fidelity).
+
+Seeds the small cabinet fixture via the importer (with the name mapping so
+taxonomy resolves), asserts the audit is all-green, then mutates one row and
+asserts the audit flags it — including the non-zero exit under ``--strict``.
+"""
+
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from django.core.management import call_command
+
+from openshiksha.apps.core.models import QuestionSubpart
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "cabinet_sample"
+SOURCE = str(FIXTURE_DIR)
+MAPPING = str(FIXTURE_DIR / "mapping.json")
+
+
+def _import():
+    call_command("import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=StringIO(), stderr=StringIO())
+
+
+def _audit(**kwargs):
+    out = StringIO()
+    call_command("audit_cabinet_fidelity", stdout=out, stderr=StringIO(), **kwargs)
+    return out.getvalue()
+
+
+@pytest.mark.django_db
+class TestCabinetFidelityAudit:
+    def test_freshly_imported_corpus_is_all_green(self):
+        _import()
+        output = _audit()
+        assert "all green" in output
+
+    def test_blank_subpart_type_flags_wrong_widget(self):
+        _import()
+        sp = QuestionSubpart.objects.filter(question__tags__name__startswith="cabinet:").first()
+        sp.subpart_type = ""
+        sp.save(update_fields=["subpart_type"])
+        output = _audit()
+        assert "defects found" in output
+
+    def test_strict_exits_nonzero_on_defect(self):
+        _import()
+        sp = QuestionSubpart.objects.filter(question__tags__name__startswith="cabinet:").first()
+        sp.subpart_type = ""
+        sp.save(update_fields=["subpart_type"])
+        with pytest.raises(SystemExit):
+            _audit(strict=True)
+
+    def test_legacy_token_leak_flags(self):
+        _import()
+        sp = QuestionSubpart.objects.filter(question__tags__name__startswith="cabinet:").first()
+        sp.question_text = "leftover #{8.gif}# token"
+        sp.save(update_fields=["question_text"])
+        output = _audit()
+        assert "defects found" in output
+
+    def test_strict_passes_clean_corpus(self):
+        _import()
+        # Should not raise on a clean corpus.
+        _audit(strict=True)

--- a/docs/changes/2026-06-01-m7-audit-fidelity.md
+++ b/docs/changes/2026-06-01-m7-audit-fidelity.md
@@ -1,0 +1,56 @@
+# Cabinet fidelity audit command + DoD regression guard
+
+## Summary
+
+Adds `audit_cabinet_fidelity` — a read-only management command that asserts the
+Cabinet Data Fidelity initiative's cross-cutting **Definition of Done** as
+enforceable metrics, plus a pytest that fails if any regress. This converts the
+DoD from a one-off manual check into a standing invariant so a future re-import
+can't silently undo the fidelity work.
+
+## Classification
+
+**New / test-coverage.**
+
+## What changed
+
+### Command — `apps/core/management/commands/audit_cabinet_fidelity.py`
+Scopes all checks to the cabinet corpus (`tags__name__startswith="cabinet:"`)
+and reports four metrics (each should be 0):
+
+| Metric | Defect it catches | Closed by |
+|---|---|---|
+| `wrong_widget` | subpart with blank/invalid `subpart_type` | M7-03 |
+| `legacy_tokens` | un-converted `_{x}_` / literal `#{img}#` token in any rendered field | M7-06 + token conversion |
+| `taxonomy_placeholders` | cabinet question still on `Imported Subject/Chapter %` | M7-09 / mapping |
+| `tag_cardinality` | cabinet tag attached to ≠ 1 Question | M7-05 |
+
+`--strict` exits non-zero when any metric is out of bounds (CI guard). Read-only;
+queries are scoped to cabinet tags so it never touches hand-authored content.
+
+### Test — `apps/core/tests/test_cabinet_fidelity_audit.py`
+Seeds the cabinet fixture via the importer (with the name mapping), asserts the
+audit is all-green, then mutates one row (blank `subpart_type`; injected `#{}#`
+leak) and asserts it flags — including the `SystemExit` under `--strict`.
+
+Full backend suite green.
+
+## Migration notes
+
+None.
+
+## Closing gate (follow-up, needs the Docker/Postgres stack)
+
+Per the daily plan, after PRs 1–5 merge, re-run
+`python manage.py import_cabinet_questions --source <cabinet>/questions` against
+the seed/dev DB to materialise M7-06 inline images and per-subpart types on the
+real corpus, then `python manage.py audit_cabinet_fidelity --strict` and confirm
+it exits green. That step requires the dev Postgres (not connected in the build
+environment), so it's the one remaining follow-on to declare the initiative
+"✅ Complete".
+
+## Next steps
+
+- Run the closing-gate re-import + `--strict` audit on the dev stack.
+- M7-11 (interactive widget) remains as the additive follow-on (not part of the
+  original DoD).


### PR DESCRIPTION
## Classification: New / test-coverage

Adds `audit_cabinet_fidelity` — a read-only command asserting the Cabinet Data Fidelity **Definition of Done** as enforceable metrics, plus a pytest guard. Converts the DoD from a manual check into a standing CI invariant.

> **Stacked on [#129](https://github.com/openshiksha/openshiksha/pull/129) (M7-03b)** so the `wrong_widget` metric can read `subpart_type`. Re-target to `modernization` once the chain merges.

## Metrics (each should be 0)

| Metric | Catches | Closed by |
|---|---|---|
| `wrong_widget` | blank/invalid `subpart_type` | M7-03 |
| `legacy_tokens` | un-converted `_{x}_` / literal `#{img}#` in any rendered field | M7-06 |
| `taxonomy_placeholders` | cabinet question on `Imported Subject/Chapter %` | M7-09 |
| `tag_cardinality` | cabinet tag attached to ≠ 1 Question | M7-05 |

`--strict` exits non-zero on any defect (CI guard). Read-only; scoped to cabinet tags.

## Tests

`test_cabinet_fidelity_audit.py` (5): freshly-imported fixture is all-green; blanking a `subpart_type` flags `wrong_widget`; injected `#{}#` leak flags; `--strict` raises `SystemExit` on defect and passes clean. Full backend suite **718 passed, 92.89%**.

## Closing gate (follow-up — needs the Docker/Postgres stack)

After PRs 1–5 merge, re-run `import_cabinet_questions` then `audit_cabinet_fidelity --strict` on the dev DB to materialise inline images + per-subpart types on the real corpus and confirm green. That requires the dev Postgres (not connected in the build env) — the one remaining step to declare the initiative ✅ Complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)