### PR TITLE
ci: add actionlint workflow YAML linter

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -3,6 +3,29 @@ name: CI/CD Pipeline
 on: push
 
 jobs:
+    workflow-lint:
+        name: Workflow Lint (actionlint)
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out the repo
+              uses: actions/checkout@v4
+            - name: Install actionlint
+              # Use the official install script from the actionlint maintainer
+              # (rhysd). Pinning to a script URL avoids a third-party action
+              # dependency for a job that just runs a static linter.
+              id: install-actionlint
+              run: |
+                bash <(curl --silent --show-error --fail https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+                echo "actionlint=$(pwd)/actionlint" >> "$GITHUB_OUTPUT"
+            - name: Run actionlint
+              # Validates GitHub Actions workflow YAML — catches typos in
+              # `uses:` versions, bad expression syntax, mismatched `needs:`
+              # references, and other footguns that otherwise only fail at
+              # run time. Shellcheck integration is disabled (-shellcheck=)
+              # because the inline `gh` script in the coverage-comment step
+              # trips style warnings that aren't worth gating CI on.
+              run: ${{ steps.install-actionlint.outputs.actionlint }} -color -shellcheck=
+
     lint:
         name: Lint
         runs-on: ubuntu-latest

--- a/docs/changes/2026-06-03-actionlint.md
+++ b/docs/changes/2026-06-03-actionlint.md
@@ -1,0 +1,39 @@
+# 2026-06-03 — actionlint workflow linting
+
+## What
+
+Added a `workflow-lint` job to `.github/workflows/ci-cd.yaml` that runs
+[actionlint](https://github.com/rhysd/actionlint) against every workflow YAML
+file in the repo.
+
+## Why
+
+`ci-cd.yaml` has grown to 9 jobs (~290 lines) with non-trivial constructs:
+multi-`needs:` dependencies, branch-conditional `if:` expressions, an inline
+`gh` shell script for sticky PR comments, several third-party actions pinned
+to major-version tags. Mistakes in any of those — a typo in a `needs:` name, a
+bad `${{ }}` expression, an action version that no longer exists — only
+surface at run time, which is slow feedback when the workflow itself is the
+thing being changed.
+
+`actionlint` catches those statically in seconds. It's the standard tool
+the GitHub Actions community uses for this and is the one the GitHub Actions
+docs themselves recommend.
+
+## How
+
+- New `workflow-lint` job at the top of the jobs list.
+- Installed via the official `download-actionlint.bash` script from the
+  upstream repo — no third-party action dependency.
+- `-shellcheck=` disables shellcheck integration. The inline `gh` script in
+  the `Post coverage summary on PR` step is intentional shell, and chasing
+  shellcheck style warnings is not the goal of this job; that can be added
+  separately if we want it later.
+- `-color` for readable output in the GitHub Actions log.
+
+## Not done in this PR
+
+- Did not add `actionlint` to the local pre-commit hook list. The hook would
+  require contributors to have the binary installed (or use a Docker image),
+  which is friction for a check that already runs in CI on every push.
+- Did not enable shellcheck integration (see above).


### PR DESCRIPTION
## Summary

- Adds a `workflow-lint` job that runs [actionlint](https://github.com/rhysd/actionlint) against `.github/workflows/` on every push
- Catches typos in `uses:` versions, bad `${{ }}` expression syntax, mismatched `needs:` references, and other workflow footguns statically — instead of waiting for the workflow to fail at run time
- `ci-cd.yaml` is up to 9 jobs / ~290 lines with non-trivial constructs (multi-`needs:` deps, branch-conditional `if:` expressions, an inline `gh` script for sticky PR comments). Static linting is overdue.

## Implementation notes

- Installed via the official `download-actionlint.bash` script from the upstream repo — no third-party action dependency.
- `-shellcheck=` disables shellcheck integration. The inline `gh` script in the `Post coverage summary on PR` step is intentional shell; chasing style warnings there is out of scope.
- Not added to `.pre-commit-config.yaml` — that would force every contributor to install the binary locally for a check that already runs in CI.

Full change rationale: [docs/changes/2026-06-03-actionlint.md](docs/changes/2026-06-03-actionlint.md).

## Test plan

- [ ] CI green on this PR (the new `workflow-lint` job passes against current `.github/workflows/ci-cd.yaml`)
- [ ] Intentionally break a `needs:` ref locally (or in a follow-up draft) to confirm the job fails red

🤖 Generated with [Claude Code](https://claude.com/claude-code)