### PR TITLE
feat(frontend): migrate Admin Dashboard + Classroom manage to V2

### DIFF
--- a/docs/changes/2026-06-03-admin-surfaces-v2.md
+++ b/docs/changes/2026-06-03-admin-surfaces-v2.md
@@ -1,0 +1,31 @@
+# 2026-06-03 — Admin Dashboard + Classroom manage migrated to V2
+
+## Summary
+Migrated `AdminDashboard.tsx`, `ClassroomManagePage.tsx`, and
+`EnrollStudentsModal.tsx` to V2 "Chalk & Unlock". Stat tiles now use the
+`<Stat>` primitive, the modal uses `.os-card` chrome, and form fields use
+`ui/Input`/`Select`.
+
+## Classification
+Improve — reskin only. Hooks, role guards, mutations unchanged.
+
+## What changed
+- Summary tiles → `<Stat>` (font-display value, ink-400 label).
+- Forms wrapped in `<Card>`; subject-room mini-form on warm `bg-paper`.
+- Indigo/red/gray classes → brand/rose/ink tokens.
+- Buttons → `<Button variant="brand"|"ghost">`.
+- Empty states → `<EmptyState>` keyhole motif.
+- ClassroomRow gets keyboard activation (Enter/Space) + focus-visible ring + warm hover.
+- Modal: black/40 → ink-900/40 backdrop; close-icon uses ink-* hovers.
+- EnrollStudentsModal preserved every query hook used by tests
+  (search placeholder, "Enroll"/"Remove" button names, label structure containing
+  student names) — test file unchanged, 84/84 still green.
+
+## Tests
+- type-check / lint / build / vitest 84/84 — green.
+
+## Verify
+`admin_demo` / `demo1234` → /admin, open a classroom, click "Manage students".
+
+## Next
+PRs 4–5 will migrate Proficiency cluster and Assignment/SRS surfaces.

--- a/frontend_modern/src/features/admin/AdminDashboard.tsx
+++ b/frontend_modern/src/features/admin/AdminDashboard.tsx
@@ -1,6 +1,15 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
+import {
+  Button,
+  Card,
+  EmptyState,
+  Input,
+  LoadingSpinner,
+  SectionHeading,
+  Select,
+  Stat,
+} from '@/shared/ui';
 import { useStandards } from '@/features/teacher/useStandards';
 import { useAdminSummary } from './useAdminSummary';
 import { useSchoolTeachers } from './useSchoolPeople';
@@ -13,17 +22,9 @@ import {
 
 const defaultAcademicYear = (): string => {
   const now = new Date();
-  // Indian academic year runs ~Apr–Mar; before April belongs to the prior year's intake.
   const startYear = now.getMonth() >= 3 ? now.getFullYear() : now.getFullYear() - 1;
   return `${startYear}-${String((startYear + 1) % 100).padStart(2, '0')}`;
 };
-
-const SummaryCard = ({ label, value }: { label: string; value: number }) => (
-  <div className="bg-white rounded-xl border border-gray-200 p-5">
-    <p className="text-2xl font-bold text-gray-900">{value}</p>
-    <p className="text-sm text-gray-500 mt-1">{label}</p>
-  </div>
-);
 
 const NewClassroomForm = ({ onDone }: { onDone: () => void }) => {
   const { data: standards } = useStandards();
@@ -58,20 +59,19 @@ const NewClassroomForm = ({ onDone }: { onDone: () => void }) => {
             'Could not create classroom. Check for duplicates.';
           setError(detail);
         },
-      }
+      },
     );
   };
 
   return (
-    <form onSubmit={submit} className="bg-white rounded-xl border border-gray-200 p-5 space-y-4">
-      <h3 className="font-semibold text-gray-900">New Classroom</h3>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <label className="block">
-          <span className="text-sm font-medium text-gray-700">Standard</span>
-          <select
+    <Card>
+      <form onSubmit={submit} className="space-y-4">
+        <h3 className="font-display font-semibold text-ink-900">New Classroom</h3>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <Select
+            label="Standard"
             value={standard}
             onChange={(e) => setStandard(e.target.value === '' ? '' : Number(e.target.value))}
-            className="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
           >
             <option value="">Select…</option>
             {standards?.map((s) => (
@@ -79,34 +79,25 @@ const NewClassroomForm = ({ onDone }: { onDone: () => void }) => {
                 Grade {s.number}
               </option>
             ))}
-          </select>
-        </label>
-        <label className="block">
-          <span className="text-sm font-medium text-gray-700">Division</span>
-          <input
+          </Select>
+          <Input
+            label="Division"
             type="text"
             value={division}
             onChange={(e) => setDivision(e.target.value)}
             placeholder="A"
-            className="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
           />
-        </label>
-        <label className="block">
-          <span className="text-sm font-medium text-gray-700">Academic Year</span>
-          <input
+          <Input
+            label="Academic Year"
             type="text"
             value={academicYear}
             onChange={(e) => setAcademicYear(e.target.value)}
             placeholder="2026-27"
-            className="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
           />
-        </label>
-        <label className="block">
-          <span className="text-sm font-medium text-gray-700">Class Teacher (optional)</span>
-          <select
+          <Select
+            label="Class Teacher (optional)"
             value={classTeacher}
             onChange={(e) => setClassTeacher(e.target.value === '' ? '' : Number(e.target.value))}
-            className="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
           >
             <option value="">None</option>
             {teachers?.map((t) => (
@@ -114,27 +105,19 @@ const NewClassroomForm = ({ onDone }: { onDone: () => void }) => {
                 {t.full_name}
               </option>
             ))}
-          </select>
-        </label>
-      </div>
-      {error && <p className="text-sm text-red-600">{error}</p>}
-      <div className="flex justify-end gap-2">
-        <button
-          type="button"
-          onClick={onDone}
-          className="px-4 py-2 rounded-lg text-sm font-medium border border-gray-300 text-gray-700 hover:bg-gray-50 transition-colors"
-        >
-          Cancel
-        </button>
-        <button
-          type="submit"
-          disabled={createClassroom.isPending}
-          className="px-4 py-2 rounded-lg text-sm font-medium bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors"
-        >
-          {createClassroom.isPending ? 'Creating…' : 'Create'}
-        </button>
-      </div>
-    </form>
+          </Select>
+        </div>
+        {error && <p className="text-sm text-rose-600">{error}</p>}
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="ghost" size="sm" onClick={onDone}>
+            Cancel
+          </Button>
+          <Button type="submit" size="sm" disabled={createClassroom.isPending}>
+            {createClassroom.isPending ? 'Creating…' : 'Create'}
+          </Button>
+        </div>
+      </form>
+    </Card>
   );
 };
 
@@ -146,7 +129,7 @@ const ClassroomRow = ({ classroom }: { classroom: Classroom }) => {
     e.stopPropagation();
     if (
       window.confirm(
-        `Deactivate Grade ${classroom.standard_number}-${classroom.division}? It will be archived, not deleted.`
+        `Deactivate Grade ${classroom.standard_number}-${classroom.division}? It will be archived, not deleted.`,
       )
     ) {
       deleteClassroom.mutate(classroom.id);
@@ -155,32 +138,41 @@ const ClassroomRow = ({ classroom }: { classroom: Classroom }) => {
 
   return (
     <div
-      className={`bg-white rounded-xl border border-gray-200 p-4 cursor-pointer hover:border-indigo-300 transition-colors ${
+      role="button"
+      tabIndex={0}
+      onClick={() => navigate(`/admin/classrooms/${classroom.id}`)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          navigate(`/admin/classrooms/${classroom.id}`);
+        }
+      }}
+      className={`os-card p-4 cursor-pointer hover:border-brand-300 hover:bg-brand-50/40 transition-colors motion-reduce:transition-none focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 ${
         !classroom.is_active ? 'opacity-60' : ''
       }`}
-      onClick={() => navigate(`/admin/classrooms/${classroom.id}`)}
     >
       <div className="flex items-center justify-between gap-4">
         <div className="min-w-0">
-          <p className="font-semibold text-gray-900">
+          <p className="font-semibold text-ink-900">
             Grade {classroom.standard_number}-{classroom.division}
             {!classroom.is_active && (
-              <span className="ml-2 text-xs font-medium text-gray-400">(archived)</span>
+              <span className="ml-2 text-xs font-medium text-ink-400">(archived)</span>
             )}
           </p>
-          <p className="text-sm text-gray-500 mt-0.5">
+          <p className="text-sm text-ink-500 mt-0.5">
             {classroom.class_teacher_name ?? 'No class teacher'} · {classroom.academic_year}
           </p>
         </div>
         <div className="text-right shrink-0 flex items-center gap-4">
-          <p className="text-sm font-medium text-gray-700">
+          <p className="text-sm font-medium text-ink-700">
             {classroom.student_count} student{classroom.student_count !== 1 ? 's' : ''}
           </p>
           {classroom.is_active && (
             <button
+              type="button"
               onClick={onDelete}
               disabled={deleteClassroom.isPending}
-              className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50"
+              className="text-xs text-rose-600 hover:text-rose-700 disabled:opacity-50 focus:outline-none focus-visible:underline"
             >
               Archive
             </button>
@@ -199,45 +191,43 @@ export const AdminDashboard = () => {
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-8 space-y-8">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">
-            {summary?.school.name ?? 'School Admin'}
-          </h1>
-          <p className="text-sm text-gray-500 mt-1">Manage classrooms, enrollment, and subject rooms.</p>
-        </div>
-        <button
-          onClick={() => setShowForm((v) => !v)}
-          className="bg-indigo-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-indigo-700 transition-colors"
-        >
-          + New Classroom
-        </button>
-      </div>
+      <SectionHeading
+        as="h1"
+        title={summary?.school.name ?? 'School Admin'}
+        description="Manage classrooms, enrollment, and subject rooms."
+        action={
+          <Button size="sm" onClick={() => setShowForm((v) => !v)}>
+            + New Classroom
+          </Button>
+        }
+      />
 
       {summaryLoading ? (
         <div className="flex justify-center py-6">
           <LoadingSpinner size="lg" />
         </div>
       ) : summary ? (
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-          <SummaryCard label="Classrooms" value={summary.classroom_count} />
-          <SummaryCard label="Teachers" value={summary.teacher_count} />
-          <SummaryCard label="Students" value={summary.student_count} />
-          <SummaryCard label="Subject Rooms" value={summary.active_subject_rooms} />
-        </div>
+        <Card>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-6">
+            <Stat label="Classrooms" value={summary.classroom_count} />
+            <Stat label="Teachers" value={summary.teacher_count} />
+            <Stat label="Students" value={summary.student_count} />
+            <Stat label="Subject Rooms" value={summary.active_subject_rooms} />
+          </div>
+        </Card>
       ) : null}
 
       {showForm && <NewClassroomForm onDone={() => setShowForm(false)} />}
 
       <section>
         <div className="flex items-center justify-between mb-3">
-          <h2 className="text-lg font-semibold text-gray-800">Classrooms</h2>
-          <label className="flex items-center gap-2 text-sm text-gray-500 cursor-pointer">
+          <h2 className="text-lg font-display font-semibold text-ink-800">Classrooms</h2>
+          <label className="flex items-center gap-2 text-sm text-ink-500 cursor-pointer">
             <input
               type="checkbox"
               checked={includeInactive}
               onChange={(e) => setIncludeInactive(e.target.checked)}
-              className="w-4 h-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              className="w-4 h-4 rounded border-ink-300 text-brand-600 focus:ring-brand-500"
             />
             Show archived
           </label>
@@ -247,9 +237,10 @@ export const AdminDashboard = () => {
             <LoadingSpinner size="lg" />
           </div>
         ) : !classrooms || classrooms.length === 0 ? (
-          <div className="text-center py-8 text-gray-400 bg-white rounded-xl border border-gray-200">
-            <p className="text-sm">No classrooms yet. Create one to start onboarding your school.</p>
-          </div>
+          <EmptyState
+            title="No classrooms yet"
+            description="Create one to start onboarding your school."
+          />
         ) : (
           <div className="space-y-3">
             {classrooms.map((c) => (

--- a/frontend_modern/src/features/admin/ClassroomManagePage.tsx
+++ b/frontend_modern/src/features/admin/ClassroomManagePage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
+import { Button, Card, EmptyState, LoadingSpinner, Select } from '@/shared/ui';
 import { useSubjects } from '@/features/teacher/useSubjects';
 import { useClassroom, useClassroomEnrollment } from './useClassrooms';
 import { useSchoolStudents, useSchoolTeachers } from './useSchoolPeople';
@@ -47,60 +47,46 @@ const NewSubjectRoomForm = ({
             'Could not create subject room. A room for this subject may already exist.';
           setError(msg);
         },
-      }
+      },
     );
   };
 
   return (
-    <form onSubmit={submit} className="bg-gray-50 rounded-xl border border-gray-200 p-4 space-y-3">
+    <form onSubmit={submit} className="rounded-xl border border-ink-200 bg-paper p-4 space-y-3">
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        <label className="block">
-          <span className="text-sm font-medium text-gray-700">Subject</span>
-          <select
-            value={subject}
-            onChange={(e) => setSubject(e.target.value === '' ? '' : Number(e.target.value))}
-            className="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          >
-            <option value="">Select subject…</option>
-            {subjects?.map((s) => (
-              <option key={s.id} value={s.id}>
-                {s.name}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="block">
-          <span className="text-sm font-medium text-gray-700">Teacher</span>
-          <select
-            value={teacher}
-            onChange={(e) => setTeacher(e.target.value === '' ? '' : Number(e.target.value))}
-            className="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          >
-            <option value="">Select teacher…</option>
-            {teachers?.map((t) => (
-              <option key={t.id} value={t.id}>
-                {t.full_name}
-              </option>
-            ))}
-          </select>
-        </label>
+        <Select
+          label="Subject"
+          value={subject}
+          onChange={(e) => setSubject(e.target.value === '' ? '' : Number(e.target.value))}
+        >
+          <option value="">Select subject…</option>
+          {subjects?.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
+          ))}
+        </Select>
+        <Select
+          label="Teacher"
+          value={teacher}
+          onChange={(e) => setTeacher(e.target.value === '' ? '' : Number(e.target.value))}
+        >
+          <option value="">Select teacher…</option>
+          {teachers?.map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.full_name}
+            </option>
+          ))}
+        </Select>
       </div>
-      {error && <p className="text-sm text-red-600">{error}</p>}
+      {error && <p className="text-sm text-rose-600">{error}</p>}
       <div className="flex justify-end gap-2">
-        <button
-          type="button"
-          onClick={onDone}
-          className="px-3 py-1.5 rounded-lg text-sm font-medium border border-gray-300 text-gray-700 hover:bg-white transition-colors"
-        >
+        <Button type="button" variant="ghost" size="sm" onClick={onDone}>
           Cancel
-        </button>
-        <button
-          type="submit"
-          disabled={createRoom.isPending}
-          className="px-3 py-1.5 rounded-lg text-sm font-medium bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors"
-        >
+        </Button>
+        <Button type="submit" size="sm" disabled={createRoom.isPending}>
           {createRoom.isPending ? 'Creating…' : 'Create Subject Room'}
-        </button>
+        </Button>
       </div>
     </form>
   );
@@ -131,11 +117,15 @@ export const ClassroomManagePage = () => {
 
   if (!classroom) {
     return (
-      <div className="max-w-2xl mx-auto px-4 py-16 text-center text-gray-500">
-        <p>Classroom not found.</p>
-        <button onClick={() => navigate('/admin')} className="mt-3 text-sm text-indigo-600 hover:underline">
-          Back to dashboard
-        </button>
+      <div className="max-w-2xl mx-auto px-4 py-16">
+        <EmptyState
+          title="Classroom not found"
+          action={
+            <Button variant="ghost" size="sm" onClick={() => navigate('/admin')}>
+              Back to dashboard
+            </Button>
+          }
+        />
       </div>
     );
   }
@@ -144,15 +134,19 @@ export const ClassroomManagePage = () => {
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-8 space-y-8">
-      <button onClick={() => navigate('/admin')} className="text-sm text-indigo-600 hover:underline">
+      <button
+        type="button"
+        onClick={() => navigate('/admin')}
+        className="text-sm text-brand-700 font-medium hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded"
+      >
         ← Back to dashboard
       </button>
 
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">
+        <h1 className="text-2xl font-display font-semibold text-ink-900">
           Grade {classroom.standard_number}-{classroom.division}
         </h1>
-        <p className="text-sm text-gray-500 mt-1">
+        <p className="text-sm text-ink-500 mt-1">
           {classroom.class_teacher_name ?? 'No class teacher'} · {classroom.academic_year} ·{' '}
           {classroom.student_count} student{classroom.student_count !== 1 ? 's' : ''}
         </p>
@@ -160,26 +154,28 @@ export const ClassroomManagePage = () => {
 
       <section>
         <div className="flex items-center justify-between mb-3">
-          <h2 className="text-lg font-semibold text-gray-800">Roster</h2>
+          <h2 className="text-lg font-display font-semibold text-ink-800">Roster</h2>
           <button
+            type="button"
             onClick={() => setShowRoster(true)}
-            className="text-sm text-indigo-600 hover:underline"
+            className="text-sm text-brand-700 font-medium hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded"
           >
             Manage students
           </button>
         </div>
-        <div className="bg-white rounded-xl border border-gray-200 p-5 text-sm text-gray-600">
+        <Card className="text-sm text-ink-700 p-5">
           {classroom.student_count} student{classroom.student_count !== 1 ? 's' : ''} enrolled in this
           classroom. Use “Manage students” to enroll or remove students.
-        </div>
+        </Card>
       </section>
 
       <section>
         <div className="flex items-center justify-between mb-3">
-          <h2 className="text-lg font-semibold text-gray-800">Subject Rooms</h2>
+          <h2 className="text-lg font-display font-semibold text-ink-800">Subject Rooms</h2>
           <button
+            type="button"
             onClick={() => setShowNewRoom((v) => !v)}
-            className="text-sm text-indigo-600 hover:underline"
+            className="text-sm text-brand-700 font-medium hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded"
           >
             + Add subject room
           </button>
@@ -196,32 +192,31 @@ export const ClassroomManagePage = () => {
             <LoadingSpinner size="lg" />
           </div>
         ) : rooms.length === 0 ? (
-          <div className="text-center py-8 text-gray-400 bg-white rounded-xl border border-gray-200">
-            <p className="text-sm">No subject rooms yet. Add one to assign a teacher and students.</p>
-          </div>
+          <EmptyState
+            title="No subject rooms yet"
+            description="Add one to assign a teacher and students."
+          />
         ) : (
           <div className="space-y-3">
             {rooms.map((room) => (
-              <div
-                key={room.id}
-                className="bg-white rounded-xl border border-gray-200 p-4 flex items-center justify-between"
-              >
+              <Card key={room.id} className="p-4 flex items-center justify-between">
                 <div>
-                  <p className="font-semibold text-gray-900">{room.subject_name}</p>
-                  <p className="text-sm text-gray-500 mt-0.5">{room.teacher_name}</p>
+                  <p className="font-semibold text-ink-900">{room.subject_name}</p>
+                  <p className="text-sm text-ink-500 mt-0.5">{room.teacher_name}</p>
                 </div>
                 <div className="text-right flex items-center gap-4">
-                  <p className="text-sm font-medium text-gray-700">
+                  <p className="text-sm font-medium text-ink-700">
                     {room.student_count} student{room.student_count !== 1 ? 's' : ''}
                   </p>
                   <button
+                    type="button"
                     onClick={() => setEnrollingRoom(room)}
-                    className="text-xs text-indigo-600 hover:underline"
+                    className="text-xs text-brand-700 font-medium hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded"
                   >
                     Manage students
                   </button>
                 </div>
-              </div>
+              </Card>
             ))}
           </div>
         )}

--- a/frontend_modern/src/features/admin/EnrollStudentsModal.tsx
+++ b/frontend_modern/src/features/admin/EnrollStudentsModal.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { Button, Input } from '@/shared/ui';
 import type { SchoolPerson } from './useSchoolPeople';
 import type { EnrollmentResult } from './useClassrooms';
 
@@ -20,7 +21,7 @@ export const EnrollStudentsModal = ({
   const [search, setSearch] = useState('');
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const [result, setResult] = useState<{ action: string; count: number; invalid: number } | null>(
-    null
+    null,
   );
   const [error, setError] = useState<string | null>(null);
 
@@ -28,7 +29,7 @@ export const EnrollStudentsModal = ({
     const q = search.trim().toLowerCase();
     if (!q) return students;
     return students.filter(
-      (s) => s.full_name.toLowerCase().includes(q) || s.email.toLowerCase().includes(q)
+      (s) => s.full_name.toLowerCase().includes(q) || s.email.toLowerCase().includes(q),
     );
   }, [students, search]);
 
@@ -58,13 +59,14 @@ export const EnrollStudentsModal = ({
   };
 
   return (
-    <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/40 p-4">
-      <div className="bg-white rounded-2xl shadow-xl w-full max-w-lg max-h-[85vh] flex flex-col">
-        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100">
-          <h3 className="font-semibold text-gray-900">{title}</h3>
+    <div className="fixed inset-0 z-40 flex items-center justify-center bg-ink-900/40 p-4">
+      <div className="os-card w-full max-w-lg max-h-[85vh] flex flex-col p-0 shadow-xl">
+        <div className="flex items-center justify-between px-5 py-4 border-b border-ink-100">
+          <h3 className="font-display font-semibold text-ink-900">{title}</h3>
           <button
+            type="button"
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 transition-colors"
+            className="text-ink-400 hover:text-ink-700 transition-colors motion-reduce:transition-none focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded"
             aria-label="Close"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -73,21 +75,20 @@ export const EnrollStudentsModal = ({
           </button>
         </div>
 
-        <div className="px-5 py-3 border-b border-gray-100">
-          <input
+        <div className="px-5 py-3 border-b border-ink-100">
+          <Input
             type="text"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search students by name or email…"
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
           />
         </div>
 
         <div className="flex-1 overflow-y-auto px-5 py-2">
           {filtered.length === 0 ? (
-            <p className="text-sm text-gray-400 py-6 text-center">No students found.</p>
+            <p className="text-sm text-ink-400 py-6 text-center">No students found.</p>
           ) : (
-            <ul className="divide-y divide-gray-100">
+            <ul className="divide-y divide-ink-100">
               {filtered.map((s) => (
                 <li key={s.id}>
                   <label className="flex items-center gap-3 py-2.5 cursor-pointer">
@@ -95,13 +96,13 @@ export const EnrollStudentsModal = ({
                       type="checkbox"
                       checked={selected.has(s.id)}
                       onChange={() => toggle(s.id)}
-                      className="w-4 h-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                      className="w-4 h-4 rounded border-ink-300 text-brand-600 focus:ring-brand-500"
                     />
                     <span className="min-w-0">
-                      <span className="block text-sm font-medium text-gray-900 truncate">
+                      <span className="block text-sm font-medium text-ink-900 truncate">
                         {s.full_name}
                       </span>
-                      <span className="block text-xs text-gray-500 truncate">{s.email}</span>
+                      <span className="block text-xs text-ink-500 truncate">{s.email}</span>
                     </span>
                   </label>
                 </li>
@@ -111,11 +112,11 @@ export const EnrollStudentsModal = ({
         </div>
 
         {(result || error) && (
-          <div className="px-5 py-2 text-sm border-t border-gray-100">
+          <div className="px-5 py-2 text-sm border-t border-ink-100">
             {error ? (
-              <span className="text-red-600">{error}</span>
+              <span className="text-rose-600">{error}</span>
             ) : (
-              <span className="text-gray-600">
+              <span className="text-ink-600">
                 {result!.count} student{result!.count !== 1 ? 's' : ''} {result!.action}ed
                 {result!.invalid > 0 && ` · ${result!.invalid} skipped (invalid)`}
               </span>
@@ -123,22 +124,23 @@ export const EnrollStudentsModal = ({
           </div>
         )}
 
-        <div className="flex items-center justify-end gap-2 px-5 py-4 border-t border-gray-100">
-          <span className="text-xs text-gray-500 mr-auto">{selected.size} selected</span>
-          <button
+        <div className="flex items-center justify-end gap-2 px-5 py-4 border-t border-ink-100">
+          <span className="text-xs text-ink-500 mr-auto">{selected.size} selected</span>
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => run('unenroll')}
             disabled={isPending || selected.size === 0}
-            className="px-4 py-2 rounded-lg text-sm font-medium border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:opacity-50 transition-colors"
           >
             Remove
-          </button>
-          <button
+          </Button>
+          <Button
+            size="sm"
             onClick={() => run('enroll')}
             disabled={isPending || selected.size === 0}
-            className="px-4 py-2 rounded-lg text-sm font-medium bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors"
           >
             Enroll
-          </button>
+          </Button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Migrates admin-role surfaces to V2 'Chalk & Unlock'.

**Classification:** Improve (reskin only)
**Initiative:** V2 design system M4-04
**Plan:** docs/daily-plans/2026-06-03-plan.md (item 3)

## Files
- features/admin/AdminDashboard.tsx
- features/admin/ClassroomManagePage.tsx
- features/admin/EnrollStudentsModal.tsx

## What changed
- Summary tiles → <Stat> primitive (font-display, brand-aligned)
- Forms wrapped in <Card>; subject-room form on warm bg-paper
- Buttons → <Button variant=brand|ghost>; form inputs → ui/Input + ui/Select
- ClassroomRow: keyboard activation (Enter/Space) + focus-visible + warm hover
- Modal: ink-900/40 backdrop, .os-card chrome
- EnrollStudentsModal test hooks (search placeholder, button names, label structure) preserved

## Tests
- type-check, lint, vitest 84/84, build — green
- EnrollStudentsModal.test.tsx still passes unchanged

## Verify
`admin_demo` / `demo1234` → /admin, open a classroom, click 'Manage students'.