### PR TITLE
infra(ci): axe-core a11y baseline on /design (non-blocking)

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -236,6 +236,17 @@ jobs:
                 name: playwright-report
                 path: frontend_modern/playwright-report
                 retention-days: 14
+            - name: Upload axe-core a11y report
+              # Baseline report from the /design showcase a11y spec. The spec
+              # itself is non-blocking (see e2e/a11y.spec.ts); this artifact
+              # is how we track the baseline over time before the WCAG 2.1 AA
+              # initiative starts.
+              uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                name: axe-report
+                path: frontend_modern/axe-report
+                retention-days: 14
 
     build-publish:
         name: Build & Publish

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ frontend_modern/.cache/
 frontend_modern/test-results/
 frontend_modern/playwright-report/
 frontend_modern/playwright/.cache/
+frontend_modern/axe-report/
 
 # Backend (Python / Django)
 backend/__pycache__/

--- a/docs/changes/2026-06-02-axe-a11y-baseline.md
+++ b/docs/changes/2026-06-02-axe-a11y-baseline.md
@@ -1,0 +1,43 @@
+# 2026-06-02 — axe-core a11y baseline on /design
+
+## What
+
+Added an accessibility baseline Playwright spec (`frontend_modern/e2e/a11y.spec.ts`)
+that runs axe-core against the `/design` showcase, writes a JSON summary to
+`frontend_modern/axe-report/design.json`, and uploads it as a CI artifact
+(`axe-report`) from the existing `frontend-e2e` job.
+
+- New dev deps: `@axe-core/playwright`, `axe-core`.
+- Spec is **non-blocking**: it always passes today and logs a summary to the
+  test console. Toggle `FAIL_ON_BLOCKING = true` in the spec to gate on
+  `serious` + `critical` violations once the WCAG 2.1 AA initiative starts.
+- CI step: `Upload axe-core a11y report` (always-on, 14-day retention).
+
+## Why
+
+The V2 "Chalk & Unlock" design overhaul is the top active initiative, and
+"Accessibility pass — WCAG 2.1 AA across the migrated V2 surfaces" is the
+next-up backlog initiative. Standing up the measurement infra now lets the
+design team see baseline a11y violations on the canonical showcase page as
+new primitives land, so the eventual AA pass starts from data rather than
+zero.
+
+`/design` is the right anchor: it is the only public, backend-free route in
+the app and the V2 DoD requires every primitive to be catalogued there.
+
+## Baseline at landing time
+
+axe-core (WCAG 2.0/2.1 A+AA tags) reports **2 violations** on `/design`:
+
+- `color-contrast` (serious, 10 nodes) — largely intentional swatch examples.
+- `label` (critical, 1 node) — `<input type="range">` inside the sandboxed
+  thermo-piston widget iframe (M7-11 interactive widget content).
+
+Both will be triaged when the AA initiative formally starts; until then the
+artifact gives us a trend line.
+
+## Out of scope
+
+- Fixing the existing violations.
+- Running axe on authenticated routes (would require the Docker stack).
+- Gating CI on a11y findings.

--- a/frontend_modern/e2e/a11y.spec.ts
+++ b/frontend_modern/e2e/a11y.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Accessibility baseline for the /design showcase.
+//
+// /design is the living catalog for every V2 "Chalk & Unlock" primitive
+// (docs/initiatives/2026-design-system-v2.md). Running axe-core here gives
+// us a stable place to measure a11y health as the design system grows.
+//
+// **Reporting mode (not gating).** A full WCAG 2.1 AA pass is a planned
+// future initiative (see docs/initiatives/STATUS.md backlog). Until that
+// initiative starts, this spec only records violations: it writes a JSON
+// summary to `axe-report/design.json` (uploaded as a CI artifact alongside
+// the Playwright HTML report) and logs counts to the test output. It does
+// not fail on findings — flip `FAIL_ON_BLOCKING` to `true` once the AA pass
+// begins and the known showcase noise (intentional low-contrast swatches,
+// sandboxed widget iframe) has been triaged.
+const FAIL_ON_BLOCKING = false;
+
+test.describe('/design — accessibility (axe-core baseline)', () => {
+  test('records axe-core violations', async ({ page }, testInfo) => {
+    await page.goto('/design');
+    await expect(page.locator('h1').first()).toBeVisible();
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze();
+
+    const byImpact: Record<string, number> = {};
+    for (const v of results.violations) {
+      const key = v.impact ?? 'unknown';
+      byImpact[key] = (byImpact[key] ?? 0) + 1;
+    }
+    const blocking = results.violations.filter(
+      (v) => v.impact === 'serious' || v.impact === 'critical',
+    );
+
+    const summary = {
+      url: '/design',
+      total: results.violations.length,
+      byImpact,
+      blocking: blocking.map((v) => ({
+        id: v.id,
+        impact: v.impact,
+        help: v.help,
+        nodes: v.nodes.length,
+      })),
+    };
+
+    const reportDir = path.join(testInfo.project.outputDir, '..', 'axe-report');
+    fs.mkdirSync(reportDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(reportDir, 'design.json'),
+      JSON.stringify({ summary, violations: results.violations }, null, 2),
+    );
+
+    console.log('[axe] /design summary:', JSON.stringify(summary, null, 2));
+
+    if (FAIL_ON_BLOCKING) {
+      expect(
+        blocking,
+        `axe-core blocking violations on /design:\n${JSON.stringify(summary.blocking, null, 2)}`,
+      ).toEqual([]);
+    }
+  });
+});

--- a/frontend_modern/package-lock.json
+++ b/frontend_modern/package-lock.json
@@ -23,6 +23,7 @@
         "zustand": "^4.4.7"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.3",
         "@playwright/test": "^1.40.1",
         "@testing-library/jest-dom": "^6.1.5",
         "@testing-library/react": "^14.1.2",
@@ -37,6 +38,7 @@
         "@vitest/coverage-v8": "^4.1.8",
         "@vitest/ui": "^4.1.8",
         "autoprefixer": "^10.4.16",
+        "axe-core": "^4.12.0",
         "eslint": "^8.56.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.5",
@@ -49,8 +51,8 @@
         "vitest": "^4.1.8"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=9.0.0"
+        "node": ">=20.19.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -71,6 +73,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright/node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2503,6 +2528,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.0.tgz",
+      "integrity": "sha512-FTavr/7Ba0IptwGOPxnQvdyW2tAsdLBMTBXz7rKH6xJ2skpyxpBxyHkDdBs4lf69yRqYpkqCdfhnwS8YULGOmg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/axios": {

--- a/frontend_modern/package.json
+++ b/frontend_modern/package.json
@@ -32,6 +32,7 @@
     "zustand": "^4.4.7"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@playwright/test": "^1.40.1",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.1.2",
@@ -46,6 +47,7 @@
     "@vitest/coverage-v8": "^4.1.8",
     "@vitest/ui": "^4.1.8",
     "autoprefixer": "^10.4.16",
+    "axe-core": "^4.12.0",
     "eslint": "^8.56.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",


### PR DESCRIPTION
## Summary

- Add `@axe-core/playwright` + a new e2e spec (`frontend_modern/e2e/a11y.spec.ts`) that runs axe-core against the `/design` showcase under the existing Playwright project.
- Spec is **non-blocking**: it records WCAG 2.0/2.1 A+AA violations, writes a JSON summary to `frontend_modern/axe-report/design.json`, and logs counts to the test output, but never fails (toggle `FAIL_ON_BLOCKING` in the spec to gate later).
- New CI step in the `frontend-e2e` job uploads `axe-report/` as an always-on artifact (14-day retention).

## Why

The V2 "Chalk & Unlock" design overhaul is the top active initiative, and a WCAG 2.1 AA pass is the next-up backlog initiative (see `docs/initiatives/STATUS.md`). Standing up the measurement infra now means the eventual AA pass starts from real data rather than zero, and any regression on `/design` — the canonical primitive catalogue — shows up immediately in CI artifacts.

## Baseline at landing time

axe (WCAG 2.0/2.1 A+AA) reports **2 violations** on `/design`:

- `color-contrast` (serious, 10 nodes) — mostly intentional swatch examples.
- `label` (critical, 1 node) — unlabeled `<input type="range">` inside the sandboxed M7-11 widget iframe.

Both will be triaged when the AA initiative formally starts.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run type-check` passes
- [x] `npx playwright test e2e/a11y.spec.ts` passes locally and emits `axe-report/design.json`
- [ ] CI `frontend-e2e` job stays green and uploads the `axe-report` artifact

See [docs/changes/2026-06-02-axe-a11y-baseline.md](docs/changes/2026-06-02-axe-a11y-baseline.md) for full notes.