### PR TITLE
fix(ai): Gemini JSON mode for question generation + chapter selector ordering

### DIFF
--- a/backend/openshiksha/apps/ai/llm_client.py
+++ b/backend/openshiksha/apps/ai/llm_client.py
@@ -431,28 +431,66 @@ def _call_anthropic_generate_questions(prompt: str, api_key: str) -> list[dict]:
 
 
 def _call_google_generate_questions(prompt: str, api_key: str) -> list[dict]:
-    """Fallback: ask the Google AI Studio model to return JSON and parse it."""
+    """Call Google AI Studio with structured JSON output (response_mime_type).
+
+    Uses Gemini's native JSON mode so the response is guaranteed valid JSON —
+    no markdown fences, no free-text wrapping, no fragile string parsing.
+    The response_schema mirrors the Anthropic tool's input_schema so both
+    providers return the same shape.
+    """
     import json as _json
 
     from google import genai
     from google.genai import types
 
-    json_prompt = (
-        prompt + "\n\nIMPORTANT: Respond ONLY with a valid JSON array of question objects, "
-        'no markdown fences, no explanation. Example: [{"question_text": "...", ...}]'
-    )
+    response_schema = {
+        "type": "object",
+        "required": ["questions"],
+        "properties": {
+            "questions": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["question_text", "correct_answer"],
+                    "properties": {
+                        "question_text": {"type": "string"},
+                        "options": {
+                            "type": "array",
+                            "nullable": True,
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "key": {"type": "string"},
+                                    "text": {"type": "string"},
+                                },
+                            },
+                        },
+                        "correct_answer": {"type": "string"},
+                        "variable_constraints": {"type": "object", "nullable": True},
+                        "suggested_tags": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "solution": {"type": "string"},
+                    },
+                },
+            }
+        },
+    }
+
     client = genai.Client(api_key=api_key)
     response = client.models.generate_content(
         model=_google_ai_model(),
-        contents=json_prompt,
+        contents=prompt,
         config=types.GenerateContentConfig(
             max_output_tokens=QUESTION_GEN_MAX_TOKENS,
             temperature=0.8,
+            response_mime_type="application/json",
+            response_schema=response_schema,
         ),
     )
-    text = (response.text or "").strip()
-    text = text.lstrip("```json").lstrip("```").rstrip("```").strip()
-    return _json.loads(text)
+    data = _json.loads(response.text or "{}")
+    return data.get("questions", [])
 
 
 def _call_ollama_generate_questions(prompt: str, base_url: str) -> list[dict]:

--- a/frontend_modern/src/features/teacher/CreateQuestionPage.tsx
+++ b/frontend_modern/src/features/teacher/CreateQuestionPage.tsx
@@ -238,12 +238,6 @@ const AIGenerationPanel = ({
 
       {open && (
         <div className="px-5 pb-5 space-y-4 border-t border-indigo-200">
-          {!chapterId && (
-            <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 mt-4">
-              Select a chapter above before generating questions.
-            </p>
-          )}
-
           <div className="mt-4">
             <label className="block text-xs font-medium text-indigo-800 mb-1">
               Topic or concept to test
@@ -609,14 +603,6 @@ export const CreateQuestionPage = ({ editMode = false }: { editMode?: boolean })
       </div>
 
       <div className="space-y-6">
-        {/* AI Generation Panel */}
-        {!editMode && (
-          <AIGenerationPanel
-            chapterId={selectedChapterId}
-            onUseDraft={handleUseDraft}
-          />
-        )}
-
         {/* Chapter selection */}
         <div className="bg-white rounded-xl border border-gray-200 p-5 space-y-4">
           <h2 className="font-semibold text-gray-800">Chapter</h2>
@@ -678,6 +664,14 @@ export const CreateQuestionPage = ({ editMode = false }: { editMode?: boolean })
             <p className="text-xs text-gray-400 mt-1">1 = easiest, 5 = hardest</p>
           </div>
         </div>
+
+        {/* AI Generation Panel — after chapter so chapterId is always set */}
+        {!editMode && (
+          <AIGenerationPanel
+            chapterId={selectedChapterId}
+            onUseDraft={handleUseDraft}
+          />
+        )}
 
         {/* Subpart tabs */}
         <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">


### PR DESCRIPTION
## What broke

Two separate issues both resulting in the \"AI provider unavailable\" stub and a confusing UI.

**Backend:** `_call_google_generate_questions` prompted Gemini to return a JSON array as free text then parsed `response.text` with `json.loads`. Long responses (e.g. polynomial MCQs) produced output that failed `JSONDecodeError` at parse time → exception swallowed → cascade fell to Ollama (not running) → stub. The HTTP response was actually **200 OK** — Gemini was working fine, the parsing was broken.

**Frontend:** The Chapter/Subject selectors were rendered *below* the AI panel in the page. `AIGenerationPanel` receives `chapterId` as a prop — so it was always `''` when the panel rendered, the amber warning always showed, and the Generate button was always disabled until you scrolled down, picked a chapter, then scrolled back up.

## Fixes

**Backend** (`llm_client.py`): Switch to Gemini's native structured output:
```python
config=types.GenerateContentConfig(
    response_mime_type="application/json",
    response_schema=response_schema,   # mirrors the Anthropic tool schema
)
```
No more free-text parsing. `response.text` is guaranteed valid JSON matching the schema.

**Frontend** (`CreateQuestionPage.tsx`): Move the Chapter section above the AI panel so `chapterId` is always populated by the time the user sees the Generate button. Remove the now-redundant "select a chapter above" warning.

## Result
- Chapter → AI panel order: pick subject/chapter/difficulty first, then Generate with AI
- Gemini returns structured JSON directly — no markdown stripping, no parse failures
- All pre-commit hooks pass (black, isort, flake8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)