### PR TITLE
feat(frontend): migrate Parent Dashboard + Insights to V2

### DIFF
--- a/docs/changes/2026-06-03-parent-surfaces-v2.md
+++ b/docs/changes/2026-06-03-parent-surfaces-v2.md
@@ -1,0 +1,36 @@
+# 2026-06-03 — Parent Dashboard + Insights migrated to V2
+
+## Summary
+Migrated all parent-role surfaces to V2 "Chalk & Unlock":
+`ParentDashboard.tsx`, `ParentInsightsLandingPage.tsx`, `ParentInsightsPage.tsx`,
+and the shared `NarrativeCard`, `AlertsPanel`, `HomeActivitiesPanel` components.
+
+## Classification
+Improve — reskin only. Data hooks, routes, role guards untouched.
+
+## What changed
+- All `indigo-*`, `text-gray-*`, `border-gray-*`, `bg-gray-50`, `red-*`, `green-*`,
+  `blue-*` classes replaced with `brand-*`/`ink-*`/`rose-*`/`emerald-*`/`amber-*`.
+- Headings now `<SectionHeading>` (font-display Fraunces).
+- Cards now `<Card>` / `.os-card`.
+- Status pills use `<Badge>` with `success`/`attention`/`urgent`/`brand` tones —
+  the dashboard now exposes an Overdue badge (previously labeled "Pending").
+- Active tab gets the chalk-underline treatment + focus-visible ring.
+- Empty states swapped for `<EmptyState>` keyhole motif.
+- Sparkline-style proficiency bars recoloured to `emerald/amber/rose` semantic
+  thresholds on warm `ink-100` track.
+- `motion-reduce:transition-none` added to every transition for a11y.
+
+## Tests
+- `npm run type-check` green
+- `npm run lint` green
+- `npm test -- --run` 84/84 (incl. `AlertsPanel.test.tsx`, `HomeActivitiesPanel.test.tsx` —
+  `data-severity` and `data-celebrate` query hooks preserved)
+- `npm run build` green
+
+## Verify
+Log in as `parent_demo` / `demo1234`. Open `/parent`, then `/parent/insights`,
+then a child insights page.
+
+## Next
+PRs 3–5 will migrate Admin, Proficiency cluster, and Assignment/SRS surfaces.

--- a/frontend_modern/src/features/parent/ParentDashboard.tsx
+++ b/frontend_modern/src/features/parent/ParentDashboard.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { useChildren } from './useChildren';
 import { useChildProficiency } from './useChildProficiency';
 import { useChildAssignments } from './useChildAssignments';
-import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
+import { Badge, Card, EmptyState, LoadingSpinner, SectionHeading } from '@/shared/ui';
 import type { User, StudentProficiency, Assignment } from '@/types/index';
 
 interface SubjectGroup {
@@ -26,21 +26,21 @@ const groupBySubject = (records: StudentProficiency[]): SubjectGroup[] => {
 
 const ProficiencyBar = ({ record }: { record: StudentProficiency }) => {
   const pct = Math.round(record.score * 100);
-  const barColor = pct >= 70 ? 'bg-green-500' : pct >= 40 ? 'bg-yellow-400' : 'bg-red-400';
+  const barColor = pct >= 70 ? 'bg-emerald-500' : pct >= 40 ? 'bg-amber-400' : 'bg-rose-400';
 
   return (
     <div className="py-2.5">
       <div className="flex items-baseline justify-between gap-2 mb-1">
-        <span className="text-sm font-medium text-gray-800 truncate">{record.tag_name}</span>
-        <span className="text-sm font-semibold text-gray-700 shrink-0">{pct}%</span>
+        <span className="text-sm font-medium text-ink-800 truncate">{record.tag_name}</span>
+        <span className="text-sm font-semibold text-ink-700 shrink-0">{pct}%</span>
       </div>
-      <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
+      <div className="h-2 bg-ink-100 rounded-full overflow-hidden">
         <div
-          className={`h-full rounded-full transition-all duration-300 ${barColor}`}
+          className={`h-full rounded-full transition-all duration-300 motion-reduce:transition-none ${barColor}`}
           style={{ width: `${pct}%` }}
         />
       </div>
-      <p className="text-xs text-gray-400 mt-1">
+      <p className="text-xs text-ink-400 mt-1">
         {record.tick_count} question{record.tick_count !== 1 ? 's' : ''} practised
       </p>
     </div>
@@ -60,12 +60,10 @@ const ChildView = ({ child }: { child: User }) => {
 
   if (!records || records.length === 0) {
     return (
-      <div className="text-center py-12 bg-white rounded-xl border border-gray-200">
-        <p className="text-gray-500 font-medium">No progress yet</p>
-        <p className="text-sm text-gray-400 mt-1">
-          {child.first_name || child.username} hasn't submitted any assignments yet.
-        </p>
-      </div>
+      <EmptyState
+        title="No progress yet"
+        description={`${child.first_name || child.username} hasn't submitted any assignments yet.`}
+      />
     );
   }
 
@@ -74,38 +72,32 @@ const ChildView = ({ child }: { child: User }) => {
   return (
     <div className="space-y-5">
       {groups.map((group) => (
-        <div
-          key={`${group.subjectName}|${group.classroomDisplay}`}
-          className="bg-white rounded-xl border border-gray-200 p-5"
-        >
+        <Card key={`${group.subjectName}|${group.classroomDisplay}`} className="p-5">
           <div className="mb-4">
-            <h3 className="font-semibold text-gray-900">{group.subjectName}</h3>
-            <p className="text-sm text-gray-500">{group.classroomDisplay}</p>
+            <h3 className="font-display font-semibold text-ink-900">{group.subjectName}</h3>
+            <p className="text-sm text-ink-500">{group.classroomDisplay}</p>
           </div>
-          <div className="divide-y divide-gray-50">
+          <div className="divide-y divide-ink-100">
             {group.records.map((r) => (
               <ProficiencyBar key={r.id} record={r} />
             ))}
           </div>
-        </div>
+        </Card>
       ))}
     </div>
   );
 };
 
-const AssignmentStatusBadge = ({ status }: { status: Assignment['child_submission_status'] }) => {
-  if (status === 'submitted') {
-    return (
-      <span className="shrink-0 text-xs font-semibold px-2 py-1 rounded-full bg-green-100 text-green-700">
-        Submitted
-      </span>
-    );
-  }
-  return (
-    <span className="shrink-0 text-xs font-semibold px-2 py-1 rounded-full bg-amber-100 text-amber-700">
-      Pending
-    </span>
-  );
+const AssignmentStatusBadge = ({
+  status,
+  isOverdue,
+}: {
+  status: Assignment['child_submission_status'];
+  isOverdue: boolean;
+}) => {
+  if (status === 'submitted') return <Badge tone="success">Submitted</Badge>;
+  if (isOverdue) return <Badge tone="urgent">Overdue</Badge>;
+  return <Badge tone="attention">Pending</Badge>;
 };
 
 const ChildAssignmentsView = ({ child }: { child: User }) => {
@@ -121,12 +113,10 @@ const ChildAssignmentsView = ({ child }: { child: User }) => {
 
   if (!assignments || assignments.length === 0) {
     return (
-      <div className="text-center py-12 bg-white rounded-xl border border-gray-200">
-        <p className="text-gray-500 font-medium">No assignments yet</p>
-        <p className="text-sm text-gray-400 mt-1">
-          Assignments will appear here once the teacher creates them.
-        </p>
-      </div>
+      <EmptyState
+        title="No assignments yet"
+        description="Assignments will appear here once the teacher creates them."
+      />
     );
   }
 
@@ -148,23 +138,23 @@ const ChildAssignmentsView = ({ child }: { child: User }) => {
         });
 
         return (
-          <div key={a.id} className="bg-white rounded-xl border border-gray-200 p-4 hover:shadow-sm transition-shadow">
+          <Card key={a.id} className="p-4 hover:shadow-sm transition-shadow motion-reduce:transition-none">
             <div className="flex items-start justify-between gap-3">
               <div className="min-w-0">
-                <p className="font-semibold text-gray-900 truncate">{a.problem_set.title}</p>
-                <p className="text-sm text-gray-500 mt-0.5">{a.subject_room_display}</p>
+                <p className="font-semibold text-ink-900 truncate">{a.problem_set.title}</p>
+                <p className="text-sm text-ink-500 mt-0.5">{a.subject_room_display}</p>
               </div>
-              <AssignmentStatusBadge status={a.child_submission_status} />
+              <AssignmentStatusBadge status={a.child_submission_status} isOverdue={isOverdue && !isSubmitted} />
             </div>
             <p
               className={`text-xs mt-2 ${
-                isOverdue && !isSubmitted ? 'text-red-500 font-medium' : 'text-gray-400'
+                isOverdue && !isSubmitted ? 'text-rose-600 font-medium' : 'text-ink-400'
               }`}
             >
               {isOverdue && !isSubmitted ? 'Overdue — ' : 'Due '}
               {dueFmt}
             </p>
-          </div>
+          </Card>
         );
       })}
     </div>
@@ -190,23 +180,23 @@ export const ParentDashboard = () => {
   if (!children || children.length === 0) {
     return (
       <div className="max-w-2xl mx-auto px-4 py-8">
-        <h1 className="text-2xl font-bold text-gray-900 mb-2">Parent Dashboard</h1>
-        <div className="text-center py-16 bg-white rounded-xl border border-gray-200">
-          <p className="text-gray-500 font-medium">No children linked to your account</p>
-          <p className="text-sm text-gray-400 mt-1">
-            Ask the school admin to link your children's accounts.
-          </p>
-        </div>
+        <SectionHeading as="h1" title="Parent Dashboard" className="mb-6" />
+        <EmptyState
+          title="No children linked to your account"
+          description="Ask the school admin to link your children's accounts."
+        />
       </div>
     );
   }
 
   return (
     <div className="max-w-2xl mx-auto px-4 py-8">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">Parent Dashboard</h1>
-        <p className="text-sm text-gray-500 mt-1">Monitor your children's learning progress.</p>
-      </div>
+      <SectionHeading
+        as="h1"
+        title="Parent Dashboard"
+        description="Monitor your children's learning progress."
+        className="mb-6"
+      />
 
       {children.length > 1 && (
         <div className="flex gap-2 flex-wrap mb-6">
@@ -214,10 +204,10 @@ export const ParentDashboard = () => {
             <button
               key={child.id}
               onClick={() => setSelectedChildId(child.id)}
-              className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+              className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors motion-reduce:transition-none focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 ${
                 child.id === effectiveChildId
-                  ? 'bg-indigo-600 text-white'
-                  : 'bg-white border border-gray-300 text-gray-700 hover:bg-gray-50'
+                  ? 'bg-brand-600 text-white'
+                  : 'bg-white border border-ink-200 text-ink-700 hover:bg-brand-50'
               }`}
             >
               {child.first_name || child.username}
@@ -233,31 +223,31 @@ export const ParentDashboard = () => {
         <>
           <div className="mb-4 flex items-start justify-between gap-3 flex-wrap">
             <div>
-              <h2 className="text-lg font-semibold text-gray-800">
+              <h2 className="text-lg font-display font-semibold text-ink-800">
                 {selectedChild.first_name || selectedChild.username}'s Overview
               </h2>
               {selectedChild.grade != null && (
-                <p className="text-sm text-gray-500">Grade {selectedChild.grade}</p>
+                <p className="text-sm text-ink-500">Grade {selectedChild.grade}</p>
               )}
             </div>
             <Link
               to={`/parent/insights/${selectedChild.id}`}
-              className="shrink-0 px-3 py-2 text-sm font-semibold rounded-lg bg-indigo-50 text-indigo-700 hover:bg-indigo-100 transition-colors"
+              className="shrink-0 px-3 py-2 text-sm font-semibold rounded-lg bg-brand-50 text-brand-700 hover:bg-brand-100 transition-colors motion-reduce:transition-none focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2"
             >
               View Insights →
             </Link>
           </div>
 
-          {/* Tab switcher */}
-          <div className="flex gap-1 mb-6 border-b border-gray-200">
+          {/* Tab switcher with chalk underline */}
+          <div className="flex gap-1 mb-6 border-b border-ink-200">
             {(['progress', 'assignments'] as const).map((tab) => (
               <button
                 key={tab}
                 onClick={() => setActiveTab(tab)}
-                className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+                className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors motion-reduce:transition-none focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 ${
                   activeTab === tab
-                    ? 'border-indigo-600 text-indigo-600'
-                    : 'border-transparent text-gray-500 hover:text-gray-700'
+                    ? 'border-brand-600 text-brand-700 chalk-underline'
+                    : 'border-transparent text-ink-500 hover:text-ink-700'
                 }`}
               >
                 {tab === 'progress' ? 'Progress' : 'Assignments'}

--- a/frontend_modern/src/features/parent/ParentInsightsLandingPage.tsx
+++ b/frontend_modern/src/features/parent/ParentInsightsLandingPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
+import { EmptyState, LoadingSpinner, SectionHeading } from '@/shared/ui';
 import { useChildren } from './useChildren';
 
 export const ParentInsightsLandingPage = () => {
@@ -24,36 +24,38 @@ export const ParentInsightsLandingPage = () => {
   if (!children || children.length === 0) {
     return (
       <div className="max-w-2xl mx-auto px-4 py-8">
-        <h1 className="text-2xl font-bold text-gray-900 mb-2">Insights</h1>
-        <div className="text-center py-16 bg-white rounded-xl border border-gray-200">
-          <p className="text-gray-500 font-medium">No children linked to your account</p>
-          <p className="text-sm text-gray-400 mt-1">
-            Ask the school admin to link your children's accounts.
-          </p>
-        </div>
+        <SectionHeading as="h1" title="Insights" className="mb-6" />
+        <EmptyState
+          title="No children linked to your account"
+          description="Ask the school admin to link your children's accounts."
+        />
       </div>
     );
   }
 
   return (
     <div className="max-w-2xl mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold text-gray-900">Insights</h1>
-      <p className="text-sm text-gray-500 mt-1">Choose a child to view their weekly summary.</p>
+      <SectionHeading
+        as="h1"
+        title="Insights"
+        description="Choose a child to view their weekly summary."
+        className="mb-6"
+      />
 
-      <div className="mt-6 grid gap-3 sm:grid-cols-2">
+      <div className="mt-2 grid gap-3 sm:grid-cols-2">
         {children.map((child) => (
           <Link
             key={child.id}
             to={`/parent/insights/${child.id}`}
-            className="rounded-xl border border-gray-200 bg-white p-5 hover:border-indigo-300 hover:shadow-sm transition-all"
+            className="os-card p-5 hover:border-brand-300 hover:shadow-sm transition-all motion-reduce:transition-none focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2"
           >
-            <p className="font-semibold text-gray-900">
+            <p className="font-display font-semibold text-ink-900">
               {child.first_name || child.username}
             </p>
             {child.grade != null && (
-              <p className="text-sm text-gray-500 mt-1">Grade {child.grade}</p>
+              <p className="text-sm text-ink-500 mt-1">Grade {child.grade}</p>
             )}
-            <p className="text-sm text-indigo-600 font-medium mt-3">Open insights →</p>
+            <p className="text-sm text-brand-700 font-medium mt-3">Open insights →</p>
           </Link>
         ))}
       </div>

--- a/frontend_modern/src/features/parent/ParentInsightsPage.tsx
+++ b/frontend_modern/src/features/parent/ParentInsightsPage.tsx
@@ -1,5 +1,5 @@
 import { useParams, Link } from 'react-router-dom';
-import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
+import { Button, Card, EmptyState, LoadingSpinner, SectionHeading } from '@/shared/ui';
 import { useChildren } from './useChildren';
 import { useLatestParentSummary, useGenerateParentSummary } from './useParentSummary';
 import { NarrativeCard } from './components/NarrativeCard';
@@ -29,8 +29,6 @@ export const ParentInsightsPage = () => {
       { child_id: validChildId, language: 'en' },
       {
         onSuccess: () => {
-          // Backend queues a Celery task; in eager mode the summary is ready immediately.
-          // Refetch after a short pause to pick up either case.
           setTimeout(() => refetch(), 1500);
         },
       },
@@ -40,12 +38,17 @@ export const ParentInsightsPage = () => {
   if (!validChildId) {
     return (
       <div className="max-w-3xl mx-auto px-4 py-8">
-        <div className="text-center py-16 bg-white rounded-xl border border-gray-200">
-          <p className="text-gray-500 font-medium">No child selected</p>
-          <Link to="/parent/insights" className="text-indigo-600 text-sm font-medium mt-2 inline-block">
-            Pick a child
-          </Link>
-        </div>
+        <EmptyState
+          title="No child selected"
+          action={
+            <Link
+              to="/parent/insights"
+              className="text-brand-700 text-sm font-medium hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded"
+            >
+              Pick a child
+            </Link>
+          }
+        />
       </div>
     );
   }
@@ -56,60 +59,53 @@ export const ParentInsightsPage = () => {
         <div>
           <Link
             to="/parent"
-            className="text-sm text-indigo-600 font-medium hover:underline"
+            className="text-sm text-brand-700 font-medium hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded"
           >
             ← Back to dashboard
           </Link>
-          <h1 className="text-2xl font-bold text-gray-900 mt-1">
-            {child ? `${child.first_name || child.username}'s Insights` : 'Insights'}
-          </h1>
-          <p className="text-sm text-gray-500 mt-1">
-            A weekly progress narrative, alerts, and suggested home activities.
-          </p>
+          <div className="mt-1">
+            <SectionHeading
+              as="h1"
+              title={child ? `${child.first_name || child.username}'s Insights` : 'Insights'}
+              description="A weekly progress narrative, alerts, and suggested home activities."
+            />
+          </div>
         </div>
       </header>
 
       {isLoading && (
-        <div className="rounded-xl border border-gray-200 bg-white p-6">
+        <Card>
           <div className="flex items-center justify-center py-8">
             <LoadingSpinner />
           </div>
-        </div>
+        </Card>
       )}
 
       {!isLoading && isError && (
-        <div className="rounded-xl border border-red-200 bg-red-50 p-5">
-          <p className="font-semibold text-red-800">Couldn't load the summary</p>
-          <p className="text-sm text-red-700 mt-1">
+        <div className="rounded-xl border border-rose-200 bg-rose-50 p-5">
+          <p className="font-semibold text-rose-800">Couldn't load the summary</p>
+          <p className="text-sm text-rose-700 mt-1">
             {(error as { message?: string })?.message || 'Please try again in a moment.'}
           </p>
-          <button
-            onClick={() => refetch()}
-            className="mt-3 px-3 py-1.5 text-sm font-medium rounded-md bg-red-600 text-white hover:bg-red-700"
-          >
+          <Button size="sm" className="mt-3" onClick={() => refetch()}>
             Retry
-          </button>
+          </Button>
         </div>
       )}
 
       {!isLoading && !isError && !summary && (
-        <div className="rounded-xl border border-gray-200 bg-white p-6 text-center">
-          <p className="font-semibold text-gray-900">No summary yet</p>
-          <p className="text-sm text-gray-500 mt-1 max-w-md mx-auto">
-            We haven't generated a weekly summary for this child yet. Tap below to create one now —
-            it usually takes about 30 seconds.
-          </p>
-          <button
-            onClick={handleGenerate}
-            disabled={generate.isPending}
-            className="mt-4 px-4 py-2 text-sm font-semibold rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 disabled:bg-indigo-300 disabled:cursor-not-allowed transition-colors"
-          >
-            {generate.isPending ? 'Generating…' : "Generate this week's summary"}
-          </button>
+        <div>
+          <EmptyState
+            title="No summary yet"
+            description="We haven't generated a weekly summary for this child yet. Tap below to create one now — it usually takes about 30 seconds."
+            action={
+              <Button onClick={handleGenerate} disabled={generate.isPending}>
+                {generate.isPending ? 'Generating…' : "Generate this week's summary"}
+              </Button>
+            }
+          />
           {generate.isError && (
-            <p className="text-sm text-red-600 mt-3">
-              Generation failed. Please try again.
-            </p>
+            <p className="text-center text-sm text-rose-600 mt-3">Generation failed. Please try again.</p>
           )}
         </div>
       )}
@@ -121,13 +117,9 @@ export const ParentInsightsPage = () => {
           <HomeActivitiesPanel activities={summary.home_activities} />
 
           <div className="flex justify-end">
-            <button
-              onClick={handleGenerate}
-              disabled={generate.isPending}
-              className="px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 disabled:opacity-60 transition-colors"
-            >
+            <Button variant="ghost" size="sm" onClick={handleGenerate} disabled={generate.isPending}>
               {generate.isPending ? 'Regenerating…' : 'Regenerate'}
-            </button>
+            </Button>
           </div>
         </>
       )}

--- a/frontend_modern/src/features/parent/components/AlertsPanel.tsx
+++ b/frontend_modern/src/features/parent/components/AlertsPanel.tsx
@@ -1,19 +1,23 @@
+import { Badge } from '@/shared/ui';
 import type { ParentAlert } from '../useParentSummary';
 
-const SEVERITY_STYLES: Record<ParentAlert['severity'], { card: string; chip: string; label: string }> = {
+const SEVERITY_STYLES: Record<
+  ParentAlert['severity'],
+  { card: string; tone: 'urgent' | 'attention' | 'brand'; label: string }
+> = {
   urgent: {
-    card: 'border-red-200 bg-red-50',
-    chip: 'bg-red-100 text-red-700',
+    card: 'border-rose-200 bg-rose-50',
+    tone: 'urgent',
     label: 'Urgent',
   },
   attention: {
     card: 'border-amber-200 bg-amber-50',
-    chip: 'bg-amber-100 text-amber-800',
+    tone: 'attention',
     label: 'Attention',
   },
   info: {
-    card: 'border-blue-200 bg-blue-50',
-    chip: 'bg-blue-100 text-blue-700',
+    card: 'border-brand-200 bg-brand-50',
+    tone: 'brand',
     label: 'Info',
   },
 };
@@ -27,7 +31,7 @@ export const AlertsPanel = ({ alerts }: Props) => {
 
   return (
     <section aria-label="Alerts" className="space-y-3">
-      <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">Alerts</h3>
+      <h3 className="text-sm font-semibold text-ink-700 uppercase tracking-wide">Alerts</h3>
       <div className="space-y-2">
         {alerts.map((alert, idx) => {
           const styles = SEVERITY_STYLES[alert.severity] ?? SEVERITY_STYLES.info;
@@ -39,14 +43,12 @@ export const AlertsPanel = ({ alerts }: Props) => {
             >
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
-                  <p className="font-semibold text-gray-900">{alert.label}</p>
-                  <p className="text-sm text-gray-700 mt-1">{alert.detail}</p>
+                  <p className="font-semibold text-ink-900">{alert.label}</p>
+                  <p className="text-sm text-ink-700 mt-1">{alert.detail}</p>
                 </div>
-                <span
-                  className={`shrink-0 text-xs font-semibold px-2 py-1 rounded-full ${styles.chip}`}
-                >
+                <Badge tone={styles.tone} className="shrink-0">
                   {styles.label}
-                </span>
+                </Badge>
               </div>
             </div>
           );

--- a/frontend_modern/src/features/parent/components/HomeActivitiesPanel.tsx
+++ b/frontend_modern/src/features/parent/components/HomeActivitiesPanel.tsx
@@ -1,3 +1,4 @@
+import { Badge } from '@/shared/ui';
 import type { HomeActivity } from '../useParentSummary';
 
 interface Props {
@@ -11,7 +12,7 @@ export const HomeActivitiesPanel = ({ activities }: Props) => {
 
   return (
     <section aria-label="Home Activities" className="space-y-3">
-      <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+      <h3 className="text-sm font-semibold text-ink-700 uppercase tracking-wide">
         Try this week at home
       </h3>
       <div className="grid gap-3 sm:grid-cols-2">
@@ -22,18 +23,18 @@ export const HomeActivitiesPanel = ({ activities }: Props) => {
               key={`${activity.title}-${idx}`}
               data-celebrate={celebrate || undefined}
               className={`rounded-xl border p-4 ${
-                celebrate ? 'border-emerald-200 bg-emerald-50' : 'border-gray-200 bg-white'
+                celebrate ? 'border-emerald-200 bg-emerald-50' : 'os-card'
               }`}
             >
               <div className="flex items-start justify-between gap-2">
-                <p className="font-semibold text-gray-900">{activity.title}</p>
+                <p className="font-semibold text-ink-900">{activity.title}</p>
                 {activity.chapter_name && (
-                  <span className="shrink-0 text-xs font-medium px-2 py-1 rounded-full bg-indigo-50 text-indigo-700">
+                  <Badge tone="brand" className="shrink-0">
                     {activity.chapter_name}
-                  </span>
+                  </Badge>
                 )}
               </div>
-              <p className="text-sm text-gray-700 mt-2 leading-relaxed">{activity.description}</p>
+              <p className="text-sm text-ink-700 mt-2 leading-relaxed">{activity.description}</p>
             </div>
           );
         })}

--- a/frontend_modern/src/features/parent/components/NarrativeCard.tsx
+++ b/frontend_modern/src/features/parent/components/NarrativeCard.tsx
@@ -1,3 +1,4 @@
+import { Badge } from '@/shared/ui';
 import type { ParentProgressSummary } from '../useParentSummary';
 
 interface Props {
@@ -13,9 +14,9 @@ const formatDate = (iso: string): string => {
 };
 
 const StatTile = ({ label, value }: { label: string; value: string }) => (
-  <div className="rounded-lg bg-gray-50 px-3 py-2">
-    <p className="text-xs text-gray-500 font-medium">{label}</p>
-    <p className="text-base font-semibold text-gray-900 mt-0.5">{value}</p>
+  <div className="rounded-lg bg-ink-50 px-3 py-2">
+    <p className="text-xs text-ink-500 font-medium">{label}</p>
+    <p className="text-base font-semibold text-ink-900 mt-0.5">{value}</p>
   </div>
 );
 
@@ -27,24 +28,22 @@ export const NarrativeCard = ({ summary }: Props) => {
     summary.score_delta > 0.01
       ? 'text-emerald-700 bg-emerald-50'
       : summary.score_delta < -0.01
-        ? 'text-red-700 bg-red-50'
-        : 'text-gray-700 bg-gray-100';
+        ? 'text-rose-700 bg-rose-50'
+        : 'text-ink-700 bg-ink-100';
 
   return (
-    <article className="rounded-xl border border-gray-200 bg-white p-5 sm:p-6">
+    <article className="os-card p-5 sm:p-6">
       <div className="flex items-start justify-between gap-3 flex-wrap">
         <div>
-          <p className="text-xs uppercase tracking-wide text-gray-500 font-medium">
+          <p className="text-xs uppercase tracking-wide text-ink-500 font-medium">
             Weekly summary · {summary.child_name}
           </p>
-          <p className="text-sm text-gray-500 mt-1">{weekRange}</p>
+          <p className="text-sm text-ink-500 mt-1">{weekRange}</p>
         </div>
-        <span className="shrink-0 text-xs font-medium px-2 py-1 rounded-full bg-indigo-50 text-indigo-700">
-          {summary.model_used}
-        </span>
+        <Badge tone="brand">{summary.model_used}</Badge>
       </div>
 
-      <p className="mt-4 text-gray-800 leading-relaxed whitespace-pre-line">
+      <p className="mt-4 text-ink-800 leading-relaxed whitespace-pre-line">
         {summary.summary_text}
       </p>
 


### PR DESCRIPTION
## Summary
Migrates all parent-role surfaces to V2 'Chalk & Unlock'.

**Classification:** Improve (reskin only)
**Initiative:** V2 design system M4-02
**Plan:** docs/daily-plans/2026-06-03-plan.md (item 2)

## Files
- features/parent/ParentDashboard.tsx
- features/parent/ParentInsightsLandingPage.tsx
- features/parent/ParentInsightsPage.tsx
- features/parent/components/NarrativeCard.tsx
- features/parent/components/AlertsPanel.tsx
- features/parent/components/HomeActivitiesPanel.tsx

## What changed
- Tokens: indigo/red/blue/green/gray → brand/rose/amber/emerald/ink
- Headings → <SectionHeading> (font-display)
- Cards → <Card> / .os-card
- Status pills → <Badge> with success/attention/urgent/brand tones; new explicit Overdue badge
- Tabs → chalk-underline with focus-visible ring
- Empty states → <EmptyState> keyhole motif
- motion-reduce:transition-none on transitions
- data-severity / data-celebrate preserved for tests

## Tests
- type-check, lint, build, vitest 84/84 — green

## Verify
`parent_demo` / `demo1234` → /parent, /parent/insights, child insights page.