### PR TITLE
feat(auth): M3-02 — migrate register flow to V2 brand

### DIFF
--- a/docs/changes/2026-06-02-register-v2.md
+++ b/docs/changes/2026-06-02-register-v2.md
@@ -1,0 +1,54 @@
+# 2026-06-02 — Register flow → V2 brand (M3-02)
+
+## Summary
+Re-skin the three register routes — `/register`, `/register/school`,
+`/register/open` — into the same chalkboard-left / paper-right brand layout the
+shipped `LoginPage` already uses. Closes **M3-02** of the
+[V2 design-system initiative](../initiatives/2026-design-system-v2.md).
+
+## Classification
+**Improve** — pure visual migration. Form `name`s, submit endpoints, and
+validation logic are untouched.
+
+## What changed
+- New `AuthLayout` wrapper in `src/features/auth/AuthLayout.tsx` —
+  chalkboard hero (`.bg-chalkboard` + `<Logo>`) + paper form panel. Mirrors
+  `LoginPage` so login + register read as one branded flow.
+- `RegisterPage` re-skinned: two `.os-card` choice tiles with brand keyhole
+  vibe (brand-tinted "Join a school", emerald-tinted "Study independently"),
+  brand link styling.
+- `RegisterSchoolPage` re-skinned: replaced the bespoke `FormField`/blue
+  Bootstrap-ish form with `<Input>` / `<Button>` primitives from `shared/ui`;
+  classroom-join-code field keeps the mono uppercase styling.
+- `RegisterOpenPage` re-skinned: same `Input`/`Button` migration; CTA text
+  remains "Start practising".
+- All three pages use the new `AuthLayout` for consistency.
+
+## Token cleanup
+`grep -nE "indigo|gray-50|primary-" src/features/auth/{Register*,AuthLayout}.tsx`
+returns nothing.
+
+## Why
+The brand shell, login, and home page already speak V2 — but the register
+flow still landed on cold blue-gradient backgrounds with the old `OS` square
+logo, breaking brand continuity on the only screens new users see. This PR
+makes onboarding feel like one product.
+
+## Tests
+- Existing test suite stays green (69/69).
+- `type-check`, `lint`, `build` clean.
+- Token grep returns 0 hits on touched files.
+
+## How to verify
+- `npm run dev` → visit `/register`, `/register/school`, `/register/open` →
+  each renders the chalkboard-left / paper-right layout with the keyhole logo;
+  forms use the brand `.input-brand` inputs and `btn-brand` CTA.
+- Submit the school form with a valid join code → existing mutation still fires.
+
+## Notes
+- Depends on PR 1 (Input primitive). Branched off
+  `feat/2026-06-02-ui-primitives`.
+
+## Next
+- PR 4 — Student Dashboard → V2.
+- PR 5 — Teacher Dashboard → V2.

--- a/frontend_modern/src/features/auth/AuthLayout.tsx
+++ b/frontend_modern/src/features/auth/AuthLayout.tsx
@@ -1,0 +1,59 @@
+import { Link } from 'react-router-dom';
+import { ReactNode } from 'react';
+import { Logo } from '@/shared/ui';
+
+interface AuthLayoutProps {
+  /** Headline rendered above the form panel content. */
+  title: string;
+  /** Subhead under the title. */
+  subtitle?: string;
+  /** The form (or any content) for the right-hand paper panel. */
+  children: ReactNode;
+  /** Optional small footer rendered under the form (e.g. "Sign in" link). */
+  footer?: ReactNode;
+}
+
+/**
+ * Two-column auth shell — chalkboard hero on the left, warm paper form panel
+ * on the right. Mirrors `LoginPage`'s layout so login + register all read as
+ * one branded flow.
+ */
+export const AuthLayout = ({ title, subtitle, children, footer }: AuthLayoutProps) => (
+  <div className="grid min-h-screen lg:grid-cols-2">
+    {/* Brand panel (chalkboard heritage) — hidden on small screens */}
+    <div className="bg-chalkboard relative hidden flex-col justify-between overflow-hidden p-12 lg:flex">
+      <Link to="/" aria-label="OpenShiksha home" className="w-fit">
+        <Logo size="md" wordmarkClassName="text-white" />
+      </Link>
+      <div className="max-w-md">
+        <h2 className="font-display text-4xl font-semibold leading-tight text-white text-balance">
+          Unlock learning, one question at a time.
+        </h2>
+        <p className="mt-4 text-ink-200">
+          Adaptive practice, instant correction, and analytics that show every
+          student exactly what to learn next.
+        </p>
+      </div>
+      <p className="text-sm text-ink-300">Non-profit · CBSE · English &amp; हिन्दी</p>
+    </div>
+
+    {/* Form panel (paper) */}
+    <div className="bg-paper flex items-center justify-center px-6 py-12">
+      <div className="w-full max-w-sm animate-fade-up">
+        {/* Compact brand for mobile (brand panel is hidden there) */}
+        <div className="mb-8 lg:hidden">
+          <Link to="/" aria-label="OpenShiksha home" className="inline-block">
+            <Logo size="md" />
+          </Link>
+        </div>
+
+        <h1 className="font-display text-3xl font-semibold text-ink-900">{title}</h1>
+        {subtitle && <p className="mt-1 text-ink-500">{subtitle}</p>}
+
+        <div className="mt-8">{children}</div>
+
+        {footer && <div className="mt-8 space-y-2 text-sm text-ink-500">{footer}</div>}
+      </div>
+    </div>
+  </div>
+);

--- a/frontend_modern/src/features/auth/RegisterOpenPage.tsx
+++ b/frontend_modern/src/features/auth/RegisterOpenPage.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { Button, Input } from '@/shared/ui';
+import { AuthLayout } from './AuthLayout';
 import { useRegisterOpenMutation } from './useRegisterMutation';
 import type { AxiosError } from 'axios';
 
@@ -36,85 +38,49 @@ export const RegisterOpenPage = () => {
     });
   };
 
+  const disabled = mutation.isPending;
+
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-emerald-50 to-teal-100 py-12 px-4">
-      <div className="w-full max-w-md">
-        <div className="text-center mb-8">
-          <div className="inline-flex items-center justify-center w-16 h-16 bg-emerald-600 rounded-2xl mb-4 shadow-lg">
-            <span className="text-white text-2xl font-bold">OS</span>
-          </div>
-          <h1 className="text-2xl font-bold text-gray-900">Study Independently</h1>
-          <p className="text-gray-500 mt-1 text-sm">Access the shared question bank for free</p>
-        </div>
-
-        <div className="bg-white rounded-2xl shadow-xl p-8">
-          <form onSubmit={handleSubmit} noValidate>
-            <div className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
-                <FormField label="First Name" id="first_name" value={form.first_name} onChange={set('first_name')} disabled={mutation.isPending} />
-                <FormField label="Last Name" id="last_name" value={form.last_name} onChange={set('last_name')} disabled={mutation.isPending} />
-              </div>
-
-              <FormField label="Username" id="username" value={form.username} onChange={set('username')} required disabled={mutation.isPending} autoComplete="username" />
-              <FormField label="Password" id="password" type="password" value={form.password} onChange={set('password')} required disabled={mutation.isPending} autoComplete="new-password" />
-              <FormField label="Email (optional)" id="email" type="email" value={form.email} onChange={set('email')} disabled={mutation.isPending} autoComplete="email" />
-
-              {mutation.isError && (
-                <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700" role="alert">
-                  {extractError(mutation.error)}
-                </div>
-              )}
-
-              <button
-                type="submit"
-                disabled={mutation.isPending || !form.username || !form.password}
-                className="w-full py-2.5 px-4 bg-emerald-600 hover:bg-emerald-700 disabled:bg-emerald-400 text-white font-semibold rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2"
-              >
-                {mutation.isPending ? 'Creating account…' : 'Start Practising'}
-              </button>
-            </div>
-          </form>
-        </div>
-
-        <p className="text-center text-sm text-gray-500 mt-4">
-          <Link to="/register" className="text-emerald-600 hover:text-emerald-800">
+    <AuthLayout
+      title="Study independently"
+      subtitle="Access the shared question bank for free."
+      footer={
+        <p>
+          <Link to="/register" className="font-semibold text-brand-700 hover:text-brand-800">
             ← Back
           </Link>
           {' · '}
-          <Link to="/login" className="text-emerald-600 hover:text-emerald-800">
+          <Link to="/login" className="font-semibold text-brand-700 hover:text-brand-800">
             Sign in
           </Link>
         </p>
-      </div>
-    </div>
+      }
+    >
+      <form onSubmit={handleSubmit} noValidate className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <Input label="First name" id="first_name" value={form.first_name} onChange={set('first_name')} disabled={disabled} />
+          <Input label="Last name" id="last_name" value={form.last_name} onChange={set('last_name')} disabled={disabled} />
+        </div>
+
+        <Input label="Username" id="username" value={form.username} onChange={set('username')} required disabled={disabled} autoComplete="username" />
+        <Input label="Password" id="password" type="password" value={form.password} onChange={set('password')} required disabled={disabled} autoComplete="new-password" />
+        <Input label="Email (optional)" id="email" type="email" value={form.email} onChange={set('email')} disabled={disabled} autoComplete="email" />
+
+        {mutation.isError && (
+          <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700" role="alert">
+            {extractError(mutation.error)}
+          </div>
+        )}
+
+        <Button
+          type="submit"
+          size="lg"
+          disabled={disabled || !form.username || !form.password}
+          className="w-full"
+        >
+          {disabled ? 'Creating account…' : 'Start practising'}
+        </Button>
+      </form>
+    </AuthLayout>
   );
 };
-
-interface FormFieldProps {
-  label: string;
-  id: string;
-  value: string;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  type?: string;
-  required?: boolean;
-  disabled?: boolean;
-  autoComplete?: string;
-}
-
-const FormField = ({ label, id, value, onChange, type = 'text', required, disabled, autoComplete }: FormFieldProps) => (
-  <div>
-    <label htmlFor={id} className="block text-sm font-medium text-gray-700 mb-1">
-      {label} {required && <span className="text-red-500">*</span>}
-    </label>
-    <input
-      id={id}
-      type={type}
-      value={value}
-      onChange={onChange}
-      required={required}
-      disabled={disabled}
-      autoComplete={autoComplete}
-      className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent text-gray-900 placeholder-gray-400 disabled:bg-gray-50 disabled:text-gray-500"
-    />
-  </div>
-);

--- a/frontend_modern/src/features/auth/RegisterPage.tsx
+++ b/frontend_modern/src/features/auth/RegisterPage.tsx
@@ -1,70 +1,61 @@
 import { Link } from 'react-router-dom';
+import { AuthLayout } from './AuthLayout';
 
 export const RegisterPage = () => (
-  <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100">
-    <div className="w-full max-w-md">
-      <div className="text-center mb-8">
-        <div className="inline-flex items-center justify-center w-16 h-16 bg-indigo-600 rounded-2xl mb-4 shadow-lg">
-          <span className="text-white text-2xl font-bold">OS</span>
-        </div>
-        <h1 className="text-3xl font-bold text-gray-900">Create Account</h1>
-        <p className="text-gray-500 mt-1">How would you like to learn?</p>
-      </div>
-
-      <div className="space-y-4">
-        <Link
-          to="/register/school"
-          className="block w-full bg-white rounded-2xl shadow-lg p-6 hover:shadow-xl transition-shadow border border-gray-100 group"
-        >
-          <div className="flex items-start gap-4">
-            <div className="w-12 h-12 bg-indigo-50 rounded-xl flex items-center justify-center shrink-0 group-hover:bg-indigo-100 transition-colors">
-              <svg className="w-6 h-6 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                  d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
-                />
-              </svg>
-            </div>
-            <div>
-              <h2 className="text-lg font-semibold text-gray-900 group-hover:text-indigo-700 transition-colors">
-                Join a School
-              </h2>
-              <p className="text-sm text-gray-500 mt-1">
-                Use a classroom join code from your teacher to enroll automatically.
-              </p>
-            </div>
-          </div>
-        </Link>
-
-        <Link
-          to="/register/open"
-          className="block w-full bg-white rounded-2xl shadow-lg p-6 hover:shadow-xl transition-shadow border border-gray-100 group"
-        >
-          <div className="flex items-start gap-4">
-            <div className="w-12 h-12 bg-emerald-50 rounded-xl flex items-center justify-center shrink-0 group-hover:bg-emerald-100 transition-colors">
-              <svg className="w-6 h-6 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                  d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-                />
-              </svg>
-            </div>
-            <div>
-              <h2 className="text-lg font-semibold text-gray-900 group-hover:text-emerald-700 transition-colors">
-                Study Independently
-              </h2>
-              <p className="text-sm text-gray-500 mt-1">
-                Practice from the shared question bank at your own pace — no school needed.
-              </p>
-            </div>
-          </div>
-        </Link>
-      </div>
-
-      <p className="text-center text-sm text-gray-500 mt-6">
+  <AuthLayout
+    title="Create your account"
+    subtitle="How would you like to learn?"
+    footer={
+      <p>
         Already have an account?{' '}
-        <Link to="/login" className="text-indigo-600 hover:text-indigo-800 font-medium">
+        <Link to="/login" className="font-semibold text-brand-700 hover:text-brand-800">
           Sign in
         </Link>
       </p>
+    }
+  >
+    <div className="space-y-4">
+      <Link
+        to="/register/school"
+        className="os-card group flex items-start gap-4 p-5 transition-shadow hover:shadow-lift focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
+      >
+        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-brand-50 transition-colors group-hover:bg-brand-100">
+          <svg className="h-6 w-6 text-brand-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+              d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+            />
+          </svg>
+        </div>
+        <div className="min-w-0">
+          <h2 className="font-display text-lg font-semibold text-ink-900 group-hover:text-brand-700">
+            Join a school
+          </h2>
+          <p className="mt-1 text-sm text-ink-500">
+            Use a classroom join code from your teacher to enroll automatically.
+          </p>
+        </div>
+      </Link>
+
+      <Link
+        to="/register/open"
+        className="os-card group flex items-start gap-4 p-5 transition-shadow hover:shadow-lift focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
+      >
+        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-emerald-50 transition-colors group-hover:bg-emerald-100">
+          <svg className="h-6 w-6 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+              d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+            />
+          </svg>
+        </div>
+        <div className="min-w-0">
+          <h2 className="font-display text-lg font-semibold text-ink-900 group-hover:text-emerald-700">
+            Study independently
+          </h2>
+          <p className="mt-1 text-sm text-ink-500">
+            Practice from the shared question bank at your own pace — no school needed.
+          </p>
+        </div>
+      </Link>
     </div>
-  </div>
+  </AuthLayout>
 );

--- a/frontend_modern/src/features/auth/RegisterSchoolPage.tsx
+++ b/frontend_modern/src/features/auth/RegisterSchoolPage.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { Button, Input } from '@/shared/ui';
+import { AuthLayout } from './AuthLayout';
 import { useRegisterSchoolMutation } from './useRegisterMutation';
 import type { AxiosError } from 'axios';
 
@@ -38,104 +40,61 @@ export const RegisterSchoolPage = () => {
     });
   };
 
+  const disabled = mutation.isPending;
+
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 py-12 px-4">
-      <div className="w-full max-w-md">
-        <div className="text-center mb-8">
-          <div className="inline-flex items-center justify-center w-16 h-16 bg-indigo-600 rounded-2xl mb-4 shadow-lg">
-            <span className="text-white text-2xl font-bold">OS</span>
-          </div>
-          <h1 className="text-2xl font-bold text-gray-900">Join Your School</h1>
-          <p className="text-gray-500 mt-1 text-sm">Enter the join code from your teacher</p>
-        </div>
-
-        <div className="bg-white rounded-2xl shadow-xl p-8">
-          <form onSubmit={handleSubmit} noValidate>
-            <div className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
-                <FormField label="First Name" id="first_name" value={form.first_name} onChange={set('first_name')} disabled={mutation.isPending} />
-                <FormField label="Last Name" id="last_name" value={form.last_name} onChange={set('last_name')} disabled={mutation.isPending} />
-              </div>
-
-              <FormField label="Username" id="username" value={form.username} onChange={set('username')} required disabled={mutation.isPending} autoComplete="username" />
-              <FormField label="Password" id="password" type="password" value={form.password} onChange={set('password')} required disabled={mutation.isPending} autoComplete="new-password" />
-              <FormField label="Email (optional)" id="email" type="email" value={form.email} onChange={set('email')} disabled={mutation.isPending} autoComplete="email" />
-
-              <div>
-                <label htmlFor="join_code" className="block text-sm font-medium text-gray-700 mb-1">
-                  Classroom Join Code <span className="text-red-500">*</span>
-                </label>
-                <input
-                  id="join_code"
-                  type="text"
-                  required
-                  value={form.join_code}
-                  onChange={set('join_code')}
-                  disabled={mutation.isPending}
-                  placeholder="e.g. ABC123"
-                  className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent text-gray-900 uppercase tracking-widest font-mono placeholder-gray-400 placeholder:normal-case placeholder:tracking-normal placeholder:font-sans"
-                  maxLength={8}
-                />
-              </div>
-
-              {mutation.isError && (
-                <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700" role="alert">
-                  {extractError(mutation.error)}
-                </div>
-              )}
-
-              <button
-                type="submit"
-                disabled={mutation.isPending || !form.username || !form.password || !form.join_code}
-                className="w-full py-2.5 px-4 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white font-semibold rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-              >
-                {mutation.isPending ? 'Creating account…' : 'Create Account'}
-              </button>
-            </div>
-          </form>
-        </div>
-
-        <p className="text-center text-sm text-gray-500 mt-4">
-          <Link to="/register" className="text-indigo-600 hover:text-indigo-800">
+    <AuthLayout
+      title="Join your school"
+      subtitle="Enter the join code from your teacher."
+      footer={
+        <p>
+          <Link to="/register" className="font-semibold text-brand-700 hover:text-brand-800">
             ← Back
           </Link>
           {' · '}
-          <Link to="/login" className="text-indigo-600 hover:text-indigo-800">
+          <Link to="/login" className="font-semibold text-brand-700 hover:text-brand-800">
             Sign in
           </Link>
         </p>
-      </div>
-    </div>
+      }
+    >
+      <form onSubmit={handleSubmit} noValidate className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <Input label="First name" id="first_name" value={form.first_name} onChange={set('first_name')} disabled={disabled} />
+          <Input label="Last name" id="last_name" value={form.last_name} onChange={set('last_name')} disabled={disabled} />
+        </div>
+
+        <Input label="Username" id="username" value={form.username} onChange={set('username')} required disabled={disabled} autoComplete="username" />
+        <Input label="Password" id="password" type="password" value={form.password} onChange={set('password')} required disabled={disabled} autoComplete="new-password" />
+        <Input label="Email (optional)" id="email" type="email" value={form.email} onChange={set('email')} disabled={disabled} autoComplete="email" />
+
+        <Input
+          label="Classroom join code"
+          id="join_code"
+          value={form.join_code}
+          onChange={set('join_code')}
+          required
+          disabled={disabled}
+          placeholder="e.g. ABC123"
+          maxLength={8}
+          className="font-mono uppercase tracking-widest placeholder:font-sans placeholder:tracking-normal placeholder:normal-case"
+        />
+
+        {mutation.isError && (
+          <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700" role="alert">
+            {extractError(mutation.error)}
+          </div>
+        )}
+
+        <Button
+          type="submit"
+          size="lg"
+          disabled={disabled || !form.username || !form.password || !form.join_code}
+          className="w-full"
+        >
+          {disabled ? 'Creating account…' : 'Create account'}
+        </Button>
+      </form>
+    </AuthLayout>
   );
 };
-
-interface FormFieldProps {
-  label: string;
-  id: string;
-  value: string;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  type?: string;
-  required?: boolean;
-  disabled?: boolean;
-  autoComplete?: string;
-  placeholder?: string;
-}
-
-const FormField = ({ label, id, value, onChange, type = 'text', required, disabled, autoComplete, placeholder }: FormFieldProps) => (
-  <div>
-    <label htmlFor={id} className="block text-sm font-medium text-gray-700 mb-1">
-      {label} {required && <span className="text-red-500">*</span>}
-    </label>
-    <input
-      id={id}
-      type={type}
-      value={value}
-      onChange={onChange}
-      required={required}
-      disabled={disabled}
-      autoComplete={autoComplete}
-      placeholder={placeholder}
-      className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent text-gray-900 placeholder-gray-400 disabled:bg-gray-50 disabled:text-gray-500"
-    />
-  </div>
-);


### PR DESCRIPTION
## Summary
Closes **M3-02** of the [V2 design-system initiative](docs/initiatives/2026-design-system-v2.md). Re-skins the three register routes — `/register`, `/register/school`, `/register/open` — into the chalkboard-left / paper-right brand layout that the shipped `LoginPage` uses, so login + register read as one branded flow.

## Classification
**Improve** — pure visual migration. Form `name`s, submit endpoints, validation logic untouched.

## Changes
- New `features/auth/AuthLayout.tsx` — chalkboard hero with `<Logo>` + paper form panel. Mirrors `LoginPage`'s layout; both register subpages reuse it for consistency.
- `RegisterPage` — two `.os-card` choice tiles (brand-tinted "Join a school", emerald-tinted "Study independently"). Brand link styling, focus-visible rings.
- `RegisterSchoolPage` — bespoke `FormField` + blue Bootstrap-ish chrome replaced with `<Input>` / `<Button>` from `shared/ui`. Classroom-join-code retains mono uppercase styling via `className`.
- `RegisterOpenPage` — same primitive migration; CTA remains "Start practising".

## Token cleanup
\`\`\`
$ grep -nE "indigo|gray-50|primary-" frontend_modern/src/features/auth/{Register*,AuthLayout}.tsx
(no matches)
\`\`\`

## Dependency
Branched off [feat/2026-06-02-ui-primitives](https://github.com/openshiksha/openshiksha/pull/135) (PR 1) for the `Input` primitive. **PR base is set to that branch** — merge PR 1 first, then this; or rebase onto modernization after PR 1 lands.

## Tests
- All 69 existing tests stay green.
- `type-check`, `lint`, `build` clean.

## How to verify
- `npm run dev` → visit `/register`, `/register/school`, `/register/open` → each renders the chalkboard-left / paper-right layout, with keyhole logo, brand `.input-brand` fields and `btn-brand` CTAs.
- Submit the school form with a valid join code — existing mutation still posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)