### PR TITLE
feat(frontend): migrate Assignment detail + SRS drill to V2

### DIFF
--- a/docs/changes/2026-06-03-assignment-srs-v2.md
+++ b/docs/changes/2026-06-03-assignment-srs-v2.md
@@ -1,0 +1,49 @@
+# 2026-06-03 — Assignment detail + SRS drill migrated to V2
+
+## Summary
+Migrated the highest-traffic student practice flow to V2 "Chalk & Unlock":
+`AssignmentDetailPage.tsx`, `SRSDrillPage.tsx`, and the shared `QuestionCard.tsx`,
+`AssignmentCard.tsx`, `AssignmentList.tsx`.
+
+## Classification
+Improve — reskin + light unlock motif on score reveals. Auto-save debounce, submit
+logic, and `RichContent`/`InteractiveWidget` wiring untouched.
+
+## What changed
+- `QuestionCard`: warm `.os-card`; MCQ/multi-select selected state =
+  `brand-500` border + `brand-50` fill; numeric/fill_blank use `.input-brand`;
+  solution reveal is brand-tinted (the "unlock" of the answer), hints stay amber.
+- `AssignmentDetailPage`: progress bar brand-500 on ink-100 track; post-submit
+  score card uses the unlock-motif palette (emerald/amber/rose) and is heading-styled
+  in Fraunces; confirm dialog uses `.os-card` chrome + `<Button>` actions.
+- `SRSDrillPage`: result card retains emerald/amber semantic surfaces, primary
+  CTAs use `<Button variant="brand"|"ghost">`, "Back to dashboard" link styles
+  to `.btn-brand`. Empty + error states swapped for `<EmptyState>`.
+- `AssignmentCard`: status pills → `<Badge>` (success/attention/urgent),
+  `<Button>` CTA; progress bar = brand-500 (unlock motif).
+- `AssignmentList`: empty state → `<EmptyState>`; section accent pills
+  recoloured to brand/amber/rose/emerald tokens. **Section heading text
+  ("Overdue", "Due Soon", "Upcoming", "Completed") and empty-state phrase
+  preserved exactly** so `AssignmentList.test.tsx` keeps passing.
+- QuestionCard radio `name` attribute (`subpart-<id>`), placeholder
+  ("Enter your answer"), and `type="number"`/`type="text"` preserved verbatim —
+  every assertion in `QuestionCard.test.tsx` still holds.
+- `motion-reduce:transition-none` + focus-visible rings throughout.
+
+## Tests
+- `npm run type-check` — green
+- `npm run lint` — green
+- `npm test -- --run` — 84/84 (incl. `QuestionCard.test.tsx` 4/4 and
+  `AssignmentList.test.tsx` 6/6) — green
+- `npm run build` — green
+
+## Verify
+Log in as `student_demo` / `demo1234`:
+1. /student → assignment cards now use unlock-motif progress and brand CTAs
+2. Open an assignment → answer MCQ + numeric → submit → see the brand/emerald
+   score reveal
+3. /student/srs/drill/<id> → drill UI, submit → result card
+
+## Closes
+M4-05 in the V2 design system rollout. After this PR, only `M4-07` (teacher
+authoring cluster) remains in the M4 product-surface migration.

--- a/frontend_modern/src/features/student/AssignmentCard.tsx
+++ b/frontend_modern/src/features/student/AssignmentCard.tsx
@@ -1,5 +1,6 @@
 import { formatDistanceToNow, isPast, parseISO } from 'date-fns';
 import { useNavigate } from 'react-router-dom';
+import { Badge, Button } from '@/shared/ui';
 import type { Assignment } from '@/types/index';
 
 interface AssignmentCardProps {
@@ -20,74 +21,69 @@ export const AssignmentCard = ({ assignment }: AssignmentCardProps) => {
     : `Due ${formatDistanceToNow(dueDate, { addSuffix: true })}`;
 
   const cta = isSubmitted ? 'Review' : completion > 0 ? 'Continue' : 'Start';
-  const ctaStyle = isSubmitted
-    ? 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-    : 'bg-indigo-600 text-white hover:bg-indigo-700';
 
   return (
-    <div className="bg-white rounded-xl border border-gray-200 p-5 hover:shadow-md transition-shadow">
+    <div className="os-card p-5 hover:shadow-md transition-shadow motion-reduce:transition-none">
       <div className="flex items-start justify-between gap-4">
-        {/* Left: Content info */}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-1">
-            <p className="text-xs font-medium text-indigo-600 uppercase tracking-wide">
+            <p className="text-xs font-semibold text-brand-700 uppercase tracking-wide">
               {problem_set.subject.name}
             </p>
             {problem_set.is_remedial && (
-              <span className="inline-flex items-center text-xs font-medium bg-amber-100 text-amber-700 px-2 py-0.5 rounded-full">
-                Remedial Practice
-              </span>
+              <Badge tone="attention">Remedial Practice</Badge>
             )}
           </div>
-          <h3 className="font-semibold text-gray-900 truncate">
+          <h3 className="font-display font-semibold text-ink-900 truncate">
             {problem_set.title}
           </h3>
-          <p className="text-sm text-gray-500 mt-0.5">
-            {problem_set.chapter.name}
-          </p>
+          <p className="text-sm text-ink-500 mt-0.5">{problem_set.chapter.name}</p>
         </div>
 
-        {/* Right: Score badge */}
         {isSubmitted && score !== null && score !== undefined && (
           <div className="flex-shrink-0">
-            <div className={`text-sm font-semibold rounded-lg px-3 py-1 ${
-              score >= 0.8 ? 'bg-green-100 text-green-700'
-              : score >= 0.5 ? 'bg-yellow-100 text-yellow-700'
-              : 'bg-red-100 text-red-700'
-            }`}>
+            <Badge
+              tone={score >= 0.8 ? 'success' : score >= 0.5 ? 'attention' : 'urgent'}
+              className="px-3 py-1 text-sm"
+            >
               {Math.round(score * 100)}%
-            </div>
+            </Badge>
           </div>
         )}
       </div>
 
-      {/* Progress bar */}
+      {/* Progress bar — uses unlock motif: brand fill on warm ink-100 track */}
       {!isSubmitted && completion > 0 && (
         <div className="mt-3">
-          <div className="flex items-center justify-between text-xs text-gray-500 mb-1">
+          <div className="flex items-center justify-between text-xs text-ink-500 mb-1">
             <span>Progress</span>
             <span>{Math.round(completion * 100)}%</span>
           </div>
-          <div className="h-1.5 bg-gray-100 rounded-full overflow-hidden">
+          <div className="h-1.5 bg-ink-100 rounded-full overflow-hidden">
             <div
-              className="h-full bg-indigo-500 rounded-full transition-all"
+              className="h-full bg-brand-500 rounded-full transition-all motion-reduce:transition-none"
               style={{ width: `${completion * 100}%` }}
             />
           </div>
         </div>
       )}
 
-      {/* Footer: due date + CTA */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mt-4">
-        <span className={`text-xs ${isOverdue && !isSubmitted ? 'text-red-600 font-medium' : 'text-gray-400'}`}>
+        <span
+          className={`text-xs ${
+            isOverdue && !isSubmitted ? 'text-rose-600 font-medium' : 'text-ink-400'
+          }`}
+        >
           {isSubmitted ? 'Submitted' : dueDateLabel}
         </span>
-        <button
+        <Button
+          variant={isSubmitted ? 'ghost' : 'brand'}
+          size="sm"
+          className="w-full sm:w-auto"
           onClick={() => navigate(`/student/assignments/${assignment.id}`)}
-          className={`w-full sm:w-auto text-sm font-medium px-4 py-2.5 sm:py-1.5 rounded-lg transition-colors ${ctaStyle}`}
         >
           {cta}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/frontend_modern/src/features/student/AssignmentDetailPage.tsx
+++ b/frontend_modern/src/features/student/AssignmentDetailPage.tsx
@@ -4,7 +4,7 @@ import { useAssignmentDetail } from './useAssignmentDetail';
 import { useSubmission, useCreateSubmission, usePatchSubmission } from './useSubmission';
 import { QuestionCard } from './QuestionCard';
 import { VideosPanel } from './VideosPanel';
-import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
+import { Button, EmptyState, LoadingSpinner } from '@/shared/ui';
 import type { Question } from '@/types/index';
 
 function countSubparts(questions: Question[]): number {
@@ -14,9 +14,8 @@ function countSubparts(questions: Question[]): number {
 function countAnswered(questions: Question[], answers: Record<string, string>): number {
   return questions.reduce(
     (sum, q) =>
-      sum +
-      q.subparts.filter((sp) => (answers[String(sp.id)] ?? '').trim().length > 0).length,
-    0
+      sum + q.subparts.filter((sp) => (answers[String(sp.id)] ?? '').trim().length > 0).length,
+    0,
   );
 }
 
@@ -27,8 +26,7 @@ export const AssignmentDetailPage = () => {
 
   const { data: assignment, isLoading: assignmentLoading, error: assignmentError } =
     useAssignmentDetail(assignmentId);
-  const { data: existingSubmission, isLoading: submissionLoading } =
-    useSubmission(assignmentId);
+  const { data: existingSubmission, isLoading: submissionLoading } = useSubmission(assignmentId);
 
   const createSubmission = useCreateSubmission();
   const patchSubmission = usePatchSubmission(assignmentId);
@@ -41,35 +39,29 @@ export const AssignmentDetailPage = () => {
 
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Once submission data loads, initialize state
   useEffect(() => {
     if (!submissionLoading) {
       if (existingSubmission) {
         setSubmissionId(existingSubmission.id);
         setAnswers(
           Object.fromEntries(
-            Object.entries(existingSubmission.answers ?? {}).map(([k, v]) => [k, String(v)])
-          )
+            Object.entries(existingSubmission.answers ?? {}).map(([k, v]) => [k, String(v)]),
+          ),
         );
         if (existingSubmission.submitted_at) {
           setIsSubmitted(true);
           setSubmitScore(existingSubmission.score);
         }
       } else if (assignmentId && !createSubmission.isPending) {
-        // No existing submission — create one
         createSubmission.mutate(assignmentId, {
           onSuccess: (sub) => setSubmissionId(sub.id),
         });
       }
     }
-    // Only run when submission load state changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [submissionLoading, existingSubmission]);
 
-  const questions = useMemo(
-    () => assignment?.problem_set?.questions ?? [],
-    [assignment]
-  );
+  const questions = useMemo(() => assignment?.problem_set?.questions ?? [], [assignment]);
   const total = countSubparts(questions);
   const answered = countAnswered(questions, answers);
 
@@ -80,7 +72,6 @@ export const AssignmentDetailPage = () => {
       setAnswers((prev) => {
         const updated = { ...prev, [String(subpartId)]: value };
 
-        // Debounced auto-save
         if (debounceTimer.current) clearTimeout(debounceTimer.current);
         debounceTimer.current = setTimeout(() => {
           if (submissionId) {
@@ -98,7 +89,7 @@ export const AssignmentDetailPage = () => {
         return updated;
       });
     },
-    [isSubmitted, submissionId, questions, total, patchSubmission]
+    [isSubmitted, submissionId, questions, total, patchSubmission],
   );
 
   const handleSubmit = () => {
@@ -118,7 +109,7 @@ export const AssignmentDetailPage = () => {
           setSubmitScore(sub.score);
           setShowConfirm(false);
         },
-      }
+      },
     );
   };
 
@@ -132,85 +123,86 @@ export const AssignmentDetailPage = () => {
 
   if (assignmentError || !assignment) {
     return (
-      <div className="text-center py-16">
-        <p className="text-gray-500">Assignment not found or could not be loaded.</p>
-        <button
-          onClick={() => navigate('/student')}
-          className="mt-4 text-sm text-indigo-600 hover:underline"
-        >
-          Back to dashboard
-        </button>
+      <div className="max-w-2xl mx-auto px-4 py-16">
+        <EmptyState
+          title="Assignment not found"
+          description="It may have been removed or you don't have access."
+          action={
+            <Button variant="ghost" size="sm" onClick={() => navigate('/student')}>
+              Back to dashboard
+            </Button>
+          }
+        />
       </div>
     );
   }
 
+  // Unlock motif on the post-submit score card.
+  const scoreBg =
+    submitScore !== null
+      ? submitScore >= 0.8
+        ? 'bg-emerald-50 border-emerald-200'
+        : submitScore >= 0.5
+          ? 'bg-amber-50 border-amber-200'
+          : 'bg-rose-50 border-rose-200'
+      : 'bg-brand-50 border-brand-200';
+
   return (
     <div className="max-w-2xl mx-auto px-4 py-6">
-      {/* Header */}
       <div className="mb-6">
         <button
+          type="button"
           onClick={() => navigate('/student')}
-          className="text-sm text-indigo-600 hover:underline mb-3 flex items-center gap-1"
+          className="text-sm text-brand-700 font-medium hover:underline mb-3 flex items-center gap-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded"
         >
           <span>&#8592;</span> Back to assignments
         </button>
-        <p className="text-xs font-medium text-indigo-600 uppercase tracking-wide">
+        <p className="text-xs font-semibold text-brand-700 uppercase tracking-wide">
           {assignment.problem_set.subject.name}
         </p>
-        <h1 className="text-xl font-bold text-gray-900 mt-0.5">
+        <h1 className="text-xl font-display font-semibold text-ink-900 mt-0.5">
           {assignment.problem_set.title}
         </h1>
-        <p className="text-sm text-gray-500">{assignment.problem_set.chapter.name}</p>
+        <p className="text-sm text-ink-500">{assignment.problem_set.chapter.name}</p>
       </div>
 
-      {/* Progress bar */}
       {!isSubmitted && total > 0 && (
         <div className="mb-6">
-          <div className="flex justify-between text-xs text-gray-500 mb-1">
-            <span>{answered} of {total} answered</span>
+          <div className="flex justify-between text-xs text-ink-500 mb-1">
+            <span>
+              {answered} of {total} answered
+            </span>
             <span>{Math.round((answered / total) * 100)}%</span>
           </div>
-          <div className="h-1.5 bg-gray-100 rounded-full overflow-hidden">
+          <div className="h-1.5 bg-ink-100 rounded-full overflow-hidden">
             <div
-              className="h-full bg-indigo-500 rounded-full transition-all duration-300"
+              className="h-full bg-brand-500 rounded-full transition-all duration-300 motion-reduce:transition-none"
               style={{ width: `${(answered / total) * 100}%` }}
             />
           </div>
         </div>
       )}
 
-      {/* Submitted state */}
       {isSubmitted && (
-        <div className={`mb-6 rounded-xl p-4 text-center ${
-          submitScore !== null
-            ? submitScore >= 0.8
-              ? 'bg-green-50 border border-green-200'
-              : submitScore >= 0.5
-              ? 'bg-yellow-50 border border-yellow-200'
-              : 'bg-red-50 border border-red-200'
-            : 'bg-indigo-50 border border-indigo-200'
-        }`}>
+        <div className={`mb-6 rounded-xl p-4 text-center border ${scoreBg}`}>
           {submitScore !== null ? (
             <>
-              <p className="text-lg font-bold text-gray-900">
+              <p className="text-2xl font-display font-semibold text-ink-900">
                 {Math.round(submitScore * 100)}%
               </p>
-              <p className="text-sm text-gray-600 mt-0.5">Assignment submitted</p>
+              <p className="text-sm text-ink-700 mt-0.5">Assignment submitted — nice work!</p>
             </>
           ) : (
             <>
-              <p className="font-semibold text-indigo-800">Submitted</p>
-              <p className="text-sm text-indigo-600 mt-0.5">Grading in progress...</p>
+              <p className="font-display font-semibold text-brand-800">Submitted</p>
+              <p className="text-sm text-brand-700 mt-0.5">Grading in progress…</p>
             </>
           )}
         </div>
       )}
 
-      {/* Questions */}
       {questions.length === 0 ? (
-        <div className="text-center py-12 text-gray-400">
-          <p>No questions in this assignment.</p>
-        </div>
+        <EmptyState title="No questions in this assignment" />
       ) : (
         <div className="space-y-4">
           {questions.map((question: Question, idx: number) => (
@@ -226,46 +218,38 @@ export const AssignmentDetailPage = () => {
         </div>
       )}
 
-      {/* Chapter videos */}
       {assignment.problem_set.chapter?.id && (
         <VideosPanel chapterId={assignment.problem_set.chapter.id} />
       )}
 
-      {/* Submit button */}
       {!isSubmitted && questions.length > 0 && (
         <div className="mt-8 flex justify-end">
-          <button
+          <Button
+            size="lg"
+            className="w-full sm:w-auto"
             onClick={() => setShowConfirm(true)}
             disabled={answered === 0}
-            className="w-full sm:w-auto bg-indigo-600 text-white px-6 py-3 sm:py-2.5 rounded-lg font-medium text-sm hover:bg-indigo-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
           >
             Submit assignment
-          </button>
+          </Button>
         </div>
       )}
 
-      {/* Confirm dialog */}
       {showConfirm && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-          <div className="bg-white rounded-2xl p-6 max-w-sm w-full mx-4 shadow-xl">
-            <h3 className="text-lg font-semibold text-gray-900">Submit assignment?</h3>
-            <p className="text-sm text-gray-500 mt-1">
-              You have answered {answered} of {total} questions. You cannot change your answers after submitting.
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-ink-900/40 p-4">
+          <div className="os-card p-6 max-w-sm w-full shadow-xl">
+            <h3 className="text-lg font-display font-semibold text-ink-900">Submit assignment?</h3>
+            <p className="text-sm text-ink-500 mt-1">
+              You have answered {answered} of {total} questions. You cannot change your answers
+              after submitting.
             </p>
             <div className="flex gap-3 mt-5 justify-end">
-              <button
-                onClick={() => setShowConfirm(false)}
-                className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"
-              >
+              <Button variant="ghost" size="sm" onClick={() => setShowConfirm(false)}>
                 Cancel
-              </button>
-              <button
-                onClick={handleSubmit}
-                disabled={patchSubmission.isPending}
-                className="px-4 py-2 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 transition-colors"
-              >
-                {patchSubmission.isPending ? 'Submitting...' : 'Submit'}
-              </button>
+              </Button>
+              <Button size="sm" onClick={handleSubmit} disabled={patchSubmission.isPending}>
+                {patchSubmission.isPending ? 'Submitting…' : 'Submit'}
+              </Button>
             </div>
           </div>
         </div>

--- a/frontend_modern/src/features/student/AssignmentList.tsx
+++ b/frontend_modern/src/features/student/AssignmentList.tsx
@@ -1,4 +1,5 @@
 import { isPast, parseISO, differenceInDays } from 'date-fns';
+import { EmptyState } from '@/shared/ui';
 import type { Assignment } from '@/types/index';
 import { AssignmentCard } from './AssignmentCard';
 
@@ -18,7 +19,7 @@ function groupAssignments(assignments: Assignment[]): GroupedAssignments {
 
   return {
     overdue: assignments.filter(
-      (a) => !a.my_submission?.submitted_at && isPast(parseISO(a.due_at))
+      (a) => !a.my_submission?.submitted_at && isPast(parseISO(a.due_at)),
     ),
     dueSoon: assignments.filter((a) => {
       if (a.my_submission?.submitted_at) return false;
@@ -41,67 +42,74 @@ export const AssignmentList = ({ assignments }: AssignmentListProps) => {
 
   if (assignments.length === 0) {
     return (
-      <div className="text-center py-16">
-        <div className="text-5xl mb-4">📚</div>
-        <h3 className="text-lg font-medium text-gray-700">No assignments yet</h3>
-        <p className="text-gray-400 mt-1">Your teacher will assign some soon. Check back later!</p>
-      </div>
+      <EmptyState
+        title="No assignments yet"
+        description="Your teacher will assign some soon. Check back later!"
+      />
     );
   }
 
   return (
     <div className="space-y-8">
       {groups.overdue.length > 0 && (
-        <Section title="Overdue" count={groups.overdue.length} accent="red">
-          {groups.overdue.map((a) => <AssignmentCard key={a.id} assignment={a} />)}
+        <Section title="Overdue" count={groups.overdue.length} accent="urgent">
+          {groups.overdue.map((a) => (
+            <AssignmentCard key={a.id} assignment={a} />
+          ))}
         </Section>
       )}
 
       {groups.dueSoon.length > 0 && (
-        <Section title="Due Soon" count={groups.dueSoon.length} accent="amber">
-          {groups.dueSoon.map((a) => <AssignmentCard key={a.id} assignment={a} />)}
+        <Section title="Due Soon" count={groups.dueSoon.length} accent="attention">
+          {groups.dueSoon.map((a) => (
+            <AssignmentCard key={a.id} assignment={a} />
+          ))}
         </Section>
       )}
 
       {groups.upcoming.length > 0 && (
-        <Section title="Upcoming" count={groups.upcoming.length} accent="blue">
-          {groups.upcoming.map((a) => <AssignmentCard key={a.id} assignment={a} />)}
+        <Section title="Upcoming" count={groups.upcoming.length} accent="brand">
+          {groups.upcoming.map((a) => (
+            <AssignmentCard key={a.id} assignment={a} />
+          ))}
         </Section>
       )}
 
       {groups.completed.length > 0 && (
-        <Section title="Completed" count={groups.completed.length} accent="green">
-          {groups.completed.map((a) => <AssignmentCard key={a.id} assignment={a} />)}
+        <Section title="Completed" count={groups.completed.length} accent="success">
+          {groups.completed.map((a) => (
+            <AssignmentCard key={a.id} assignment={a} />
+          ))}
         </Section>
       )}
     </div>
   );
 };
 
+type Accent = 'urgent' | 'attention' | 'brand' | 'success';
+
 interface SectionProps {
   title: string;
   count: number;
-  accent: 'red' | 'amber' | 'blue' | 'green';
+  accent: Accent;
   children: React.ReactNode;
 }
 
-const ACCENT_COLORS = {
-  red: 'text-red-600 bg-red-50',
-  amber: 'text-amber-600 bg-amber-50',
-  blue: 'text-blue-600 bg-blue-50',
-  green: 'text-green-600 bg-green-50',
+const ACCENT_COLORS: Record<Accent, string> = {
+  urgent: 'text-rose-700 bg-rose-50',
+  attention: 'text-amber-800 bg-amber-50',
+  brand: 'text-brand-700 bg-brand-50',
+  success: 'text-emerald-700 bg-emerald-50',
 };
 
 const Section = ({ title, count, accent, children }: SectionProps) => (
   <div>
     <div className="flex items-center gap-2 mb-3">
-      <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wider">{title}</h2>
+      <h2 className="text-sm font-semibold text-ink-700 uppercase tracking-wider">{title}</h2>
       <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${ACCENT_COLORS[accent]}`}>
         {count}
       </span>
     </div>
-    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-      {children}
-    </div>
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{children}</div>
   </div>
 );

--- a/frontend_modern/src/features/student/QuestionCard.tsx
+++ b/frontend_modern/src/features/student/QuestionCard.tsx
@@ -26,22 +26,26 @@ function CollapsibleReveal({
   tone: 'hint' | 'solution';
 }) {
   const [open, setOpen] = useState(false);
+  // Worked solutions feel like "unlocking" the answer → brand-tinted panel.
+  // Hints stay amber so students recognise them as guidance, not the answer.
   const styles =
     tone === 'solution'
-      ? { btn: 'text-indigo-700 hover:text-indigo-900', box: 'bg-indigo-50 border-indigo-100' }
-      : { btn: 'text-amber-700 hover:text-amber-900', box: 'bg-amber-50 border-amber-100' };
+      ? { btn: 'text-brand-700 hover:text-brand-800', box: 'bg-brand-50 border-brand-100' }
+      : { btn: 'text-amber-800 hover:text-amber-900', box: 'bg-amber-50 border-amber-100' };
 
   return (
     <div className="mt-3">
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className={`text-xs font-medium transition-colors ${styles.btn}`}
+        className={`text-xs font-medium transition-colors motion-reduce:transition-none focus:outline-none focus-visible:underline ${styles.btn}`}
       >
         {open ? '▾' : '▸'} {label}
       </button>
       {open && (
-        <div className={`mt-2 rounded-lg border p-3 text-sm text-gray-800 leading-relaxed ${styles.box}`}>
+        <div
+          className={`mt-2 rounded-lg border p-3 text-sm text-ink-800 leading-relaxed ${styles.box}`}
+        >
           <RichContent text={content} variant="block" />
         </div>
       )}
@@ -49,12 +53,6 @@ function CollapsibleReveal({
   );
 }
 
-/**
- * Progressive AI hint panel shown during practice. On first request it fetches
- * the cached (or freshly generated) hint sequence for the subpart, then reveals
- * one hint at a time so the student is nudged gradually rather than handed the
- * whole chain at once. Hints never contain the correct answer.
- */
 function AIHintPanel({ subpartId }: { subpartId: number }) {
   const { mutate, data, isPending, isError } = useHints();
   const [revealed, setRevealed] = useState(0);
@@ -67,10 +65,7 @@ function AIHintPanel({ subpartId }: { subpartId: number }) {
       setRevealed((n) => Math.min(n + 1, hints.length));
       return;
     }
-    mutate(
-      { subpart_id: subpartId },
-      { onSuccess: () => setRevealed(1) }
-    );
+    mutate({ subpart_id: subpartId }, { onSuccess: () => setRevealed(1) });
   };
 
   if (!started) {
@@ -79,7 +74,7 @@ function AIHintPanel({ subpartId }: { subpartId: number }) {
         <button
           type="button"
           onClick={handleStart}
-          className="text-xs font-medium text-amber-700 hover:text-amber-900 transition-colors"
+          className="text-xs font-medium text-amber-800 hover:text-amber-900 transition-colors motion-reduce:transition-none focus:outline-none focus-visible:underline"
         >
           💡 Get a hint
         </button>
@@ -89,10 +84,10 @@ function AIHintPanel({ subpartId }: { subpartId: number }) {
 
   return (
     <div className="mt-3">
-      {isPending && <p className="text-xs text-gray-500">Thinking of a good hint…</p>}
+      {isPending && <p className="text-xs text-ink-500">Thinking of a good hint…</p>}
 
       {isError && (
-        <p className="text-xs text-red-600">
+        <p className="text-xs text-rose-600">
           Couldn&apos;t load a hint right now. Please try again.
         </p>
       )}
@@ -100,9 +95,9 @@ function AIHintPanel({ subpartId }: { subpartId: number }) {
       {hints.slice(0, revealed).map((hint) => (
         <div
           key={hint.level}
-          className="mt-2 rounded-lg border border-amber-100 bg-amber-50 p-3 text-sm text-gray-800 leading-relaxed"
+          className="mt-2 rounded-lg border border-amber-100 bg-amber-50 p-3 text-sm text-ink-800 leading-relaxed"
         >
-          <span className="mr-1 font-medium text-amber-700">Hint {hint.level}:</span>
+          <span className="mr-1 font-medium text-amber-800">Hint {hint.level}:</span>
           <RichContent text={hint.text} />
         </div>
       ))}
@@ -111,14 +106,14 @@ function AIHintPanel({ subpartId }: { subpartId: number }) {
         <button
           type="button"
           onClick={() => setRevealed((n) => Math.min(n + 1, hints.length))}
-          className="mt-2 text-xs font-medium text-amber-700 hover:text-amber-900 transition-colors"
+          className="mt-2 text-xs font-medium text-amber-800 hover:text-amber-900 transition-colors motion-reduce:transition-none focus:outline-none focus-visible:underline"
         >
           ▸ Show next hint ({revealed}/{hints.length})
         </button>
       )}
 
       {data && revealed >= hints.length && hints.length > 0 && (
-        <p className="mt-2 text-xs text-gray-400">That&apos;s all the hints — give it a try!</p>
+        <p className="mt-2 text-xs text-ink-400">That&apos;s all the hints — give it a try!</p>
       )}
     </div>
   );
@@ -126,8 +121,6 @@ function AIHintPanel({ subpartId }: { subpartId: number }) {
 
 interface SubpartInputProps {
   subpart: QuestionSubpart;
-  /** Effective answer type for this subpart (subpart_type, falling back to the
-   *  question's type). Drives which input widget renders. */
   widgetType: SubpartType | 'compound';
   value: string;
   onChange: (value: string) => void;
@@ -141,10 +134,10 @@ function SubpartInput({ subpart, widgetType, value, onChange, isSubmitted }: Sub
         {subpart.options.map((opt: MCQOption) => (
           <label
             key={opt.key}
-            className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+            className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors motion-reduce:transition-none ${
               value === opt.key
-                ? 'border-indigo-500 bg-indigo-50'
-                : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50'
+                ? 'border-brand-500 bg-brand-50'
+                : 'border-ink-200 hover:border-ink-300 hover:bg-ink-50'
             } ${isSubmitted ? 'cursor-not-allowed opacity-75' : ''}`}
           >
             <input
@@ -154,9 +147,9 @@ function SubpartInput({ subpart, widgetType, value, onChange, isSubmitted }: Sub
               checked={value === opt.key}
               onChange={() => !isSubmitted && onChange(opt.key)}
               disabled={isSubmitted}
-              className="text-indigo-600 focus:ring-indigo-500"
+              className="text-brand-600 focus:ring-brand-500"
             />
-            <span className="text-sm text-gray-800">
+            <span className="text-sm text-ink-800">
               <strong className="mr-1">{opt.key}.</strong>
               <RichContent text={opt.text} />
             </span>
@@ -181,10 +174,10 @@ function SubpartInput({ subpart, widgetType, value, onChange, isSubmitted }: Sub
         {subpart.options.map((opt: MCQOption) => (
           <label
             key={opt.key}
-            className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+            className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors motion-reduce:transition-none ${
               selected.includes(opt.key)
-                ? 'border-indigo-500 bg-indigo-50'
-                : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50'
+                ? 'border-brand-500 bg-brand-50'
+                : 'border-ink-200 hover:border-ink-300 hover:bg-ink-50'
             } ${isSubmitted ? 'cursor-not-allowed opacity-75' : ''}`}
           >
             <input
@@ -193,9 +186,9 @@ function SubpartInput({ subpart, widgetType, value, onChange, isSubmitted }: Sub
               checked={selected.includes(opt.key)}
               onChange={() => toggle(opt.key)}
               disabled={isSubmitted}
-              className="text-indigo-600 focus:ring-indigo-500 rounded"
+              className="text-brand-600 focus:ring-brand-500 rounded"
             />
-            <span className="text-sm text-gray-800">
+            <span className="text-sm text-ink-800">
               <strong className="mr-1">{opt.key}.</strong>
               <RichContent text={opt.text} />
             </span>
@@ -213,7 +206,7 @@ function SubpartInput({ subpart, widgetType, value, onChange, isSubmitted }: Sub
         onChange={(e) => !isSubmitted && onChange(e.target.value)}
         disabled={isSubmitted}
         placeholder="Enter your answer"
-        className="mt-3 block w-full max-w-xs rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500 disabled:bg-gray-50 disabled:cursor-not-allowed"
+        className="input-brand mt-3 max-w-xs disabled:cursor-not-allowed"
       />
     );
   }
@@ -226,7 +219,7 @@ function SubpartInput({ subpart, widgetType, value, onChange, isSubmitted }: Sub
       onChange={(e) => !isSubmitted && onChange(e.target.value)}
       disabled={isSubmitted}
       placeholder="Enter your answer"
-      className="mt-3 block w-full max-w-sm rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500 disabled:bg-gray-50 disabled:cursor-not-allowed"
+      className="input-brand mt-3 max-w-sm disabled:cursor-not-allowed"
     />
   );
 }
@@ -240,16 +233,16 @@ export const QuestionCard = ({
 }: QuestionCardProps) => {
   const handleChange = useCallback(
     (subpartId: number, value: string) => onAnswerChange(subpartId, value),
-    [onAnswerChange]
+    [onAnswerChange],
   );
 
   return (
-    <div className="bg-white rounded-xl border border-gray-200 p-6">
+    <div className="os-card p-6">
       <div className="flex items-center gap-2 mb-4">
-        <span className="flex-shrink-0 w-7 h-7 rounded-full bg-indigo-100 text-indigo-700 text-xs font-bold flex items-center justify-center">
+        <span className="flex-shrink-0 w-7 h-7 rounded-full bg-brand-100 text-brand-700 text-xs font-bold flex items-center justify-center font-display">
           {questionNumber}
         </span>
-        <span className="text-xs font-medium text-gray-400 uppercase tracking-wide">
+        <span className="text-xs font-medium text-ink-400 uppercase tracking-wide">
           {question.question_type.replace('_', ' ')}
           {question.difficulty != null && ` · Difficulty ${question.difficulty}`}
         </span>
@@ -266,9 +259,9 @@ export const QuestionCard = ({
         const isAnswered = value.trim().length > 0;
 
         return (
-          <div key={subpart.id} className={i > 0 ? 'mt-6 pt-6 border-t border-gray-100' : ''}>
+          <div key={subpart.id} className={i > 0 ? 'mt-6 pt-6 border-t border-ink-100' : ''}>
             {question.subparts.length > 1 && (
-              <p className="text-xs text-gray-400 mb-1">Part {String.fromCharCode(97 + i)})</p>
+              <p className="text-xs text-ink-400 mb-1">Part {String.fromCharCode(97 + i)})</p>
             )}
 
             {subpart.image_url && (
@@ -276,30 +269,30 @@ export const QuestionCard = ({
                 <img
                   src={subpart.image_url}
                   alt="Question diagram"
-                  className="max-w-full rounded border border-gray-200"
+                  className="max-w-full rounded border border-ink-200"
                   style={{ maxHeight: '320px', objectFit: 'contain' }}
                   loading="lazy"
-                  onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                  onError={(e) => {
+                    (e.target as HTMLImageElement).style.display = 'none';
+                  }}
                 />
               </div>
             )}
 
             {subpart.is_interactive && subpart.interactive_html ? (
-              // M7-11: authored interactive widget runs in a sandboxed iframe;
-              // falls back to the sanitised prompt if the widget HTML is absent.
               <InteractiveWidget
                 html={subpart.interactive_html}
                 fallbackText={subpart.question_text}
-                className="text-sm text-gray-800"
+                className="text-sm text-ink-800"
               />
             ) : subpart.question_text ? (
               <RichContent
                 text={subpart.question_text}
                 variant="block"
-                className="text-sm text-gray-800"
+                className="text-sm text-ink-800"
               />
             ) : (
-              <p className="text-sm text-gray-400 italic">No question text available.</p>
+              <p className="text-sm text-ink-400 italic">No question text available.</p>
             )}
 
             <SubpartInput
@@ -311,7 +304,7 @@ export const QuestionCard = ({
             />
 
             {isAnswered && !isSubmitted && (
-              <p className="text-xs text-green-600 mt-1">Answered</p>
+              <p className="text-xs text-emerald-700 mt-1">Answered</p>
             )}
 
             {!isSubmitted && <AIHintPanel subpartId={subpart.id} />}

--- a/frontend_modern/src/features/student/SRSDrillPage.tsx
+++ b/frontend_modern/src/features/student/SRSDrillPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { Skeleton } from '@/shared/ui';
+import { Button, EmptyState, Skeleton } from '@/shared/ui';
 import { QuestionCard } from './QuestionCard';
 import { useMarkReviewed, useSRSDrill, type SRSReviewResult } from './useSRSDrill';
 
@@ -24,11 +24,11 @@ export const SRSDrillPage = () => {
 
   const answeredCount = useMemo(
     () => Object.values(answers).filter((v) => v && v.trim().length > 0).length,
-    [answers]
+    [answers],
   );
   const totalSubparts = useMemo(
     () => drill?.questions.reduce((sum, q) => sum + q.subparts.length, 0) ?? 0,
-    [drill]
+    [drill],
   );
 
   const handleAnswerChange = (subpartId: number, value: string) => {
@@ -39,7 +39,7 @@ export const SRSDrillPage = () => {
     if (!drill || answeredCount === 0) return;
     markReviewed(
       { entryId: drill.entry_id, answers },
-      { onSuccess: (data) => setResult(data) }
+      { onSuccess: (data) => setResult(data) },
     );
   };
 
@@ -61,21 +61,19 @@ export const SRSDrillPage = () => {
 
   if (isError || !drill) {
     return (
-      <div className="max-w-2xl mx-auto px-4 py-12 text-center">
-        <div className="rounded-xl border border-gray-200 bg-white p-8">
-          <p className="text-base font-semibold text-gray-900 mb-2">
-            Review session not found
-          </p>
-          <p className="text-sm text-gray-500 mb-4">
-            This review may have been removed or is no longer available.
-          </p>
-          <Link
-            to="/student"
-            className="inline-block bg-indigo-600 text-white text-sm font-medium px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors"
-          >
-            Back to dashboard
-          </Link>
-        </div>
+      <div className="max-w-2xl mx-auto px-4 py-12">
+        <EmptyState
+          title="Review session not found"
+          description="This review may have been removed or is no longer available."
+          action={
+            <Link
+              to="/student"
+              className="btn-brand inline-block focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2"
+            >
+              Back to dashboard
+            </Link>
+          }
+        />
       </div>
     );
   }
@@ -87,44 +85,35 @@ export const SRSDrillPage = () => {
       <div className="max-w-2xl mx-auto px-4 py-10">
         <div
           className={`rounded-2xl border p-8 text-center ${
-            passed
-              ? 'border-green-200 bg-green-50'
-              : 'border-amber-200 bg-amber-50'
+            passed ? 'border-emerald-200 bg-emerald-50' : 'border-amber-200 bg-amber-50'
           }`}
         >
           <div className="text-5xl mb-4" aria-hidden>
             {passed ? '🎉' : '📚'}
           </div>
-          <h2 className="text-2xl font-bold text-gray-900 mb-2">
+          <h2 className="text-2xl font-display font-semibold text-ink-900 mb-2">
             {passed ? 'Great review!' : 'Keep practicing!'}
           </h2>
-          <p className="text-gray-700 mb-1">
+          <p className="text-ink-700 mb-1">
             You scored <span className="font-semibold">{pct}%</span> on{' '}
             <span className="font-semibold">{drill.chapter_name}</span>
           </p>
-          <p className="text-sm text-gray-500 mb-6">
+          <p className="text-sm text-ink-500 mb-6">
             {passed
               ? `Next review scheduled for ${result.next_review_date}`
               : 'Interval reset — see this chapter again tomorrow'}
           </p>
           <div className="flex flex-wrap gap-2 justify-center">
-            <button
-              type="button"
-              onClick={() => navigate('/student')}
-              className="bg-indigo-600 text-white px-5 py-2.5 rounded-lg text-sm font-medium hover:bg-indigo-700 transition-colors"
-            >
-              Back to Dashboard
-            </button>
-            <button
-              type="button"
+            <Button onClick={() => navigate('/student')}>Back to Dashboard</Button>
+            <Button
+              variant="ghost"
               onClick={() => {
                 setAnswers({});
                 setResult(null);
               }}
-              className="bg-white border border-gray-300 text-gray-700 px-5 py-2.5 rounded-lg text-sm font-medium hover:bg-gray-50 transition-colors"
             >
               Review again
-            </button>
+            </Button>
           </div>
         </div>
       </div>
@@ -137,22 +126,22 @@ export const SRSDrillPage = () => {
         <button
           type="button"
           onClick={() => navigate('/student')}
-          className="text-sm text-indigo-600 hover:text-indigo-800 mb-3 inline-flex items-center gap-1 transition-colors"
+          className="text-sm text-brand-700 font-medium hover:underline mb-3 inline-flex items-center gap-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded"
         >
           ← Back
         </button>
         <div className="flex items-center gap-3">
           <span
-            className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-orange-100 text-2xl"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-brand-100 text-2xl"
             aria-hidden
           >
             🔁
           </span>
           <div className="min-w-0">
-            <h1 className="text-xl font-bold text-gray-900 truncate">
+            <h1 className="text-xl font-display font-semibold text-ink-900 truncate">
               {drill.chapter_name}
             </h1>
-            <p className="text-sm text-gray-500 truncate">
+            <p className="text-sm text-ink-500 truncate">
               {drill.subject_name} · Spaced review
             </p>
           </div>
@@ -160,30 +149,27 @@ export const SRSDrillPage = () => {
       </div>
 
       {drill.questions.length === 0 ? (
-        <div className="rounded-xl border border-gray-200 bg-white p-8 text-center">
-          <div className="text-4xl mb-3" aria-hidden>
-            📭
-          </div>
-          <p className="text-base font-semibold text-gray-900 mb-1">
-            No review questions yet
-          </p>
-          <p className="text-sm text-gray-500 mb-5">
-            Your teacher hasn't added questions for {drill.chapter_name} yet.
-          </p>
-          <Link
-            to="/student"
-            className="inline-block bg-indigo-600 text-white text-sm font-medium px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors"
-          >
-            Back to dashboard
-          </Link>
-        </div>
+        <EmptyState
+          title="No review questions yet"
+          description={`Your teacher hasn't added questions for ${drill.chapter_name} yet.`}
+          action={
+            <Link
+              to="/student"
+              className="btn-brand inline-block focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2"
+            >
+              Back to dashboard
+            </Link>
+          }
+        />
       ) : (
         <>
-          <div className="mb-4 flex items-center justify-between text-xs text-gray-500">
+          <div className="mb-4 flex items-center justify-between text-xs text-ink-500">
             <span>
               {answeredCount} / {totalSubparts} answered
             </span>
-            <span>{drill.questions.length} question{drill.questions.length !== 1 ? 's' : ''}</span>
+            <span>
+              {drill.questions.length} question{drill.questions.length !== 1 ? 's' : ''}
+            </span>
           </div>
 
           <div className="space-y-4">
@@ -200,16 +186,16 @@ export const SRSDrillPage = () => {
           </div>
 
           <div className="mt-6 sticky bottom-4">
-            <button
-              type="button"
+            <Button
+              size="lg"
+              className="w-full shadow-sm"
               onClick={handleSubmit}
               disabled={isPending || answeredCount === 0}
-              className="w-full bg-indigo-600 text-white px-8 py-3 rounded-xl font-semibold shadow-sm hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               {isPending ? 'Submitting…' : 'Submit Review'}
-            </button>
+            </Button>
             {answeredCount === 0 && (
-              <p className="text-xs text-center text-gray-400 mt-2">
+              <p className="text-xs text-center text-ink-400 mt-2">
                 Answer at least one question to submit
               </p>
             )}


### PR DESCRIPTION
## Summary
Migrates the student practice flow (highest student traffic surface) to V2 'Chalk & Unlock'.

**Classification:** Improve (reskin + unlock motif on score reveal)
**Initiative:** V2 design system M4-05
**Plan:** docs/daily-plans/2026-06-03-plan.md (item 5)

## Files
- features/student/QuestionCard.tsx
- features/student/AssignmentDetailPage.tsx
- features/student/SRSDrillPage.tsx
- features/student/AssignmentCard.tsx
- features/student/AssignmentList.tsx

## What changed
- QuestionCard: .os-card, MCQ selected = brand-500 + brand-50, solution reveal brand-tinted, hints amber
- AssignmentDetailPage: progress brand-500, score card on unlock-motif palette (emerald/amber/rose, font-display), .os-card confirm dialog
- SRSDrillPage: result card semantic surfaces, EmptyState for error/no-questions, brand CTAs
- AssignmentCard: Badge status pills, brand-500 progress bar, ui/Button CTA
- AssignmentList: EmptyState; accent pills retoned to brand/amber/rose/emerald
- Section heading text preserved verbatim for AssignmentList.test.tsx
- QuestionCard radio names, placeholders, input types preserved for QuestionCard.test.tsx
- motion-reduce:transition-none + focus-visible rings throughout

## Tests
- type-check, lint, vitest 84/84 (incl. 4 QuestionCard tests + 6 AssignmentList tests), build — green

## Verify
`student_demo` / `demo1234` → open an assignment, answer MCQ + numeric, submit; then /student/srs/drill.

## Closes
After this PR, only M4-07 (teacher authoring cluster) remains in M4.