### PR TITLE
feat(ui): M1-06 — Input/Stat/SectionHeading/EmptyState primitives

### DIFF
--- a/docs/changes/2026-06-02-ui-primitives.md
+++ b/docs/changes/2026-06-02-ui-primitives.md
@@ -1,0 +1,47 @@
+# 2026-06-02 — `ui/` foundation primitives (M1-06)
+
+## Summary
+Add the four remaining V2 "Chalk & Unlock" foundation primitives — `Input`
+(+ `Textarea`, `Select`), `Stat`, `SectionHeading`, `EmptyState` — to
+`frontend_modern/src/shared/ui/`. Closes **M1-06** of the
+[V2 design system initiative](../initiatives/2026-design-system-v2.md).
+
+## Classification
+**New** — additive only, no existing pages touched.
+
+## Why
+The brand shell, login, and home page already speak V2 — but every M4 dashboard
+migration still needs primitives that don't exist yet. Building these as a
+foundation PR means later page migrations compose `ui/` parts instead of
+hand-rolling warm styles. PR 3/4/5 in today's batch consume the same primitives.
+
+## What's new
+- `Input` — labelled text field, with `hint`, `error`, `leftIcon`, ARIA wiring
+  (`aria-invalid` + `aria-describedby`), focus-visible ring, disabled state.
+- `Textarea` — same chrome as `Input`, multiline.
+- `Select` — native select with brand chevron and matching label/hint/error chrome.
+- `Stat` — KPI block for dashboard headlines: big `font-display` value, small
+  uppercase label, optional `delta` pill (consumes `Badge` tones) + `hint`.
+- `SectionHeading` — `font-display` section title with optional `eyebrow`,
+  `description`, and right-aligned `action` slot. `as` prop sets semantic level.
+- `EmptyState` — canonical "nothing here yet" surface on `.os-card`, brand
+  keyhole glyph, optional action.
+
+## Wiring
+- Exported from `src/shared/ui/index.ts`.
+- Every new primitive rendered on the `/design` route with all key variants
+  (Input default/error/disabled, Select, Textarea, Stat with/without delta,
+  SectionHeading with/without action, EmptyState with/without action).
+- `shared/ui/README.md` table updated.
+
+## Tests
+- `Input.test.tsx`, `Stat.test.tsx`, `SectionHeading.test.tsx`,
+  `EmptyState.test.tsx` — render-smoke per primitive (default + key variants).
+- All frontend tests green: 40/40.
+- `npm run type-check`, `npm run lint`, `npm run build` clean.
+
+## Next steps
+- PR 2 — global states (LoadingSpinner, NotFoundPage, ErrorBoundary).
+- PR 3 — register flow → V2 (uses new `Input`).
+- PR 4 — Student Dashboard → V2 (uses `Stat`, `SectionHeading`, `EmptyState`).
+- PR 5 — Teacher Dashboard → V2 (same primitives).

--- a/frontend_modern/src/features/design/DesignSystemPage.tsx
+++ b/frontend_modern/src/features/design/DesignSystemPage.tsx
@@ -1,4 +1,18 @@
-import { Logo, Button, Card, Badge, RichContent, InteractiveWidget, Skeleton } from '@/shared/ui';
+import {
+  Logo,
+  Button,
+  Card,
+  Badge,
+  RichContent,
+  InteractiveWidget,
+  Skeleton,
+  Input,
+  Textarea,
+  Select,
+  Stat,
+  SectionHeading,
+  EmptyState,
+} from '@/shared/ui';
 
 /**
  * Living catalogue of the V2 "Chalk & Unlock" design system. Every new `ui/`
@@ -189,6 +203,53 @@ export const DesignSystemPage = () => (
             }
           />
         </Card>
+      </Section>
+
+      <Section kicker="Components" title="Form inputs">
+        <Card className="grid gap-4 sm:grid-cols-2">
+          <Input label="Full name" placeholder="Aanya Sharma" />
+          <Input
+            label="School email"
+            type="email"
+            placeholder="you@school.edu"
+            hint="We only use this to send progress digests."
+          />
+          <Input label="Roll number" defaultValue="07-A" disabled />
+          <Input label="Phone" placeholder="+91" error="Enter a valid 10-digit number." />
+          <Select label="Board" defaultValue="CBSE">
+            <option value="CBSE">CBSE</option>
+            <option value="ICSE">ICSE</option>
+            <option value="STATE">State board</option>
+          </Select>
+          <Textarea label="Notes" placeholder="Anything we should know?" rows={3} />
+        </Card>
+      </Section>
+
+      <Section kicker="Components" title="Stats (KPI block)">
+        <Card className="grid gap-6 sm:grid-cols-3">
+          <Stat label="Current streak" value="14d" delta="+2 days" tone="success" hint="Personal best" />
+          <Stat label="Mastery" value="84%" delta="+6%" tone="brand" />
+          <Stat label="Due" value="3" hint="of 5 assignments" />
+        </Card>
+      </Section>
+
+      <Section kicker="Components" title="Section heading">
+        <Card className="space-y-6">
+          <SectionHeading eyebrow="Today" title="Practice queue" description="Pick something to work on right now." action={<a href="#" className="text-sm font-semibold text-brand-700 hover:text-brand-800">View all</a>} />
+          <div className="border-t border-ink-100" />
+          <SectionHeading title="Recent activity" />
+        </Card>
+      </Section>
+
+      <Section kicker="Components" title="Empty state">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <EmptyState
+            title="No assignments yet"
+            description="Your teacher hasn't assigned anything yet — but you can keep practicing."
+            action={<Button>Browse practice</Button>}
+          />
+          <EmptyState title="No streak yet" description="Answer one question today to start the chain." />
+        </div>
       </Section>
 
       <Section kicker="Components" title="Skeleton (loading)">

--- a/frontend_modern/src/shared/ui/EmptyState.test.tsx
+++ b/frontend_modern/src/shared/ui/EmptyState.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { EmptyState } from './EmptyState';
+import { Button } from './Button';
+
+describe('<EmptyState />', () => {
+  it('renders title and description', () => {
+    render(<EmptyState title="No assignments yet" description="Check back soon." />);
+    expect(screen.getByText('No assignments yet')).toBeInTheDocument();
+    expect(screen.getByText('Check back soon.')).toBeInTheDocument();
+  });
+
+  it('renders an action slot when provided', () => {
+    render(
+      <EmptyState
+        title="Empty"
+        action={<Button>Browse practice</Button>}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Browse practice' })).toBeInTheDocument();
+  });
+
+  it('uses role=status for screen readers', () => {
+    render(<EmptyState title="Empty" />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+});

--- a/frontend_modern/src/shared/ui/EmptyState.tsx
+++ b/frontend_modern/src/shared/ui/EmptyState.tsx
@@ -1,0 +1,61 @@
+import clsx from 'clsx';
+import { HTMLAttributes, ReactNode } from 'react';
+
+interface EmptyStateProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
+  title: ReactNode;
+  description?: ReactNode;
+  /** Optional primary action (typically a `<Button>`). */
+  action?: ReactNode;
+  /** Optional custom icon node; defaults to the keyhole motif. */
+  icon?: ReactNode;
+}
+
+const KeyholeGlyph = () => (
+  <svg
+    aria-hidden="true"
+    viewBox="0 0 64 64"
+    width="48"
+    height="48"
+    fill="none"
+    className="text-brand-500"
+  >
+    <circle cx="32" cy="32" r="30" stroke="currentColor" strokeWidth="2" opacity="0.25" />
+    <circle cx="32" cy="26" r="7" stroke="currentColor" strokeWidth="3" />
+    <path
+      d="M28 31 L26 44 L38 44 L36 31"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+/**
+ * Canonical "nothing here yet" surface. Keyhole motif on warm paper, with an
+ * optional primary action. Use for empty lists, dashboards, and search results.
+ */
+export const EmptyState = ({
+  title,
+  description,
+  action,
+  icon,
+  className,
+  ...props
+}: EmptyStateProps) => (
+  <div
+    role="status"
+    className={clsx(
+      'os-card flex flex-col items-center gap-3 px-6 py-10 text-center',
+      className,
+    )}
+    {...props}
+  >
+    <div className="flex h-16 w-16 items-center justify-center rounded-full bg-brand-50">
+      {icon ?? <KeyholeGlyph />}
+    </div>
+    <h3 className="font-display text-lg font-semibold text-ink-900">{title}</h3>
+    {description && <p className="max-w-md text-sm text-ink-500">{description}</p>}
+    {action && <div className="mt-2">{action}</div>}
+  </div>
+);

--- a/frontend_modern/src/shared/ui/Input.test.tsx
+++ b/frontend_modern/src/shared/ui/Input.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Input, Textarea, Select } from './Input';
+
+describe('<Input />', () => {
+  it('renders with a label associated to the input', () => {
+    render(<Input label="Email" placeholder="you@example.com" />);
+    const input = screen.getByLabelText('Email');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('placeholder', 'you@example.com');
+  });
+
+  it('shows hint text when provided and no error', () => {
+    render(<Input label="Name" hint="As shown on your school ID" />);
+    expect(screen.getByText('As shown on your school ID')).toBeInTheDocument();
+  });
+
+  it('shows error and sets aria-invalid when error is set', () => {
+    render(<Input label="Name" error="Required" />);
+    const input = screen.getByLabelText('Name');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByText('Required')).toBeInTheDocument();
+  });
+
+  it('renders disabled state', () => {
+    render(<Input label="Name" disabled />);
+    expect(screen.getByLabelText('Name')).toBeDisabled();
+  });
+});
+
+describe('<Textarea />', () => {
+  it('renders a labelled multiline field', () => {
+    render(<Textarea label="Bio" placeholder="Tell us…" />);
+    const field = screen.getByLabelText('Bio');
+    expect(field.tagName).toBe('TEXTAREA');
+  });
+});
+
+describe('<Select />', () => {
+  it('renders a labelled select with options', () => {
+    render(
+      <Select label="Board" defaultValue="CBSE">
+        <option value="CBSE">CBSE</option>
+        <option value="ICSE">ICSE</option>
+      </Select>,
+    );
+    const field = screen.getByLabelText('Board') as HTMLSelectElement;
+    expect(field.tagName).toBe('SELECT');
+    expect(field.value).toBe('CBSE');
+  });
+});

--- a/frontend_modern/src/shared/ui/Input.tsx
+++ b/frontend_modern/src/shared/ui/Input.tsx
@@ -1,0 +1,181 @@
+import clsx from 'clsx';
+import {
+  forwardRef,
+  InputHTMLAttributes,
+  ReactNode,
+  SelectHTMLAttributes,
+  TextareaHTMLAttributes,
+  useId,
+} from 'react';
+
+interface FieldChromeProps {
+  label?: ReactNode;
+  hint?: ReactNode;
+  error?: ReactNode;
+  /** Render the field at full available width (default true). */
+  block?: boolean;
+}
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement>, FieldChromeProps {
+  leftIcon?: ReactNode;
+}
+
+/**
+ * Text input in the V2 brand language. Composes `.input-brand` plus accessible
+ * label/hint/error wiring. Forward-refs to the underlying `<input>`.
+ */
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    { label, hint, error, leftIcon, block = true, className, id, type = 'text', ...props },
+    ref,
+  ) => {
+    const reactId = useId();
+    const inputId = id ?? `${reactId}-input`;
+    const hintId = hint ? `${inputId}-hint` : undefined;
+    const errorId = error ? `${inputId}-error` : undefined;
+    const describedBy = [hintId, errorId].filter(Boolean).join(' ') || undefined;
+    return (
+      <div className={clsx(block && 'w-full')}>
+        {label && (
+          <label htmlFor={inputId} className="mb-1.5 block text-sm font-medium text-ink-700">
+            {label}
+          </label>
+        )}
+        <div className="relative">
+          {leftIcon && (
+            <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-ink-400">
+              {leftIcon}
+            </span>
+          )}
+          <input
+            ref={ref}
+            id={inputId}
+            type={type}
+            aria-invalid={error ? true : undefined}
+            aria-describedby={describedBy}
+            className={clsx(
+              'input-brand',
+              leftIcon && 'pl-10',
+              error && 'border-rose-400 focus:border-rose-500',
+              props.disabled && 'cursor-not-allowed bg-ink-50 text-ink-400',
+              className,
+            )}
+            {...props}
+          />
+        </div>
+        {hint && !error && (
+          <p id={hintId} className="mt-1.5 text-xs text-ink-500">
+            {hint}
+          </p>
+        )}
+        {error && (
+          <p id={errorId} className="mt-1.5 text-xs font-medium text-rose-600">
+            {error}
+          </p>
+        )}
+      </div>
+    );
+  },
+);
+
+Input.displayName = 'Input';
+
+interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement>, FieldChromeProps {}
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ label, hint, error, block = true, className, id, rows = 4, ...props }, ref) => {
+    const reactId = useId();
+    const fieldId = id ?? `${reactId}-textarea`;
+    const hintId = hint ? `${fieldId}-hint` : undefined;
+    const errorId = error ? `${fieldId}-error` : undefined;
+    const describedBy = [hintId, errorId].filter(Boolean).join(' ') || undefined;
+    return (
+      <div className={clsx(block && 'w-full')}>
+        {label && (
+          <label htmlFor={fieldId} className="mb-1.5 block text-sm font-medium text-ink-700">
+            {label}
+          </label>
+        )}
+        <textarea
+          ref={ref}
+          id={fieldId}
+          rows={rows}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={describedBy}
+          className={clsx(
+            'input-brand resize-y',
+            error && 'border-rose-400 focus:border-rose-500',
+            props.disabled && 'cursor-not-allowed bg-ink-50 text-ink-400',
+            className,
+          )}
+          {...props}
+        />
+        {hint && !error && (
+          <p id={hintId} className="mt-1.5 text-xs text-ink-500">
+            {hint}
+          </p>
+        )}
+        {error && (
+          <p id={errorId} className="mt-1.5 text-xs font-medium text-rose-600">
+            {error}
+          </p>
+        )}
+      </div>
+    );
+  },
+);
+
+Textarea.displayName = 'Textarea';
+
+interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement>, FieldChromeProps {}
+
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(
+  ({ label, hint, error, block = true, className, id, children, ...props }, ref) => {
+    const reactId = useId();
+    const fieldId = id ?? `${reactId}-select`;
+    const hintId = hint ? `${fieldId}-hint` : undefined;
+    const errorId = error ? `${fieldId}-error` : undefined;
+    const describedBy = [hintId, errorId].filter(Boolean).join(' ') || undefined;
+    return (
+      <div className={clsx(block && 'w-full')}>
+        {label && (
+          <label htmlFor={fieldId} className="mb-1.5 block text-sm font-medium text-ink-700">
+            {label}
+          </label>
+        )}
+        <select
+          ref={ref}
+          id={fieldId}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={describedBy}
+          className={clsx(
+            'input-brand appearance-none pr-10 bg-no-repeat',
+            error && 'border-rose-400 focus:border-rose-500',
+            props.disabled && 'cursor-not-allowed bg-ink-50 text-ink-400',
+            className,
+          )}
+          style={{
+            backgroundImage:
+              "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'><path d='M1 1l5 5 5-5' stroke='%23737373' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/></svg>\")",
+            backgroundPosition: 'right 0.85rem center',
+          }}
+          {...props}
+        >
+          {children}
+        </select>
+        {hint && !error && (
+          <p id={hintId} className="mt-1.5 text-xs text-ink-500">
+            {hint}
+          </p>
+        )}
+        {error && (
+          <p id={errorId} className="mt-1.5 text-xs font-medium text-rose-600">
+            {error}
+          </p>
+        )}
+      </div>
+    );
+  },
+);
+
+Select.displayName = 'Select';

--- a/frontend_modern/src/shared/ui/README.md
+++ b/frontend_modern/src/shared/ui/README.md
@@ -32,11 +32,15 @@ new screens from these, not from raw Tailwind. Full plan:
 | `Badge` | Status pill — `tone: 'brand' \| 'neutral' \| 'success' \| 'attention' \| 'urgent'`. |
 | `RichContent` | Sanitised HTML + KaTeX renderer (`text`, `variant`). Use for any question/option/solution/hint content from the API. |
 | `Skeleton` | Branded loading placeholder (`w`, `h`, `rounded`). Warm `ink-100` pulse. |
+| `Input` / `Textarea` / `Select` | Form fields with brand chrome — `label`, `hint`, `error`, `leftIcon`. ARIA wired. |
+| `Stat` | KPI block — big display-font `value`, small label, optional trend `delta` + `tone`. |
+| `SectionHeading` | Section title in `font-display` — optional `eyebrow`, `description`, right-aligned `action`. |
+| `EmptyState` | "Nothing here yet" surface — keyhole glyph, headline, body, optional primary action. |
 
-## Wanted next (see backlog `M1-06`)
+## Wanted next
 
-`Input`, `Stat`, `SectionHeading`, `EmptyState` (keyhole motif),
-`ProgressRing` ("unlock" mastery).
+`ProgressRing` ("unlock" mastery), `LoadingSpinner` (keyhole-derived),
+`ErrorBoundary`/404 fallback.
 
 ## Adding a component
 

--- a/frontend_modern/src/shared/ui/SectionHeading.test.tsx
+++ b/frontend_modern/src/shared/ui/SectionHeading.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SectionHeading } from './SectionHeading';
+
+describe('<SectionHeading />', () => {
+  it('renders title as h2 by default', () => {
+    render(<SectionHeading title="Assignments due" />);
+    const heading = screen.getByRole('heading', { name: 'Assignments due' });
+    expect(heading.tagName).toBe('H2');
+  });
+
+  it('renders as h1 when `as` is set', () => {
+    render(<SectionHeading title="Dashboard" as="h1" />);
+    const heading = screen.getByRole('heading', { name: 'Dashboard' });
+    expect(heading.tagName).toBe('H1');
+  });
+
+  it('renders eyebrow, description and action slot', () => {
+    render(
+      <SectionHeading
+        eyebrow="Today"
+        title="Practice"
+        description="Pick something to work on"
+        action={<a href="/all">View all</a>}
+      />,
+    );
+    expect(screen.getByText('Today')).toBeInTheDocument();
+    expect(screen.getByText('Pick something to work on')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'View all' })).toBeInTheDocument();
+  });
+});

--- a/frontend_modern/src/shared/ui/SectionHeading.tsx
+++ b/frontend_modern/src/shared/ui/SectionHeading.tsx
@@ -1,0 +1,48 @@
+import clsx from 'clsx';
+import { createElement, HTMLAttributes, ReactNode } from 'react';
+
+interface SectionHeadingProps extends Omit<HTMLAttributes<HTMLElement>, 'title'> {
+  title: ReactNode;
+  /** Small uppercase pre-title (e.g. section category). */
+  eyebrow?: ReactNode;
+  /** Subtle description rendered below the title. */
+  description?: ReactNode;
+  /** Right-aligned slot (e.g. a "View all" link). */
+  action?: ReactNode;
+  /** Heading element to render (semantic level). Defaults to `h2`. */
+  as?: 'h1' | 'h2' | 'h3' | 'h4';
+}
+
+/**
+ * Section header in the V2 brand language. `font-display` title, optional
+ * eyebrow + description, and an action slot for inline links like "View all".
+ */
+export const SectionHeading = ({
+  title,
+  eyebrow,
+  description,
+  action,
+  as = 'h2',
+  className,
+  ...props
+}: SectionHeadingProps) => {
+  const headingSize = as === 'h1' ? 'text-3xl sm:text-4xl' : as === 'h2' ? 'text-2xl' : 'text-xl';
+  return (
+    <div className={clsx('flex items-end justify-between gap-4', className)} {...props}>
+      <div className="min-w-0">
+        {eyebrow && (
+          <p className="mb-1 text-xs font-semibold uppercase tracking-widest text-brand-600">
+            {eyebrow}
+          </p>
+        )}
+        {createElement(
+          as,
+          { className: clsx('font-display font-semibold text-ink-900', headingSize) },
+          title,
+        )}
+        {description && <p className="mt-1.5 max-w-2xl text-sm text-ink-500">{description}</p>}
+      </div>
+      {action && <div className="shrink-0 self-end">{action}</div>}
+    </div>
+  );
+};

--- a/frontend_modern/src/shared/ui/Stat.test.tsx
+++ b/frontend_modern/src/shared/ui/Stat.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Stat } from './Stat';
+
+describe('<Stat />', () => {
+  it('renders label and value', () => {
+    render(<Stat label="Streak" value="14d" />);
+    expect(screen.getByText('Streak')).toBeInTheDocument();
+    expect(screen.getByText('14d')).toBeInTheDocument();
+  });
+
+  it('renders delta badge when provided', () => {
+    render(<Stat label="Score" value="84%" delta="+6%" tone="success" />);
+    expect(screen.getByText('+6%')).toBeInTheDocument();
+  });
+
+  it('renders optional hint text', () => {
+    render(<Stat label="Due" value="3" hint="of 5 assignments" />);
+    expect(screen.getByText('of 5 assignments')).toBeInTheDocument();
+  });
+});

--- a/frontend_modern/src/shared/ui/Stat.tsx
+++ b/frontend_modern/src/shared/ui/Stat.tsx
@@ -1,0 +1,41 @@
+import clsx from 'clsx';
+import { HTMLAttributes, ReactNode } from 'react';
+import { Badge } from './Badge';
+
+type Tone = 'brand' | 'neutral' | 'success' | 'attention' | 'urgent';
+
+interface StatProps extends HTMLAttributes<HTMLDivElement> {
+  label: ReactNode;
+  value: ReactNode;
+  /** Optional trend or delta text (e.g. "+12% this week"). */
+  delta?: ReactNode;
+  /** Tone for the optional delta pill. */
+  tone?: Tone;
+  /** Optional small caption rendered under the value (e.g. context like "of 20 due"). */
+  hint?: ReactNode;
+}
+
+/**
+ * Headline metric block — used for dashboard KPIs. Big display-font value over a
+ * small uppercase label, with an optional trend pill.
+ */
+export const Stat = ({
+  label,
+  value,
+  delta,
+  tone = 'neutral',
+  hint,
+  className,
+  ...props
+}: StatProps) => (
+  <div className={clsx('flex flex-col gap-1', className)} {...props}>
+    <p className="text-xs font-semibold uppercase tracking-widest text-ink-400">{label}</p>
+    <div className="flex items-baseline gap-3">
+      <span className="font-display text-3xl font-semibold text-ink-900 sm:text-4xl">
+        {value}
+      </span>
+      {delta && <Badge tone={tone}>{delta}</Badge>}
+    </div>
+    {hint && <p className="text-xs text-ink-500">{hint}</p>}
+  </div>
+);

--- a/frontend_modern/src/shared/ui/index.ts
+++ b/frontend_modern/src/shared/ui/index.ts
@@ -11,3 +11,7 @@ export { renderRichContent } from './renderRichContent';
 export { InteractiveWidget } from './InteractiveWidget';
 export type { InteractiveWidgetProps } from './InteractiveWidget';
 export { Skeleton } from './Skeleton';
+export { Input, Textarea, Select } from './Input';
+export { Stat } from './Stat';
+export { SectionHeading } from './SectionHeading';
+export { EmptyState } from './EmptyState';


### PR DESCRIPTION
## Summary
Closes **M1-06** of the [V2 "Chalk & Unlock" design-system initiative](docs/initiatives/2026-design-system-v2.md). Adds the four foundation primitives every M4 dashboard migration needs:

- **`Input` / `Textarea` / `Select`** — labelled form fields with `hint`, `error`, `leftIcon`, ARIA wiring (`aria-invalid` + `aria-describedby`), focus-visible ring, disabled state.
- **`Stat`** — KPI block for dashboard headlines: big `font-display` value, small uppercase label, optional `delta` pill + `hint`.
- **`SectionHeading`** — `font-display` section title with optional `eyebrow`, `description`, right-aligned `action` slot. `as` prop sets semantic level.
- **`EmptyState`** — canonical "nothing here yet" surface on `.os-card`, brand keyhole glyph, optional primary action.

## Classification
**New** — additive only. No existing pages touched.

## What changed
- New files in `frontend_modern/src/shared/ui/`: `Input.tsx`, `Stat.tsx`, `SectionHeading.tsx`, `EmptyState.tsx` (+ `*.test.tsx` for each).
- Exported from `src/shared/ui/index.ts`.
- Every variant rendered on the `/design` route (Input default/error/disabled, Select, Textarea, Stat with/without delta, SectionHeading with/without action, EmptyState with/without action).
- `shared/ui/README.md` table updated.

## Tests
- 4 new `*.test.tsx` files — render-smoke per primitive (default + key variants).
- Frontend: `npm run type-check`, `npm run lint`, `npm run build`, `npm test` — all green (40/40).

## How to verify
- `cd frontend_modern && npm run dev`, open `/design`, scroll to "Form inputs" / "Stats" / "Section heading" / "Empty state" — every variant should render with brand tokens (no `indigo`/`primary`/raw hex).
- `grep -nE "indigo|primary-|#[0-9a-fA-F]{3,6}" frontend_modern/src/shared/ui/{Input,Stat,SectionHeading,EmptyState}.tsx` → only `#737373` chevron icon (the muted ink colour for native select arrow).

## Next
This unlocks PRs 3/4/5 of today's batch (register flow, Student Dash, Teacher Dash) which all import these primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)