### PR TITLE
feat(frontend): migrate proficiency cluster to V2

### DIFF
--- a/docs/changes/2026-06-03-proficiency-cluster-v2.md
+++ b/docs/changes/2026-06-03-proficiency-cluster-v2.md
@@ -1,0 +1,27 @@
+# 2026-06-03 — Proficiency cluster migrated to V2
+
+## Summary
+Migrated the student proficiency cluster: `ProficiencyPage.tsx`, `StreakBadge.tsx`,
+and the two dashboard child panels `DueForReviewPanel.tsx` + `RecommendationsPanel.tsx`.
+Mastery now reads as the "unlock" motif — brand-600 fill at >=70% with a check glyph.
+
+## Classification
+Improve — reskin + a touch of motif (unlock check) on mastery rows.
+
+## What changed
+- `ProficiencyPage`: SectionHeading, Card, EmptyState; ink/brand tokens; mastery
+  bar in `brand-600` + check glyph (unlock motif).
+- `StreakBadge`: tier palette swung to brand/amber tokens (orange/yellow/amber/purple →
+  brand/amber/amber/brand) — escalates within the brand language.
+- `DueForReviewPanel`: red/blue → rose/brand; `os-card` with amber warning border.
+- `RecommendationsPanel`: priority badges and links to ink/brand tokens; warm divider.
+- `motion-reduce:transition-none` + focus-visible rings on the Practice CTA.
+
+## Tests
+- type-check / lint / build / vitest 84/84 — green.
+
+## Verify
+`student_demo` / `demo1234` → /student (dashboard panels) and /student/proficiency.
+
+## Next
+PR5 will migrate Assignment detail + SRS drill + shared cards.

--- a/frontend_modern/src/features/student/DueForReviewPanel.tsx
+++ b/frontend_modern/src/features/student/DueForReviewPanel.tsx
@@ -14,9 +14,9 @@ const getUrgency = (nextReviewDate: string): Urgency => {
 };
 
 const URGENCY_STYLES: Record<Urgency, { dot: string; text: string; label: string; bg: string }> = {
-  overdue: { dot: 'bg-red-500', text: 'text-red-700', label: 'Overdue', bg: 'bg-red-50' },
-  today: { dot: 'bg-amber-500', text: 'text-amber-700', label: 'Due today', bg: 'bg-amber-50' },
-  soon: { dot: 'bg-blue-400', text: 'text-blue-700', label: 'Coming up', bg: '' },
+  overdue: { dot: 'bg-rose-500', text: 'text-rose-700', label: 'Overdue', bg: 'bg-rose-50' },
+  today: { dot: 'bg-amber-500', text: 'text-amber-800', label: 'Due today', bg: 'bg-amber-50' },
+  soon: { dot: 'bg-brand-400', text: 'text-brand-700', label: 'Coming up', bg: '' },
 };
 
 const SRSRow = ({ entry }: { entry: SRSEntry }) => {
@@ -26,26 +26,26 @@ const SRSRow = ({ entry }: { entry: SRSEntry }) => {
     urgency === 'overdue'
       ? `Overdue since ${entry.next_review_date}`
       : urgency === 'today'
-      ? 'Due today'
-      : `Due ${entry.next_review_date}`;
+        ? 'Due today'
+        : `Due ${entry.next_review_date}`;
 
   return (
     <div className={`flex items-center justify-between py-2.5 px-3 rounded-lg ${style.bg}`}>
       <div className="flex items-center gap-2 min-w-0">
         <span className={`shrink-0 w-2 h-2 rounded-full ${style.dot}`} />
         <div className="min-w-0">
-          <p className="text-sm font-medium text-gray-900 truncate">{entry.chapter_name}</p>
+          <p className="text-sm font-medium text-ink-900 truncate">{entry.chapter_name}</p>
           <p className={`text-xs ${style.text}`}>{dueLabel}</p>
         </div>
       </div>
       <div className="flex items-center gap-3 shrink-0 ml-3">
         <div className="text-right hidden sm:block">
-          <p className="text-xs text-gray-500">every {entry.interval_days}d</p>
-          <p className="text-xs text-gray-400">{entry.repetitions}× reviewed</p>
+          <p className="text-xs text-ink-500">every {entry.interval_days}d</p>
+          <p className="text-xs text-ink-400">{entry.repetitions}× reviewed</p>
         </div>
         <Link
           to={`/student/srs-drill/${entry.id}`}
-          className="text-xs font-semibold text-indigo-600 hover:text-white border border-indigo-200 rounded-full px-3 py-1 hover:bg-indigo-600 hover:border-indigo-600 transition-colors"
+          className="text-xs font-semibold text-brand-700 hover:text-white border border-brand-200 rounded-full px-3 py-1 hover:bg-brand-600 hover:border-brand-600 transition-colors motion-reduce:transition-none focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2"
         >
           Practice
         </Link>
@@ -60,22 +60,22 @@ export const DueForReviewPanel = () => {
   if (!entries || entries.length === 0) return null;
 
   const sorted = [...entries].sort((a, b) =>
-    a.next_review_date.localeCompare(b.next_review_date)
+    a.next_review_date.localeCompare(b.next_review_date),
   );
   const overdueCount = sorted.filter((e) => getUrgency(e.next_review_date) === 'overdue').length;
 
   return (
-    <div className="bg-white rounded-xl border border-amber-200 p-5 mt-6">
+    <div className="os-card border-amber-200 p-5 mt-6">
       <div className="flex items-center justify-between mb-3">
-        <h2 className="text-base font-semibold text-gray-900">
+        <h2 className="text-base font-display font-semibold text-ink-900">
           Due for Review
           {overdueCount > 0 && (
-            <span className="ml-2 text-xs font-semibold bg-red-100 text-red-700 px-2 py-0.5 rounded-full">
+            <span className="ml-2 text-xs font-semibold bg-rose-100 text-rose-800 px-2 py-0.5 rounded-full">
               {overdueCount} overdue
             </span>
           )}
         </h2>
-        <span className="text-xs text-gray-400">
+        <span className="text-xs text-ink-400">
           {entries.length} topic{entries.length !== 1 ? 's' : ''}
         </span>
       </div>
@@ -84,12 +84,12 @@ export const DueForReviewPanel = () => {
           <SRSRow key={e.id} entry={e} />
         ))}
         {entries.length > 5 && (
-          <p className="text-xs text-center text-gray-400 pt-1">
+          <p className="text-xs text-center text-ink-400 pt-1">
             +{entries.length - 5} more topics
           </p>
         )}
       </div>
-      <p className="text-xs text-gray-400 mt-3 pt-2 border-t border-gray-100">
+      <p className="text-xs text-ink-400 mt-3 pt-2 border-t border-ink-100">
         Practice your assignments to push review dates forward.
       </p>
     </div>

--- a/frontend_modern/src/features/student/ProficiencyPage.tsx
+++ b/frontend_modern/src/features/student/ProficiencyPage.tsx
@@ -1,6 +1,6 @@
 import { useProficiency } from './useProficiency';
 import { useProficiencyHistory } from './useProficiencyHistory';
-import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
+import { Card, EmptyState, LoadingSpinner, SectionHeading } from '@/shared/ui';
 import { TrendSparkline } from '@/shared/components/TrendSparkline';
 import type { StudentProficiency } from '@/types/index';
 
@@ -22,9 +22,12 @@ const groupBySubject = (records: StudentProficiency[]): SubjectGroup[] => {
   return Array.from(map.values());
 };
 
+// Unlock motif: mastery (>=70%) reads as "unlocked" in brand orange;
+// approaching uses amber, struggling uses rose. Track is warm ink-100.
 const ProficiencyBar = ({ record }: { record: StudentProficiency }) => {
   const pct = Math.round(record.score * 100);
-  const barColor = pct >= 70 ? 'bg-green-500' : pct >= 40 ? 'bg-yellow-400' : 'bg-red-400';
+  const isMastered = pct >= 70;
+  const barColor = isMastered ? 'bg-brand-600' : pct >= 40 ? 'bg-amber-400' : 'bg-rose-400';
   const { data: history } = useProficiencyHistory({
     tagId: record.question_tag,
     subjectRoomId: record.subject_room,
@@ -34,19 +37,26 @@ const ProficiencyBar = ({ record }: { record: StudentProficiency }) => {
     <div className="flex items-center gap-3 py-2">
       <div className="flex-1 min-w-0">
         <div className="flex items-baseline justify-between gap-2 mb-1">
-          <span className="text-sm font-medium text-gray-800 truncate">{record.tag_name}</span>
+          <span className="text-sm font-medium text-ink-800 truncate flex items-center gap-1.5">
+            {isMastered && (
+              <span aria-label="Mastered" title="Topic unlocked" className="text-brand-600">
+                ✓
+              </span>
+            )}
+            {record.tag_name}
+          </span>
           <div className="flex items-center gap-2 shrink-0">
             {history && history.length >= 2 && <TrendSparkline snapshots={history} />}
-            <span className="text-sm font-semibold text-gray-700">{pct}%</span>
+            <span className="text-sm font-semibold text-ink-700">{pct}%</span>
           </div>
         </div>
-        <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
+        <div className="h-2 bg-ink-100 rounded-full overflow-hidden">
           <div
-            className={`h-full rounded-full transition-all ${barColor}`}
+            className={`h-full rounded-full transition-all motion-reduce:transition-none ${barColor}`}
             style={{ width: `${pct}%` }}
           />
         </div>
-        <p className="text-xs text-gray-400 mt-1">
+        <p className="text-xs text-ink-400 mt-1">
           Based on {record.tick_count} question{record.tick_count !== 1 ? 's' : ''}
         </p>
       </div>
@@ -68,12 +78,16 @@ export const ProficiencyPage = () => {
   if (!records || records.length === 0) {
     return (
       <div className="max-w-2xl mx-auto px-4 py-8">
-        <h1 className="text-2xl font-bold text-gray-900 mb-2">My Progress</h1>
-        <p className="text-sm text-gray-500 mb-8">Your proficiency per topic, updated after each submission.</p>
-        <div className="text-center py-16 bg-white rounded-xl border border-gray-200">
-          <p className="text-gray-500 font-medium">No progress yet</p>
-          <p className="text-sm text-gray-400 mt-1">Complete an assignment to see your progress here.</p>
-        </div>
+        <SectionHeading
+          as="h1"
+          title="My Progress"
+          description="Your proficiency per topic, updated after each submission."
+          className="mb-6"
+        />
+        <EmptyState
+          title="No progress yet"
+          description="Complete an assignment to see your progress here."
+        />
       </div>
     );
   }
@@ -82,22 +96,26 @@ export const ProficiencyPage = () => {
 
   return (
     <div className="max-w-2xl mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold text-gray-900 mb-2">My Progress</h1>
-      <p className="text-sm text-gray-500 mb-8">Your proficiency per topic, updated after each submission.</p>
+      <SectionHeading
+        as="h1"
+        title="My Progress"
+        description="Your proficiency per topic, updated after each submission."
+        className="mb-8"
+      />
 
       <div className="space-y-6">
         {groups.map((group) => (
-          <div key={`${group.subjectName}|${group.classroomDisplay}`} className="bg-white rounded-xl border border-gray-200 p-5">
+          <Card key={`${group.subjectName}|${group.classroomDisplay}`} className="p-5">
             <div className="mb-4">
-              <h2 className="font-semibold text-gray-900">{group.subjectName}</h2>
-              <p className="text-sm text-gray-500">{group.classroomDisplay}</p>
+              <h2 className="font-display font-semibold text-ink-900">{group.subjectName}</h2>
+              <p className="text-sm text-ink-500">{group.classroomDisplay}</p>
             </div>
-            <div className="divide-y divide-gray-50">
+            <div className="divide-y divide-ink-100">
               {group.records.map((r) => (
                 <ProficiencyBar key={r.id} record={r} />
               ))}
             </div>
-          </div>
+          </Card>
         ))}
       </div>
     </div>

--- a/frontend_modern/src/features/student/RecommendationsPanel.tsx
+++ b/frontend_modern/src/features/student/RecommendationsPanel.tsx
@@ -2,10 +2,10 @@ import { useRecommendations } from './useRecommendations';
 import { usePracticePlan } from './usePracticePlan';
 
 const PRIORITY_BADGE: Record<number, string> = {
-  1: 'bg-red-100 text-red-800 border border-red-300',
-  2: 'bg-orange-100 text-orange-800 border border-orange-300',
-  3: 'bg-yellow-100 text-yellow-800 border border-yellow-300',
-  4: 'bg-blue-100 text-blue-800 border border-blue-300',
+  1: 'bg-rose-100 text-rose-800 border border-rose-300',
+  2: 'bg-amber-100 text-amber-800 border border-amber-300',
+  3: 'bg-brand-100 text-brand-800 border border-brand-300',
+  4: 'bg-ink-100 text-ink-700 border border-ink-200',
 };
 
 export const RecommendationsPanel = () => {
@@ -16,11 +16,11 @@ export const RecommendationsPanel = () => {
   if (!recommendations || recommendations.length === 0) return null;
 
   return (
-    <div className="bg-white rounded-xl border border-indigo-200 p-5">
+    <div className="os-card border-brand-200 p-5">
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-base font-semibold text-gray-900">What to Practice Next</h2>
+        <h2 className="text-base font-display font-semibold text-ink-900">What to Practice Next</h2>
         {plan && (
-          <span className="text-xs text-gray-500">
+          <span className="text-xs text-ink-500">
             Today&apos;s plan: ~{plan.estimated_minutes} min
           </span>
         )}
@@ -30,7 +30,7 @@ export const RecommendationsPanel = () => {
         {recommendations.map((rec) => (
           <div
             key={rec.id}
-            className="flex items-start justify-between gap-3 py-2 border-b border-gray-100 last:border-0"
+            className="flex items-start justify-between gap-3 py-2 border-b border-ink-100 last:border-0"
           >
             <div className="flex items-start gap-3 min-w-0">
               <span
@@ -39,12 +39,12 @@ export const RecommendationsPanel = () => {
                 {rec.priority_display.toUpperCase()}
               </span>
               <div className="min-w-0">
-                <p className="text-sm font-medium text-gray-900 truncate">{rec.chapter_name}</p>
-                <p className="text-xs text-gray-500 mt-0.5">{rec.reason_display}</p>
+                <p className="text-sm font-medium text-ink-900 truncate">{rec.chapter_name}</p>
+                <p className="text-xs text-ink-500 mt-0.5">{rec.reason_display}</p>
               </div>
             </div>
             <div className="text-right shrink-0">
-              <p className="text-sm font-semibold text-gray-700">
+              <p className="text-sm font-semibold text-ink-700">
                 {Math.round(rec.score_snapshot * 100)}%
               </p>
             </div>
@@ -53,20 +53,20 @@ export const RecommendationsPanel = () => {
       </div>
 
       {plan && (
-        <div className="mt-4 pt-3 border-t border-gray-100 flex items-center justify-between">
-          <span className="text-xs text-gray-500">
+        <div className="mt-4 pt-3 border-t border-ink-100 flex items-center justify-between">
+          <span className="text-xs text-ink-500">
             {plan.recommendations.length} topic{plan.recommendations.length !== 1 ? 's' : ''} in today&apos;s plan
           </span>
           <div className="flex items-center gap-3">
             <a
               href="/student/proficiency"
-              className="text-xs font-medium text-indigo-600 hover:text-indigo-800"
+              className="text-xs font-medium text-brand-700 hover:text-brand-800 focus:outline-none focus-visible:underline"
             >
               View progress →
             </a>
             <a
               href="/student/learning-path"
-              className="text-xs font-medium text-indigo-600 hover:text-indigo-800"
+              className="text-xs font-medium text-brand-700 hover:text-brand-800 focus:outline-none focus-visible:underline"
             >
               View learning path →
             </a>

--- a/frontend_modern/src/features/student/StreakBadge.tsx
+++ b/frontend_modern/src/features/student/StreakBadge.tsx
@@ -8,34 +8,35 @@ interface TierConfig {
   textColor: string;
 }
 
+// Milestone tiers escalate through brand-warm tones to amber, capped by brand.
 const TIER_CONFIG: Record<Exclude<MilestoneTier, 'none'>, TierConfig> = {
   starter: {
     icon: '🔥',
     label: 'On Fire',
-    bgColor: 'bg-orange-50',
-    borderColor: 'border-orange-200',
-    textColor: 'text-orange-700',
+    bgColor: 'bg-brand-50',
+    borderColor: 'border-brand-200',
+    textColor: 'text-brand-700',
   },
   week: {
     icon: '⚡',
     label: 'Week Warrior',
-    bgColor: 'bg-yellow-50',
-    borderColor: 'border-yellow-200',
-    textColor: 'text-yellow-700',
+    bgColor: 'bg-amber-50',
+    borderColor: 'border-amber-200',
+    textColor: 'text-amber-800',
   },
   month: {
     icon: '🌟',
     label: 'Month Master',
-    bgColor: 'bg-amber-50',
-    borderColor: 'border-amber-200',
-    textColor: 'text-amber-700',
+    bgColor: 'bg-amber-100',
+    borderColor: 'border-amber-300',
+    textColor: 'text-amber-900',
   },
   champion: {
     icon: '👑',
     label: 'Champion',
-    bgColor: 'bg-purple-50',
-    borderColor: 'border-purple-200',
-    textColor: 'text-purple-700',
+    bgColor: 'bg-brand-100',
+    borderColor: 'border-brand-300',
+    textColor: 'text-brand-800',
   },
 };
 
@@ -49,7 +50,7 @@ interface StreakBadgeProps {
 export const StreakBadge = ({ streak, tier, longestStreak, graceUsed }: StreakBadgeProps) => {
   if (streak === 0 || tier === 'none') {
     return (
-      <div className="inline-flex items-center gap-1.5 bg-gray-50 border border-gray-200 text-gray-500 text-xs font-semibold px-3 py-1 rounded-full mt-2">
+      <div className="inline-flex items-center gap-1.5 bg-ink-50 border border-ink-200 text-ink-500 text-xs font-semibold px-3 py-1 rounded-full mt-2">
         <span>🔥</span>
         <span>{streak}-day streak</span>
       </div>


### PR DESCRIPTION
## Summary
Migrates the proficiency cluster to V2 'Chalk & Unlock'.

**Classification:** Improve (reskin + unlock motif)
**Initiative:** V2 design system M4-06a
**Plan:** docs/daily-plans/2026-06-03-plan.md (item 4)

## Files
- features/student/ProficiencyPage.tsx
- features/student/StreakBadge.tsx
- features/student/DueForReviewPanel.tsx (deferred from M4-01)
- features/student/RecommendationsPanel.tsx (deferred from M4-01)

## What changed
- ProficiencyPage: SectionHeading + Card + EmptyState; mastery bar = brand-600 + check glyph (unlock motif)
- StreakBadge tiers: orange/yellow/amber/purple → brand/amber/amber/brand
- Panels: rose/brand semantic tones; warm os-card borders
- motion-reduce:transition-none + focus-visible rings

## Tests
- type-check, lint, vitest 84/84, build — green

## Verify
`student_demo` / `demo1234` → /student (dashboard panels), /student/proficiency.