### PR TITLE
feat(ui): M2-03 — branded spinner, 404 page, error boundary

### DIFF
--- a/docs/changes/2026-06-02-global-states.md
+++ b/docs/changes/2026-06-02-global-states.md
@@ -1,0 +1,53 @@
+# 2026-06-02 — Global states: branded spinner, 404, error boundary (M2-03)
+
+## Summary
+Replace the legacy indigo spinner / plain-text 404 / missing error-recovery surface
+with branded V2 equivalents. Closes **M2-03** of the
+[V2 design-system initiative](../initiatives/2026-design-system-v2.md).
+
+## Classification
+**New** + **Improve** — re-brand existing `LoadingSpinner` chrome, add new
+`ErrorBoundary` and `NotFoundPage`, wire both into `App.tsx`.
+
+## What changed
+- `src/shared/components/LoadingSpinner.tsx` — repainted from `border-indigo-600` to
+  a `brand-100` track + `brand-600` head, sizes use `border-2`/`border-[3px]`
+  rings instead of a single bottom-border arc. Uses `motion-safe:animate-spin`
+  so `prefers-reduced-motion` users see a static ring.
+- `src/shared/ui/LoadingSpinner.tsx` — canonical V2 re-export so new code imports
+  from `@/shared/ui`.
+- `src/shared/ui/ErrorBoundary.tsx` — class-component fallback with warm `.os-card`
+  recovery surface, rose alert icon, "Try again" CTA, optional custom `fallback`.
+- `src/features/shared/NotFoundPage.tsx` — warm-paper 404 with `Logo`, big
+  `font-display` "404", calm copy, "Back to home" CTA.
+- `src/App.tsx` — replaced inline `NotFound` with `NotFoundPage`; wrapped
+  `<Routes>` in `<ErrorBoundary>` so render-time errors anywhere under the
+  router fall back gracefully without swallowing auth redirects.
+- `/design` route gained "Loading spinner" and "404 / error boundary" preview
+  sections.
+
+## Why
+Any route can hit a full-screen unbranded state (spinner / 404 / crash) and
+break the brand. This PR makes all three on-brand without introducing a toast
+dependency (`react-hot-toast` not present today — left as a follow-up per the
+plan).
+
+## Tests
+- `ErrorBoundary.test.tsx` — renders children when no error; renders default
+  fallback when child throws; supports custom `fallback`.
+- `NotFoundPage.test.tsx` — renders "404", headline, and a "Back to home" link
+  targeting `/`.
+- Frontend: `npm run type-check`, `npm run lint`, `npm run build`,
+  `npm test` — all green (58/58).
+
+## How to verify
+- `cd frontend_modern && npm run dev`. Visit `/design` and scroll to "Loading
+  spinner" + "404 / error boundary" sections.
+- Visit `/this-route-does-not-exist` → branded 404 with keyhole logo and back-home link.
+- Toggle OS reduced-motion → the spinner becomes a static ring.
+
+## Next
+- PR 3 — register flow → V2 (uses new `Input` from PR 1).
+- PR 4 — Student Dashboard → V2.
+- PR 5 — Teacher Dashboard → V2.
+- Follow-up: theme `react-hot-toast` once / if it's introduced.

--- a/frontend_modern/src/App.tsx
+++ b/frontend_modern/src/App.tsx
@@ -30,12 +30,8 @@ import { AdminDashboard } from './features/admin/AdminDashboard';
 import { ClassroomManagePage } from './features/admin/ClassroomManagePage';
 import { UserRole } from './types/index';
 import { LoadingSpinner } from './shared/components/LoadingSpinner';
-
-const NotFound = () => (
-  <div className="text-center py-16">
-    <h2 className="text-2xl font-semibold text-gray-700">404 - Page Not Found</h2>
-  </div>
-);
+import { ErrorBoundary } from './shared/ui';
+import { NotFoundPage } from './features/shared/NotFoundPage';
 
 function App() {
   const { isAuthenticated, isLoading, user } = useAuth();
@@ -58,6 +54,7 @@ function App() {
 
   return (
     <Router>
+      <ErrorBoundary>
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
@@ -287,8 +284,9 @@ function App() {
         />
 
         <Route path="/" element={isAuthenticated ? <Navigate to={defaultPath} replace /> : <HomePage />} />
-        <Route path="*" element={<NotFound />} />
+        <Route path="*" element={<NotFoundPage />} />
       </Routes>
+      </ErrorBoundary>
     </Router>
   );
 }

--- a/frontend_modern/src/features/design/DesignSystemPage.tsx
+++ b/frontend_modern/src/features/design/DesignSystemPage.tsx
@@ -1,4 +1,4 @@
-import { Logo, Button, Card, Badge, RichContent, InteractiveWidget, Skeleton } from '@/shared/ui';
+import { Logo, Button, Card, Badge, RichContent, InteractiveWidget, Skeleton, LoadingSpinner } from '@/shared/ui';
 
 /**
  * Living catalogue of the V2 "Chalk & Unlock" design system. Every new `ui/`
@@ -197,6 +197,41 @@ export const DesignSystemPage = () => (
           <Skeleton w="w-full" h="h-4" />
           <Skeleton w="w-5/6" h="h-4" />
           <Skeleton w="w-2/3" h="h-4" />
+        </Card>
+      </Section>
+
+      <Section kicker="States" title="Loading spinner">
+        <Card className="flex flex-wrap items-center gap-8">
+          <div className="flex flex-col items-center gap-2">
+            <LoadingSpinner size="sm" />
+            <span className="text-xs text-ink-500">sm</span>
+          </div>
+          <div className="flex flex-col items-center gap-2">
+            <LoadingSpinner size="md" />
+            <span className="text-xs text-ink-500">md</span>
+          </div>
+          <div className="flex flex-col items-center gap-2">
+            <LoadingSpinner size="lg" />
+            <span className="text-xs text-ink-500">lg</span>
+          </div>
+          <p className="ml-auto max-w-xs text-xs text-ink-500">
+            Honours <code>prefers-reduced-motion</code> — the ring is static when
+            reduced motion is requested.
+          </p>
+        </Card>
+      </Section>
+
+      <Section kicker="States" title="404 / error boundary">
+        <Card>
+          <p className="mb-3 text-sm text-ink-500">
+            Unknown URLs render <code>NotFoundPage</code> (the catch-all route).
+            Render-time errors anywhere under the router render the
+            <code> ErrorBoundary</code> fallback. Both surfaces use the warm
+            paper background, brand keyhole motif, and a single primary action.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <a href="/this-route-does-not-exist" className="btn-ghost">Preview 404</a>
+          </div>
         </Card>
       </Section>
 

--- a/frontend_modern/src/features/shared/NotFoundPage.test.tsx
+++ b/frontend_modern/src/features/shared/NotFoundPage.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { NotFoundPage } from './NotFoundPage';
+
+describe('<NotFoundPage />', () => {
+  it('renders 404, headline and back-home link', () => {
+    render(
+      <MemoryRouter>
+        <NotFoundPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('404')).toBeInTheDocument();
+    expect(screen.getByText(/Nothing behind this door/i)).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /Back to home/i });
+    expect(link).toHaveAttribute('href', '/');
+  });
+});

--- a/frontend_modern/src/features/shared/NotFoundPage.tsx
+++ b/frontend_modern/src/features/shared/NotFoundPage.tsx
@@ -1,0 +1,23 @@
+import { Link } from 'react-router-dom';
+import { Logo } from '@/shared/ui';
+
+/**
+ * Branded 404 page. Warm paper, keyhole mark, calm copy, "Back home" CTA. The
+ * catch-all `*` route in `App.tsx` renders this.
+ */
+export const NotFoundPage = () => (
+  <div className="bg-paper flex min-h-screen flex-col items-center justify-center px-6 py-12 text-center">
+    <Logo size="lg" float />
+    <p className="mt-8 font-display text-6xl font-semibold text-brand-600 sm:text-7xl">404</p>
+    <h1 className="mt-4 font-display text-2xl font-semibold text-ink-900 sm:text-3xl">
+      Nothing behind this door
+    </h1>
+    <p className="mt-3 max-w-md text-ink-500">
+      The page you were looking for has moved or never existed. Let&apos;s get
+      you back to learning.
+    </p>
+    <Link to="/" className="btn-brand mt-8">
+      Back to home
+    </Link>
+  </div>
+);

--- a/frontend_modern/src/shared/components/LoadingSpinner.tsx
+++ b/frontend_modern/src/shared/components/LoadingSpinner.tsx
@@ -1,17 +1,26 @@
 interface LoadingSpinnerProps {
   size?: 'sm' | 'md' | 'lg';
+  /** Optional descriptive label for screen readers. */
+  label?: string;
 }
 
 const sizeClasses = {
-  sm: 'h-4 w-4',
-  md: 'h-8 w-8',
-  lg: 'h-12 w-12',
+  sm: 'h-4 w-4 border-2',
+  md: 'h-8 w-8 border-2',
+  lg: 'h-12 w-12 border-[3px]',
 };
 
-export const LoadingSpinner = ({ size = 'md' }: LoadingSpinnerProps) => (
+/**
+ * Branded loading spinner — a keyhole-inspired ring in `brand-600` on a soft
+ * `brand-100` track. `motion-safe:animate-spin` honours `prefers-reduced-motion`
+ * by rendering as a static ring.
+ */
+export const LoadingSpinner = ({ size = 'md', label = 'Loading' }: LoadingSpinnerProps) => (
   <div
-    className={`animate-spin rounded-full border-b-2 border-indigo-600 ${sizeClasses[size]}`}
     role="status"
-    aria-label="Loading"
-  />
+    aria-label={label}
+    className={`inline-block rounded-full border-brand-100 border-t-brand-600 motion-safe:animate-spin ${sizeClasses[size]}`}
+  >
+    <span className="sr-only">{label}</span>
+  </div>
 );

--- a/frontend_modern/src/shared/ui/ErrorBoundary.test.tsx
+++ b/frontend_modern/src/shared/ui/ErrorBoundary.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ErrorBoundary } from './ErrorBoundary';
+
+const Boom = ({ shouldThrow }: { shouldThrow: boolean }) => {
+  if (shouldThrow) throw new Error('kaboom');
+  return <p>healthy</p>;
+};
+
+describe('<ErrorBoundary />', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it('renders children when no error', () => {
+    render(
+      <ErrorBoundary>
+        <Boom shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('healthy')).toBeInTheDocument();
+  });
+
+  it('renders default fallback when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <Boom shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
+  });
+
+  it('renders a custom fallback when supplied', () => {
+    render(
+      <ErrorBoundary fallback={(err) => <p>custom: {err.message}</p>}>
+        <Boom shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('custom: kaboom')).toBeInTheDocument();
+  });
+});

--- a/frontend_modern/src/shared/ui/ErrorBoundary.tsx
+++ b/frontend_modern/src/shared/ui/ErrorBoundary.tsx
@@ -1,0 +1,84 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  /** Optional custom fallback. Receives the error + a reset handler. */
+  fallback?: (error: Error, reset: () => void) => ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+/**
+ * V2 error boundary. Catches render-time errors in its subtree and shows a
+ * warm-paper recovery card with a "Try again" action. Must be a class component
+ * — hooks can't catch errors.
+ *
+ * Wrap the authenticated content outlet, NOT the router or auth gate, so that
+ * navigation/redirects aren't swallowed.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    if (typeof console !== 'undefined') {
+      console.error('[ErrorBoundary]', error, info.componentStack);
+    }
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    if (this.state.error) {
+      if (this.props.fallback) {
+        return this.props.fallback(this.state.error, this.reset);
+      }
+      return (
+        <div className="bg-paper flex min-h-[60vh] items-center justify-center px-6 py-12">
+          <div className="os-card max-w-md p-8 text-center">
+            <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-rose-100">
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+                width="28"
+                height="28"
+                fill="none"
+                className="text-rose-600"
+              >
+                <path
+                  d="M12 8v5m0 3h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4.99c-.77-1.33-2.69-1.33-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3z"
+                  stroke="currentColor"
+                  strokeWidth="1.8"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+            <h2 className="font-display text-xl font-semibold text-ink-900">
+              Something went wrong
+            </h2>
+            <p className="mt-2 text-sm text-ink-500">
+              The page hit an unexpected error. Try again — if it keeps happening,
+              reload the app or sign in again.
+            </p>
+            <button
+              type="button"
+              onClick={this.reset}
+              className="btn-brand mt-6"
+            >
+              Try again
+            </button>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/frontend_modern/src/shared/ui/LoadingSpinner.tsx
+++ b/frontend_modern/src/shared/ui/LoadingSpinner.tsx
@@ -1,0 +1,2 @@
+// Canonical V2 re-export so new code imports `LoadingSpinner` from `@/shared/ui`.
+export { LoadingSpinner } from '../components/LoadingSpinner';

--- a/frontend_modern/src/shared/ui/index.ts
+++ b/frontend_modern/src/shared/ui/index.ts
@@ -11,3 +11,5 @@ export { renderRichContent } from './renderRichContent';
 export { InteractiveWidget } from './InteractiveWidget';
 export type { InteractiveWidgetProps } from './InteractiveWidget';
 export { Skeleton } from './Skeleton';
+export { LoadingSpinner } from './LoadingSpinner';
+export { ErrorBoundary } from './ErrorBoundary';


### PR DESCRIPTION
## Summary
Closes **M2-03** of the [V2 design-system initiative](docs/initiatives/2026-design-system-v2.md). Removes the last unbranded full-screen states the app can hit.

- **`LoadingSpinner`** repainted from `border-indigo-600` → `border-brand-100`/`border-t-brand-600` ring. Uses `motion-safe:animate-spin` so `prefers-reduced-motion` users see a static ring. Same API; every existing call site picks it up automatically.
- **`NotFoundPage`** — warm-paper 404 with `<Logo>` keyhole, big `font-display` "404", calm copy, "Back to home" CTA. Wired as `*` catch-all route in `App.tsx`.
- **`ErrorBoundary`** — class-component fallback (warm `.os-card`, rose alert glyph, "Try again" reset CTA, optional custom \`fallback\` prop). Wraps `<Routes>` inside `<Router>` so render-time errors fall back gracefully without swallowing auth/route redirects.
- `/design` route gained "Loading spinner" and "404 / error boundary" preview sections.

## Classification
**New** (`ErrorBoundary`, `NotFoundPage`) + **Improve** (`LoadingSpinner` re-paint).

## Toast — deliberately deferred
Per the plan: \`react-hot-toast\` (or any toast lib) isn't in the tree today, so adding one would expand scope. Themed-toast slated as a follow-up when a toast mechanism is introduced.

## Tests
- `ErrorBoundary.test.tsx` — renders children when no error; default fallback when a child throws; supports custom `fallback`.
- `NotFoundPage.test.tsx` — renders "404", headline, and a back-home link to `/`.
- All frontend tests green (58/58). `type-check`, `lint`, `build` clean.

## How to verify
- `cd frontend_modern && npm run dev`
- Hit \`/this-route-does-not-exist\` → branded 404.
- Visit \`/design\` → "Loading spinner" + "404 / error boundary" sections.
- Toggle OS reduced-motion → spinner becomes static.

🤖 Generated with [Claude Code](https://claude.com/claude-code)