### PR TITLE
feat(student): M4-01 — migrate Student Dashboard to V2 brand

### DIFF
--- a/docs/changes/2026-06-02-student-dashboard-v2.md
+++ b/docs/changes/2026-06-02-student-dashboard-v2.md
@@ -1,0 +1,46 @@
+# 2026-06-02 — Student Dashboard → V2 brand (M4-01)
+
+## Summary
+Re-skin `features/student/StudentDashboard.tsx` from the legacy
+indigo/gray-50 palette to the V2 "Chalk & Unlock" brand tokens. Closes
+**M4-01** of the [V2 design-system initiative](../initiatives/2026-design-system-v2.md).
+
+## Classification
+**Improve** — pure visual migration. No data hooks or panel internals touched.
+
+## What changed (token map)
+- `text-2xl font-bold text-gray-900` → `font-display text-3xl font-semibold text-ink-900`.
+- `text-gray-500` → `text-ink-500`.
+- "My Progress" link `text-indigo-600 hover:text-indigo-800` → `text-brand-700 hover:text-brand-800`.
+- Open-student "not enrolled" block (`border-indigo-200 bg-indigo-50
+  text-indigo-800` + custom `bg-indigo-600` button) → the V2 `EmptyState`
+  primitive with a brand `<Button>` CTA.
+- Error block kept warm `rose-` palette but switched to `rounded-xl`.
+
+## Scope
+Per the daily plan, this PR scopes to the dashboard's own JSX + empty state.
+Child panel internals (`DueForReviewPanel`, `RecommendationsPanel`,
+`AssignmentList`/`AssignmentCard`, `StreakBadge`, `AnnouncementsBanner`) keep
+their existing styling and remain in the M4 backlog as separate increments.
+
+## Token cleanup
+`grep -nE "indigo|gray-50|primary-" frontend_modern/src/features/student/StudentDashboard.tsx`
+→ no matches.
+
+## Tests
+- All 69 existing tests stay green.
+- `type-check`, `lint`, `build` clean.
+
+## How to verify
+- `npm run dev` → log in as a student → dashboard greeting is `font-display`
+  and warm; the "My Progress" link is brand-orange; the empty-state for open
+  students renders the keyhole `EmptyState` with a brand CTA.
+
+## Dependency
+Depends on PR 1 (Input/Stat/SectionHeading/EmptyState primitives). Branched
+off `feat/2026-06-02-ui-primitives`.
+
+## Next
+- PR 5 — Teacher Dashboard → V2.
+- Follow-up M4 increments: `StreakBadge`, `AssignmentCard`,
+  `DueForReviewPanel`, `RecommendationsPanel`, `AnnouncementsBanner` chrome.

--- a/frontend_modern/src/features/student/StudentDashboard.tsx
+++ b/frontend_modern/src/features/student/StudentDashboard.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
+import { Button, EmptyState } from '@/shared/ui';
 import { AssignmentList } from './AssignmentList';
 import { useAssignments } from './useAssignments';
 import { useStreak } from './useStreak';
@@ -16,30 +17,32 @@ export const StudentDashboard = () => {
   const { data: assignments, isLoading, isError } = useAssignments();
   const { data: streak } = useStreak();
 
-  const greeting = user?.first_name ? `Hi, ${user.first_name}!` : 'Your Dashboard';
+  const greeting = user?.first_name ? `Hi, ${user.first_name}!` : 'Your dashboard';
 
   return (
     <div>
       {/* Page header */}
-      <div className="flex items-start justify-between gap-4 mb-6">
+      <div className="mb-6 flex items-start justify-between gap-4">
         <div className="min-w-0">
-          <h1 className="text-2xl font-bold text-gray-900 truncate">{greeting}</h1>
+          <h1 className="font-display text-3xl font-semibold text-ink-900 truncate">{greeting}</h1>
           {streak ? (
-            <StreakBadge
-              streak={streak.current_streak}
-              tier={streak.milestone_tier}
-              longestStreak={streak.longest_streak}
-              graceUsed={streak.streak_grace_used}
-            />
+            <div className="mt-2">
+              <StreakBadge
+                streak={streak.current_streak}
+                tier={streak.milestone_tier}
+                longestStreak={streak.longest_streak}
+                graceUsed={streak.streak_grace_used}
+              />
+            </div>
           ) : (
-            <p className="text-gray-500 mt-1 text-sm sm:text-base">Here are your assignments</p>
+            <p className="mt-1 text-sm text-ink-500 sm:text-base">Here are your assignments.</p>
           )}
         </div>
         <button
           onClick={() => navigate('/student/proficiency')}
-          className="text-sm text-indigo-600 hover:text-indigo-800 font-medium whitespace-nowrap shrink-0 mt-1"
+          className="shrink-0 whitespace-nowrap text-sm font-semibold text-brand-700 hover:text-brand-800"
         >
-          My Progress →
+          My progress →
         </button>
       </div>
 
@@ -54,29 +57,25 @@ export const StudentDashboard = () => {
       )}
 
       {isError && (
-        <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+        <div
+          className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700"
+          role="alert"
+        >
           Failed to load assignments. Please refresh the page.
         </div>
       )}
 
       {assignments && assignments.length === 0 && user?.role === UserRole.OPEN_STUDENT && (
-        <div className="rounded-xl border border-indigo-200 bg-indigo-50 p-6 text-center">
-          <p className="text-indigo-800 font-medium mb-1">You&apos;re not enrolled in a classroom yet.</p>
-          <p className="text-indigo-600 text-sm mb-4">
-            Browse the shared question bank to start practising on your own.
-          </p>
-          <button
-            onClick={() => navigate('/student/browse')}
-            className="px-5 py-2.5 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold rounded-lg transition-colors text-sm"
-          >
-            Browse Subjects →
-          </button>
-        </div>
+        <EmptyState
+          title="You're not enrolled in a classroom yet"
+          description="Browse the shared question bank to start practising on your own."
+          action={
+            <Button onClick={() => navigate('/student/browse')}>Browse subjects →</Button>
+          }
+        />
       )}
 
-      {assignments && assignments.length > 0 && (
-        <AssignmentList assignments={assignments} />
-      )}
+      {assignments && assignments.length > 0 && <AssignmentList assignments={assignments} />}
 
       <RecommendationsPanel />
       <DueForReviewPanel />


### PR DESCRIPTION
## Summary
Closes **M4-01** of the [V2 design-system initiative](docs/initiatives/2026-design-system-v2.md). Re-skins the highest-traffic post-login surface from cold indigo/gray-50 into warm brand+ink tokens, so the login → dashboard handoff no longer reads as two different apps.

## Changes
- Headline `text-2xl font-bold text-gray-900` → `font-display text-3xl font-semibold text-ink-900`.
- `text-gray-500` → `text-ink-500`.
- "My progress" link `text-indigo-600` → `text-brand-700`.
- Open-student "not enrolled" block (indigo border + bg + custom button) → V2 `EmptyState` primitive with a `<Button>` brand CTA.
- Error block becomes a `rounded-xl` warm-rose alert.

## Scope (per daily plan)
Dashboard's own JSX + empty state only. Child panel internals (`DueForReviewPanel`, `RecommendationsPanel`, `AssignmentList`, `StreakBadge`, `AnnouncementsBanner`) keep their existing styling and are logged as M4 follow-ups.

## Token cleanup
\`\`\`
$ grep -nE "indigo|gray-50|primary-" frontend_modern/src/features/student/StudentDashboard.tsx
(no matches)
\`\`\`

## Dependency
Branched off [feat/2026-06-02-ui-primitives](https://github.com/openshiksha/openshiksha/pull/135) (PR 1) for `EmptyState`. PR base is set to that branch.

## Tests
- 69/69 existing tests stay green.
- `type-check`, `lint`, `build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)