### PR TITLE
fix(cabinet): lift container.content.text into Question.stem_text on import

### DIFF
--- a/backend/openshiksha/apps/api/serializers/core.py
+++ b/backend/openshiksha/apps/api/serializers/core.py
@@ -255,9 +255,7 @@ class QuestionWithSubpartsStudentSerializer(serializers.ModelSerializer):
         # (student_id, subpart_id) and zero-cost when no variables are set.
         first = instance.subparts.order_by("index").first()
         if first and first.variable_constraints:
-            values = sample_variable_values(
-                first.variable_constraints, request.user.id, first.id
-            )
+            values = sample_variable_values(first.variable_constraints, request.user.id, first.id)
             data["stem_text"] = substitute_variables(stem, values)
         return data
 

--- a/backend/openshiksha/apps/api/serializers/core.py
+++ b/backend/openshiksha/apps/api/serializers/core.py
@@ -206,7 +206,14 @@ class QuestionSubpartStudentSerializer(serializers.ModelSerializer):
 
 
 class QuestionWithSubpartsStudentSerializer(serializers.ModelSerializer):
-    """Question serializer using the student-safe subpart serializer."""
+    """Question serializer using the student-safe subpart serializer.
+
+    Substitutes ``{{var}}`` tokens in ``stem_text`` for authenticated students
+    using the first subpart's per-student seeded values. This keeps stem
+    numbers consistent with the body of the question the student is solving,
+    and is a no-op for stems that don't reference variables (the dominant
+    case in cabinet content).
+    """
 
     subparts = QuestionSubpartStudentSerializer(many=True, read_only=True)
     tags = QuestionTagSerializer(many=True, read_only=True)
@@ -228,6 +235,31 @@ class QuestionWithSubpartsStudentSerializer(serializers.ModelSerializer):
             "is_active",
             "created_at",
         ]
+
+    def to_representation(self, instance):
+        from openshiksha.apps.api.croupier import sample_variable_values, substitute_variables
+
+        data = super().to_representation(instance)
+        stem = data.get("stem_text")
+        if not stem or "{{" not in stem:
+            return data
+
+        request = self.context.get("request")
+        if not (request and request.user.is_authenticated):
+            return data
+
+        # Stems can reference variables shared with their subparts (e.g. a
+        # cabinet container whose prompt mentions a quantity that subparts then
+        # ask about). We seed off the first subpart so the stem's numbers
+        # match the first subpart the student sees — deterministic per
+        # (student_id, subpart_id) and zero-cost when no variables are set.
+        first = instance.subparts.order_by("index").first()
+        if first and first.variable_constraints:
+            values = sample_variable_values(
+                first.variable_constraints, request.user.id, first.id
+            )
+            data["stem_text"] = substitute_variables(stem, values)
+        return data
 
 
 class QuestionSerializer(serializers.ModelSerializer):

--- a/backend/openshiksha/apps/api/tests/test_stem_substitution.py
+++ b/backend/openshiksha/apps/api/tests/test_stem_substitution.py
@@ -9,6 +9,7 @@ values.
 """
 
 import pytest
+
 from django.contrib.auth.models import AnonymousUser
 from rest_framework.test import APIRequestFactory
 

--- a/backend/openshiksha/apps/api/tests/test_stem_substitution.py
+++ b/backend/openshiksha/apps/api/tests/test_stem_substitution.py
@@ -33,9 +33,7 @@ def question_with_stem_vars(db):
     board = Board.objects.create(name="CBSE Stem Sub")
     standard = Standard.objects.create(number=8, description="Class 8")
     subject = Subject.objects.create(name="Maths Stem Sub")
-    chapter = Chapter.objects.create(
-        name="Linear Equations Stem", subject=subject, standard=standard, order=1
-    )
+    chapter = Chapter.objects.create(name="Linear Equations Stem", subject=subject, standard=standard, order=1)
     school = School.objects.create(name="Stem Test School", board=board)
     student = User.objects.create_user(
         username="stem_student",
@@ -106,12 +104,12 @@ def test_stem_substitution_is_deterministic(question_with_stem_vars):
     request = factory.get("/")
     request.user = question_with_stem_vars["student"]
 
-    a = QuestionWithSubpartsStudentSerializer(
-        question_with_stem_vars["question"], context={"request": request}
-    ).data["stem_text"]
-    b = QuestionWithSubpartsStudentSerializer(
-        question_with_stem_vars["question"], context={"request": request}
-    ).data["stem_text"]
+    a = QuestionWithSubpartsStudentSerializer(question_with_stem_vars["question"], context={"request": request}).data[
+        "stem_text"
+    ]
+    b = QuestionWithSubpartsStudentSerializer(question_with_stem_vars["question"], context={"request": request}).data[
+        "stem_text"
+    ]
     assert a == b
 
 
@@ -122,9 +120,7 @@ def test_stem_unchanged_when_no_variables(db):
     board = Board.objects.create(name="CBSE Stem Static")
     standard = Standard.objects.create(number=9, description="Class 9")
     subject = Subject.objects.create(name="Maths Stem Static")
-    chapter = Chapter.objects.create(
-        name="Polynomials Stem Static", subject=subject, standard=standard, order=1
-    )
+    chapter = Chapter.objects.create(name="Polynomials Stem Static", subject=subject, standard=standard, order=1)
     school = School.objects.create(name="Stem Static School", board=board)
     student = User.objects.create_user(
         username="stem_static_student",

--- a/backend/openshiksha/apps/api/tests/test_stem_substitution.py
+++ b/backend/openshiksha/apps/api/tests/test_stem_substitution.py
@@ -1,0 +1,172 @@
+"""
+Tests for per-student {{var}} substitution in Question.stem_text.
+
+The stem occasionally references the same variables a subpart samples — e.g.
+"Consider a triangle with sides {{a}}, {{b}}, {{c}}" — and the student's view
+of the stem must match the numbers they see in the body. We seed off the first
+subpart so the stem and that subpart are guaranteed to use the same per-student
+values.
+"""
+
+import pytest
+from django.contrib.auth.models import AnonymousUser
+from rest_framework.test import APIRequestFactory
+
+from openshiksha.apps.api.croupier import sample_variable_values
+from openshiksha.apps.api.serializers.core import QuestionWithSubpartsStudentSerializer
+from openshiksha.apps.core.models import (
+    Board,
+    Chapter,
+    Question,
+    QuestionSubpart,
+    QuestionType,
+    School,
+    Standard,
+    Subject,
+    User,
+    UserRole,
+)
+
+
+@pytest.fixture
+def question_with_stem_vars(db):
+    board = Board.objects.create(name="CBSE Stem Sub")
+    standard = Standard.objects.create(number=8, description="Class 8")
+    subject = Subject.objects.create(name="Maths Stem Sub")
+    chapter = Chapter.objects.create(
+        name="Linear Equations Stem", subject=subject, standard=standard, order=1
+    )
+    school = School.objects.create(name="Stem Test School", board=board)
+    student = User.objects.create_user(
+        username="stem_student",
+        password="pass",
+        role=UserRole.STUDENT,
+        school=school,
+        grade=8,
+    )
+    question = Question.objects.create(
+        standard=standard,
+        subject=subject,
+        chapter=chapter,
+        question_type=QuestionType.NUMERIC,
+        difficulty=2,
+        is_active=True,
+        stem_text="A trader sells {{a}} apples and {{b}} bananas. Use this context to answer.",
+    )
+    sp = QuestionSubpart.objects.create(
+        question=question,
+        index=0,
+        subpart_type=QuestionType.NUMERIC,
+        question_text="How many fruits in total?",
+        correct_answer={"type": "numeric", "answer": "{{a}} + {{b}}"},
+        variable_constraints={
+            "a": {"min": 5, "max": 50, "integer": True},
+            "b": {"min": 5, "max": 50, "integer": True},
+        },
+    )
+    return {"question": question, "first_subpart": sp, "student": student}
+
+
+@pytest.mark.django_db
+def test_authenticated_student_sees_substituted_stem(question_with_stem_vars):
+    """{{a}} and {{b}} in the stem are replaced with concrete numbers."""
+    factory = APIRequestFactory()
+    request = factory.get("/")
+    request.user = question_with_stem_vars["student"]
+    serializer = QuestionWithSubpartsStudentSerializer(
+        question_with_stem_vars["question"], context={"request": request}
+    )
+    data = serializer.data
+    assert "{{" not in data["stem_text"], data["stem_text"]
+    assert any(c.isdigit() for c in data["stem_text"])
+
+
+@pytest.mark.django_db
+def test_stem_uses_same_seed_as_first_subpart(question_with_stem_vars):
+    """Stem numbers match whatever the first subpart's sample yields."""
+    student = question_with_stem_vars["student"]
+    first = question_with_stem_vars["first_subpart"]
+    expected = sample_variable_values(first.variable_constraints, student.id, first.id)
+
+    factory = APIRequestFactory()
+    request = factory.get("/")
+    request.user = student
+    serializer = QuestionWithSubpartsStudentSerializer(
+        question_with_stem_vars["question"], context={"request": request}
+    )
+    rendered = serializer.data["stem_text"]
+    assert f"sells {expected['a']} apples" in rendered
+    assert f"and {expected['b']} bananas" in rendered
+
+
+@pytest.mark.django_db
+def test_stem_substitution_is_deterministic(question_with_stem_vars):
+    """Two render passes for the same student yield identical stem text."""
+    factory = APIRequestFactory()
+    request = factory.get("/")
+    request.user = question_with_stem_vars["student"]
+
+    a = QuestionWithSubpartsStudentSerializer(
+        question_with_stem_vars["question"], context={"request": request}
+    ).data["stem_text"]
+    b = QuestionWithSubpartsStudentSerializer(
+        question_with_stem_vars["question"], context={"request": request}
+    ).data["stem_text"]
+    assert a == b
+
+
+@pytest.mark.django_db
+def test_stem_unchanged_when_no_variables(db):
+    """Static stems (the common case — cabinet stems don't use vars today)
+    pass through unchanged with no substitution work."""
+    board = Board.objects.create(name="CBSE Stem Static")
+    standard = Standard.objects.create(number=9, description="Class 9")
+    subject = Subject.objects.create(name="Maths Stem Static")
+    chapter = Chapter.objects.create(
+        name="Polynomials Stem Static", subject=subject, standard=standard, order=1
+    )
+    school = School.objects.create(name="Stem Static School", board=board)
+    student = User.objects.create_user(
+        username="stem_static_student",
+        password="pass",
+        role=UserRole.STUDENT,
+        school=school,
+        grade=9,
+    )
+    static_stem = "For the given graphs find the number of zeros in each case"
+    question = Question.objects.create(
+        standard=standard,
+        subject=subject,
+        chapter=chapter,
+        question_type=QuestionType.NUMERIC,
+        difficulty=2,
+        is_active=True,
+        stem_text=static_stem,
+    )
+    QuestionSubpart.objects.create(
+        question=question,
+        index=0,
+        subpart_type=QuestionType.NUMERIC,
+        question_text="<div>Graph 1</div>",
+        correct_answer={"type": "numeric", "answer": 2},
+        variable_constraints={},
+    )
+
+    factory = APIRequestFactory()
+    request = factory.get("/")
+    request.user = student
+    serializer = QuestionWithSubpartsStudentSerializer(question, context={"request": request})
+    assert serializer.data["stem_text"] == static_stem
+
+
+@pytest.mark.django_db
+def test_anonymous_request_returns_stem_untouched(question_with_stem_vars):
+    """Anonymous request → no substitution; the raw stored stem is returned.
+    Anonymous browsing is rare but must not crash."""
+    factory = APIRequestFactory()
+    request = factory.get("/")
+    request.user = AnonymousUser()
+    serializer = QuestionWithSubpartsStudentSerializer(
+        question_with_stem_vars["question"], context={"request": request}
+    )
+    assert "{{a}}" in serializer.data["stem_text"]

--- a/backend/openshiksha/apps/core/management/commands/import_cabinet_questions.py
+++ b/backend/openshiksha/apps/core/management/commands/import_cabinet_questions.py
@@ -685,7 +685,40 @@ class Command(BaseCommand):
             stats["compound"] = stats.get("compound", 0) + 1
         standard, subject, chapter = self._resolve_taxonomy(ids, mapping, stats)
 
-        stem_text = _lift_shared_stem(converted) if len(converted) > 1 else ""
+        # Stem extraction. Priority:
+        #   1. Container-level `content.text` (+ optional `content.img`) — the
+        #      cabinet's *authoritative* question prompt for compound questions
+        #      whose subparts are sub-questions ("Graph 1", "Graph 2", "Graph 3"
+        #      under "For the given graphs find the number of zeros in each
+        #      case"). 38% of containers carry this field; without lifting it,
+        #      students see only the sub-labels and not the actual question.
+        #   2. Fallback: subparts that share an identical leading paragraph
+        #      (M7-07). Used when the container has no explicit content.
+        container_content = container.get("content") or {}
+        container_stem = ""
+        if isinstance(container_content, dict):
+            raw_stem = (container_content.get("text") or "").strip()
+            if raw_stem:
+                # Rewrite inline images and resolve `#{name}#` tokens in the
+                # stem just like we do for subpart bodies (M7-06).
+                container_stem = rewrite_inline_images(raw_stem, ids["raw_dir"], chapter_base)
+            # Container can also carry its own diagram (content.img) — render
+            # it as a trailing <img> in the stem so the picture stays attached
+            # to the question prompt, not orphaned on a subpart.
+            container_img = container_content.get("img")
+            if container_img:
+                img_url = (
+                    container_img
+                    if str(container_img).startswith(("http://", "https://"))
+                    else f"{chapter_base}/img/{container_img}"
+                )
+                img_tag = f'<p><img src="{img_url}" alt=""></p>'
+                container_stem = (container_stem + img_tag).strip() if container_stem else img_tag
+
+        if container_stem:
+            stem_text = container_stem
+        else:
+            stem_text = _lift_shared_stem(converted) if len(converted) > 1 else ""
         if stem_text:
             stats["stems"] = stats.get("stems", 0) + 1
 

--- a/backend/openshiksha/apps/core/tests/fixtures/cabinet_sample/containers/CBSE/openshiksha/10/1/18/549.json
+++ b/backend/openshiksha/apps/core/tests/fixtures/cabinet_sample/containers/CBSE/openshiksha/10/1/18/549.json
@@ -1,0 +1,8 @@
+{
+  "content": {
+    "text": "For the given graphs find the number of zeros in each case",
+    "img": "4.png"
+  },
+  "subparts": [9001, 9002],
+  "hint": null
+}

--- a/backend/openshiksha/apps/core/tests/fixtures/cabinet_sample/mapping.json
+++ b/backend/openshiksha/apps/core/tests/fixtures/cabinet_sample/mapping.json
@@ -1,9 +1,11 @@
 {
   "subjects": {
+    "1": "Algebra",
     "12": "Mathematics",
     "13": "Science"
   },
   "chapters": {
+    "18": "Polynomial Roots",
     "45": "Addition",
     "46": "Prime Numbers",
     "47": "Cell Biology"

--- a/backend/openshiksha/apps/core/tests/fixtures/cabinet_sample/raw/CBSE/openshiksha/10/1/18/9001.json
+++ b/backend/openshiksha/apps/core/tests/fixtures/cabinet_sample/raw/CBSE/openshiksha/10/1/18/9001.json
@@ -1,0 +1,9 @@
+{
+  "subpart_index": 0,
+  "type": 3,
+  "content": {"text": "<div>Graph 1</div>"},
+  "answer": {"value": 2},
+  "variable_constraints": {},
+  "solution": {"text": "Two zeroes — two x-axis crossings."},
+  "hint": null
+}

--- a/backend/openshiksha/apps/core/tests/fixtures/cabinet_sample/raw/CBSE/openshiksha/10/1/18/9002.json
+++ b/backend/openshiksha/apps/core/tests/fixtures/cabinet_sample/raw/CBSE/openshiksha/10/1/18/9002.json
@@ -1,0 +1,9 @@
+{
+  "subpart_index": 1,
+  "type": 3,
+  "content": {"text": "<div>Graph 2</div>"},
+  "answer": {"value": 3},
+  "variable_constraints": {},
+  "solution": {"text": "Three zeroes — two crossings and a touch."},
+  "hint": null
+}

--- a/backend/openshiksha/apps/core/tests/test_import_cabinet.py
+++ b/backend/openshiksha/apps/core/tests/test_import_cabinet.py
@@ -348,13 +348,9 @@ class TestImportCommand:
         and before this fix the importer silently dropped it — leaving
         students with only the sub-labels ("Graph 1", "Graph 2", "Graph 3")
         and no actual question. This regression test pins it down."""
-        call_command(
-            "import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=StringIO(), stderr=StringIO()
-        )
+        call_command("import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=StringIO(), stderr=StringIO())
         q = Question.objects.get(tags__name__endswith=":q549")
-        assert (
-            "For the given graphs find the number of zeros in each case" in q.stem_text
-        ), q.stem_text
+        assert "For the given graphs find the number of zeros in each case" in q.stem_text, q.stem_text
         # Subpart bodies are untouched — the stem doesn't get duplicated into them.
         first_sp = q.subparts.order_by("index").first()
         assert "number of zeros" not in (first_sp.question_text or "")
@@ -363,9 +359,7 @@ class TestImportCommand:
         """When the container has `content.img`, the importer renders it as a
         trailing <img> tag inside the stem so the picture stays attached to
         the question prompt rather than orphaned on a subpart."""
-        call_command(
-            "import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=StringIO(), stderr=StringIO()
-        )
+        call_command("import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=StringIO(), stderr=StringIO())
         q = Question.objects.get(tags__name__endswith=":q549")
         assert "<img" in q.stem_text and 'src="' in q.stem_text
         # Image URL points at the chapter's img/ subdirectory on the cabinet repo.
@@ -375,9 +369,7 @@ class TestImportCommand:
         """The `stems=` line in the importer report counts container-lifted
         stems too, not just the M7-07 shared-paragraph lifts."""
         out = StringIO()
-        call_command(
-            "import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=out, stderr=StringIO()
-        )
+        call_command("import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=out, stderr=StringIO())
         # At minimum the q549 container-lifted stem should be counted.
         assert "stems=" in out.getvalue()
         # Extract the numeric value after "stems=".

--- a/backend/openshiksha/apps/core/tests/test_import_cabinet.py
+++ b/backend/openshiksha/apps/core/tests/test_import_cabinet.py
@@ -232,8 +232,8 @@ class TestImportCommand:
     def test_malformed_question_skipped(self):
         out, err = StringIO(), StringIO()
         call_command("import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=out, stderr=err)
-        # 7 valid questions import; the type-99 one is skipped.
-        assert Question.objects.count() == 7
+        # 8 valid containers import; the type-99 one is skipped.
+        assert Question.objects.count() == 8
         assert "skip" in err.getvalue()
 
     def test_idempotent_reimport(self):
@@ -241,7 +241,7 @@ class TestImportCommand:
             call_command(
                 "import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=StringIO(), stderr=StringIO()
             )
-        assert Question.objects.count() == 7
+        assert Question.objects.count() == 8
 
     def test_solution_and_hint_imported(self):
         call_command("import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=StringIO(), stderr=StringIO())
@@ -340,3 +340,47 @@ class TestImportCommand:
             assert ":c" in tag.name and ":q" in tag.name, tag.name
             # Each tag should be attached to exactly one Question.
             assert tag.questions.count() == 1
+
+    def test_container_content_text_lifted_into_stem(self):
+        """The container's `content.text` field is the authoritative question
+        prompt for compound questions (e.g. "For the given graphs find the
+        number of zeros in each case"). 38% of cabinet containers carry it,
+        and before this fix the importer silently dropped it — leaving
+        students with only the sub-labels ("Graph 1", "Graph 2", "Graph 3")
+        and no actual question. This regression test pins it down."""
+        call_command(
+            "import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=StringIO(), stderr=StringIO()
+        )
+        q = Question.objects.get(tags__name__endswith=":q549")
+        assert (
+            "For the given graphs find the number of zeros in each case" in q.stem_text
+        ), q.stem_text
+        # Subpart bodies are untouched — the stem doesn't get duplicated into them.
+        first_sp = q.subparts.order_by("index").first()
+        assert "number of zeros" not in (first_sp.question_text or "")
+
+    def test_container_content_img_attached_to_stem(self):
+        """When the container has `content.img`, the importer renders it as a
+        trailing <img> tag inside the stem so the picture stays attached to
+        the question prompt rather than orphaned on a subpart."""
+        call_command(
+            "import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=StringIO(), stderr=StringIO()
+        )
+        q = Question.objects.get(tags__name__endswith=":q549")
+        assert "<img" in q.stem_text and 'src="' in q.stem_text
+        # Image URL points at the chapter's img/ subdirectory on the cabinet repo.
+        assert "img/4.png" in q.stem_text
+
+    def test_stems_stat_includes_container_lifts(self):
+        """The `stems=` line in the importer report counts container-lifted
+        stems too, not just the M7-07 shared-paragraph lifts."""
+        out = StringIO()
+        call_command(
+            "import_cabinet_questions", source=SOURCE, mapping=MAPPING, stdout=out, stderr=StringIO()
+        )
+        # At minimum the q549 container-lifted stem should be counted.
+        assert "stems=" in out.getvalue()
+        # Extract the numeric value after "stems=".
+        line = next(ln for ln in out.getvalue().splitlines() if "stems=" in ln)
+        n = int(line.split("stems=")[1].split()[0])
+        assert n >= 1, line


### PR DESCRIPTION
## The bug

Reported via question [container `549.json`](https://github.com/openshiksha/openshiksha-cabinet/blob/HEAD/questions/raw/1/1/10/1/18/) — students saw three subpart labels (`Graph 1`, `Graph 2`, `Graph 3`) and never the actual question:

> **"For the given graphs find the number of zeros in each case"**

The text was in the cabinet source the whole time — at `container.content.text` — but the importer never read that field. It walked `container.subparts` and ignored everything else on the container, so the question stem was silently dropped.

## Scope

A scan of the live 648-container cabinet corpus shows the same problem on **252 of 648 containers (38.9%)** — nearly 4 in 10 questions in the bank were missing their stem. Plus **30 more** containers have a `content.img` (the actual diagram) being orphaned.

Examples of stems that were being dropped:
- *"For the given graphs find the number of zeros in each case"*
- *"Consider the equilibrium below: N₂O₄(g) ⇌ 2 NO₂(g)"*
- *"Your first job after college is working as an Assistant Engineer for a firm…"*

## The fix

### `import_cabinet_questions._import_container`

- Extract `container.content.text` → `Question.stem_text` (with M7-06 inline-image rewriting applied)
- Extract `container.content.img` → trailing `<img>` in the stem so the diagram stays attached to the prompt
- Container-level stem **takes precedence** over the M7-07 `_lift_shared_stem` fallback (which lifts a paragraph repeated across subparts)
- `stems=` reporter stat now counts container-lifted stems too

### `QuestionWithSubpartsStudentSerializer.to_representation`

Defensive addition: substitute `{{var}}` tokens in `stem_text` for authenticated students using the **first subpart's per-student seed**. Zero cabinet stems currently use tokens (confirmed by corpus scan), but several future authoring paths will, and getting the wiring in now means stems will never display raw `{{a}}` tokens to students.

## Verification

### Tests (68 passing in related suites)
- `test_container_content_text_lifted_into_stem` — q549 fixture has the stem rendered and the subpart body untouched (no duplication into subparts)
- `test_container_content_img_attached_to_stem` — verifies `<img>` with chapter-scoped raw-GitHub URL is appended
- `test_stems_stat_includes_container_lifts` — reporter stat counts stem lifts
- 5 new stem-substitution serializer tests covering determinism, seed match with first subpart, static stems unchanged, anonymous request safe
- Existing `test_malformed_question_skipped` + `test_idempotent_reimport` bumped from 7→8 questions to match the new fixture
- Cabinet fidelity audit stays clean (no taxonomy placeholders)

### UI flow — confirmed end-to-end

The stem field already flows through every render site; no frontend changes needed:

| Layer | Status |
|---|---|
| `QuestionWithSubpartsStudentSerializer` (student) | Exposes `stem_text` ✓ |
| `QuestionSerializer` (teacher) | Exposes `stem_text` ✓ |
| Student `QuestionCard` | Renders `<RichContent text={question.stem_text} variant=\"block\" />` ✓ |
| Teacher `QuestionPreviewPanel` (#142) | Renders `<RichContent text={question.stem_text} variant=\"block\" />` ✓ |
| Assignment Detail / Browse Practice / SRS Drill | All go through `QuestionCard` ✓ |
| Build Problem Set / Question Bank preview | Both go through `QuestionPreviewPanel` ✓ |

## Next step after merge

Re-run `import_cabinet_questions --source .../questions` to backfill the 252 affected questions. The import is idempotent (M7-05) so it's safe to run on the live DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)