### PR TITLE
feat(frontend): migrate Browse cluster to V2 (M4-06b-i)

### DIFF
--- a/docs/changes/2026-06-04-browse-cluster-v2.md
+++ b/docs/changes/2026-06-04-browse-cluster-v2.md
@@ -1,0 +1,46 @@
+# M4-06b-i — Browse cluster → V2
+
+**Classification:** Improve.
+
+## Summary
+Migrates the student "browse the question bank and practice" slice
+(`BrowsePage`, `BrowsePracticePage`) from the legacy `primary`/`indigo`/cold-gray
+template to the V2 "Chalk & Unlock" tokens + `src/shared/ui` primitives. Closes
+half of the deferred M4-06b in the V2 initiative.
+
+## Files changed
+- `frontend_modern/src/features/student/BrowsePage.tsx`
+- `frontend_modern/src/features/student/BrowsePracticePage.tsx`
+
+## What changed
+- Page chrome composes `SectionHeading` (eyebrow + Fraunces title), `Select`
+  fields (for board/grade filters), `os-card` containers, `Button`
+  (`variant="brand"`), `Badge` (`tone="brand"` for the per-chapter question
+  count), and `EmptyState` (keyhole motif) for the no-results surface.
+- Table chrome moved from `bg-gray-50`/`text-gray-*` to warm `ink-*` tones with
+  `brand-50/40` hover rows.
+- `BrowsePracticePage` reuses the same primitives; `QuestionCard` is left
+  untouched (already V2 since #185 / M4-05) per the daily plan's scope guard.
+- Empty/error/submitted states all routed through the primitives so they share
+  the system's keyhole motif and warm paper surface.
+
+## What was preserved
+- Data hooks (`useBrowseChapters`, the inline `useBrowsePractice` query),
+  routes, role guards, and props — reskin only, no logic refactor.
+- `QuestionCard` (per plan, untouched here; lives under M4-05).
+- The (currently no-op) filter wiring — fixing the actual filtering is M7-03,
+  out of scope for the V2 reskin.
+
+## Continuous improvement
+- Page-level filter chrome is now a single `.os-card` row + `Select`
+  primitives, replacing two hand-rolled `<select>` blocks with focus-ring
+  classes spelled out by hand. The Select primitive already carries
+  focus-visible + AA labels.
+
+## Verification
+- `npm run type-check`, `npm run lint`, `npm run build`, `npm test` — all green.
+- Grep `primary|indigo|blue-|gray-50|text-gray-` in both files → 0 matches.
+
+## Next
+- M4-06b-ii Learning Path + Videos.
+- M7-03 Browse filter wiring (the controls don't currently filter results).

--- a/frontend_modern/src/features/student/BrowsePage.tsx
+++ b/frontend_modern/src/features/student/BrowsePage.tsx
@@ -1,7 +1,14 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/shared/hooks/useAuth';
-import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
+import {
+  Badge,
+  Button,
+  EmptyState,
+  LoadingSpinner,
+  SectionHeading,
+  Select,
+} from '@/shared/ui';
 import { useBrowseChapters } from './useBrowseChapters';
 import { useSubjects } from '../teacher/useSubjects';
 
@@ -21,39 +28,45 @@ export const BrowsePage = () => {
 
   return (
     <div>
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{greeting}</h1>
-        <p className="text-gray-500 mt-1 text-sm">
-          Practice from the shared question bank — choose a chapter to start.
-        </p>
-      </div>
+      <SectionHeading
+        as="h1"
+        eyebrow="Self-directed practice"
+        title={greeting}
+        description="Practice from the shared question bank — choose a chapter to start."
+        className="mb-6"
+      />
 
-      {/* Filters */}
-      <div className="flex flex-wrap gap-3 mb-6">
-        <select
+      <div className="os-card mb-6 flex flex-wrap items-end gap-3 p-4">
+        <Select
+          label="Subject"
           value={selectedSubject}
           onChange={(e) => setSelectedSubject(e.target.value)}
-          className="px-3 py-2 rounded-lg border border-gray-300 bg-white text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          className="min-w-[12rem]"
+          block={false}
         >
           <option value="">All Subjects</option>
           {subjects?.map((s) => (
-            <option key={s.id} value={s.id}>{s.name}</option>
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
           ))}
-        </select>
-
-        <select
+        </Select>
+        <Select
+          label="Grade"
           value={selectedStandard}
           onChange={(e) => setSelectedStandard(e.target.value)}
-          className="px-3 py-2 rounded-lg border border-gray-300 bg-white text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          className="min-w-[10rem]"
+          block={false}
         >
           <option value="">All Standards</option>
           {Array.from({ length: 12 }, (_, i) => i + 1).map((n) => (
-            <option key={n} value={n}>Grade {n}</option>
+            <option key={n} value={n}>
+              Grade {n}
+            </option>
           ))}
-        </select>
+        </Select>
       </div>
 
-      {/* Chapter list */}
       {isLoading && (
         <div className="flex justify-center py-16">
           <LoadingSpinner size="lg" />
@@ -61,53 +74,65 @@ export const BrowsePage = () => {
       )}
 
       {isError && (
-        <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+        <div
+          role="alert"
+          className="os-card border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700"
+        >
           Failed to load chapters. Please refresh the page.
         </div>
       )}
 
       {chapters && chapters.length === 0 && !isLoading && (
-        <div className="text-center py-16 text-gray-400">
-          <svg className="w-12 h-12 mx-auto mb-4 opacity-40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
-              d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-            />
-          </svg>
-          <p className="font-medium">No chapters found</p>
-          <p className="text-sm mt-1">Try a different subject or standard filter.</p>
-        </div>
+        <EmptyState
+          title="No chapters found"
+          description="Try a different subject or standard filter."
+        />
       )}
 
       {chapters && chapters.length > 0 && (
-        <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+        <div className="os-card overflow-hidden p-0">
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-gray-200 bg-gray-50">
-                <th className="text-left px-4 py-3 font-medium text-gray-700">Chapter</th>
-                <th className="text-left px-4 py-3 font-medium text-gray-700 hidden sm:table-cell">Subject</th>
-                <th className="text-left px-4 py-3 font-medium text-gray-700 hidden sm:table-cell">Grade</th>
-                <th className="text-right px-4 py-3 font-medium text-gray-700">Questions</th>
+              <tr className="border-b border-ink-100 bg-ink-50">
+                <th className="px-4 py-3 text-left font-display font-semibold text-ink-700">
+                  Chapter
+                </th>
+                <th className="hidden px-4 py-3 text-left font-display font-semibold text-ink-700 sm:table-cell">
+                  Subject
+                </th>
+                <th className="hidden px-4 py-3 text-left font-display font-semibold text-ink-700 sm:table-cell">
+                  Grade
+                </th>
+                <th className="px-4 py-3 text-right font-display font-semibold text-ink-700">
+                  Questions
+                </th>
                 <th className="px-4 py-3" />
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-100">
+            <tbody className="divide-y divide-ink-100">
               {chapters.map((ch) => (
-                <tr key={ch.id} className="hover:bg-gray-50 transition-colors">
-                  <td className="px-4 py-3 font-medium text-gray-900">{ch.name}</td>
-                  <td className="px-4 py-3 text-gray-500 hidden sm:table-cell">{ch.subject}</td>
-                  <td className="px-4 py-3 text-gray-500 hidden sm:table-cell">Grade {ch.standard}</td>
-                  <td className="px-4 py-3 text-right">
-                    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-50 text-indigo-700">
-                      {ch.question_count} Q
-                    </span>
+                <tr
+                  key={ch.id}
+                  className="transition-colors hover:bg-brand-50/40"
+                >
+                  <td className="px-4 py-3 font-medium text-ink-900">{ch.name}</td>
+                  <td className="hidden px-4 py-3 text-ink-500 sm:table-cell">
+                    {ch.subject}
+                  </td>
+                  <td className="hidden px-4 py-3 text-ink-500 sm:table-cell">
+                    Grade {ch.standard}
                   </td>
                   <td className="px-4 py-3 text-right">
-                    <button
+                    <Badge tone="brand">{ch.question_count} Q</Badge>
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <Button
+                      variant="brand"
+                      size="sm"
                       onClick={() => navigate(`/student/browse/chapter/${ch.id}`)}
-                      className="text-sm font-medium text-indigo-600 hover:text-indigo-800 transition-colors"
                     >
                       Practice →
-                    </button>
+                    </Button>
                   </td>
                 </tr>
               ))}

--- a/frontend_modern/src/features/student/BrowsePracticePage.tsx
+++ b/frontend_modern/src/features/student/BrowsePracticePage.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from '@/api/client';
 import { QuestionCard } from './QuestionCard';
-import { LoadingSpinner } from '@/shared/ui';
+import { Button, EmptyState, LoadingSpinner, SectionHeading } from '@/shared/ui';
 import type { PaginatedResponse, Question } from '@/types/index';
 
 const useBrowsePractice = (chapterId: number | null) =>
@@ -47,9 +47,15 @@ export const BrowsePracticePage = () => {
 
   if (isError || !questions) {
     return (
-      <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+      <div
+        role="alert"
+        className="os-card border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700"
+      >
         Failed to load questions.{' '}
-        <button onClick={() => navigate('/student/browse')} className="underline">
+        <button
+          onClick={() => navigate('/student/browse')}
+          className="underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded"
+        >
           Go back
         </button>
       </div>
@@ -58,42 +64,46 @@ export const BrowsePracticePage = () => {
 
   if (questions.length === 0) {
     return (
-      <div className="text-center py-16 text-gray-500">
-        <p className="font-medium">No questions available for this chapter yet.</p>
-        <Link to="/student/browse" className="text-indigo-600 hover:text-indigo-800 text-sm mt-2 inline-block">
-          ← Back to browse
-        </Link>
-      </div>
+      <EmptyState
+        title="No questions available for this chapter yet."
+        action={
+          <Link to="/student/browse">
+            <Button variant="ghost" size="sm">
+              ← Back to browse
+            </Button>
+          </Link>
+        }
+      />
     );
   }
 
   if (submitted) {
     const chapterName = questions[0].chapter_name ?? 'this chapter';
     return (
-      <div className="max-w-2xl mx-auto">
-        <div className="bg-white rounded-xl border border-gray-200 p-8 text-center">
-          <div className="text-4xl mb-4">🎉</div>
-          <h2 className="text-xl font-bold text-gray-900 mb-2">Practice Complete!</h2>
-          <p className="text-gray-500 text-sm mb-1">{chapterName}</p>
-          <p className="text-gray-700 mb-6">
-            You answered {answeredCount} of {totalSubparts} question{totalSubparts !== 1 ? 's' : ''}.
+      <div className="mx-auto max-w-2xl">
+        <div className="os-card p-8 text-center">
+          <div className="mb-4 text-4xl">🎉</div>
+          <h2 className="mb-2 font-display text-xl font-semibold text-ink-900">
+            Practice Complete!
+          </h2>
+          <p className="mb-1 text-sm text-ink-500">{chapterName}</p>
+          <p className="mb-6 text-ink-700">
+            You answered {answeredCount} of {totalSubparts} question
+            {totalSubparts !== 1 ? 's' : ''}.
           </p>
-          <div className="flex flex-col sm:flex-row gap-3 justify-center">
-            <button
+          <div className="flex flex-col justify-center gap-3 sm:flex-row">
+            <Button
+              variant="ghost"
               onClick={() => {
                 setAnswers({});
                 setSubmitted(false);
               }}
-              className="px-5 py-2 rounded-lg border border-gray-300 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
             >
               Practice Again
-            </button>
-            <Link
-              to="/student/browse"
-              className="px-5 py-2 rounded-lg bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 transition-colors text-center"
-            >
+            </Button>
+            <Button variant="brand" onClick={() => navigate('/student/browse')}>
               Browse More Chapters
-            </Link>
+            </Button>
           </div>
         </div>
       </div>
@@ -101,14 +111,25 @@ export const BrowsePracticePage = () => {
   }
 
   return (
-    <div className="max-w-2xl mx-auto">
-      <div className="flex items-center justify-between mb-4">
-        <Link to="/student/browse" className="text-sm text-indigo-600 hover:text-indigo-800">
+    <div className="mx-auto max-w-2xl">
+      <SectionHeading
+        as="h1"
+        eyebrow="Practice"
+        title={questions[0].chapter_name ?? 'Chapter Practice'}
+        action={
+          <span className="text-sm text-ink-500">
+            {answeredCount} / {totalSubparts} answered
+          </span>
+        }
+        className="mb-4"
+      />
+      <div className="mb-4">
+        <Link
+          to="/student/browse"
+          className="rounded text-sm font-medium text-brand-700 hover:text-brand-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
+        >
           ← Browse
         </Link>
-        <span className="text-sm text-gray-500">
-          {answeredCount} / {totalSubparts} answered
-        </span>
       </div>
 
       <div className="space-y-4">
@@ -127,13 +148,14 @@ export const BrowsePracticePage = () => {
       </div>
 
       <div className="mt-6 flex justify-end">
-        <button
+        <Button
+          variant="brand"
+          size="lg"
           onClick={() => setSubmitted(true)}
           disabled={answeredCount === 0}
-          className="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-300 text-white font-semibold rounded-lg transition-colors"
         >
           Submit Practice
-        </button>
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Migrates the student **Browse** slice — `BrowsePage` + `BrowsePracticePage` — from the legacy `primary`/`indigo`/cold-gray template to V2 *Chalk & Unlock* tokens + `src/shared/ui` primitives. Half of the deferred **M4-06b** in the [V2 design system initiative](docs/initiatives/2026-design-system-v2.md).

## Classification
**Improve** — reskin only; data hooks, routes, role guards, props unchanged.

## What changed
- Page chrome composed from `SectionHeading`, `Select`, `os-card`, `Button` (`variant="brand"`), `Badge` (`tone="brand"`), `EmptyState` (keyhole motif).
- Chapter list table → warm `ink-*` tones with `brand-50/40` hover rows.
- `QuestionCard` left untouched (already V2 since #185 / M4-05).
- Filter wiring left as-is — fixing the filter is M7-03, out of scope.

## Verification
- `npm run type-check`, `npm run lint`, `npm run build`, `npm test` — all green (84 tests pass).
- `grep -E 'primary|indigo|blue-|gray-50|text-gray-'` in both files → 0 matches.

## Legacy reference
Net-new modern capability — the legacy Django app had no self-directed browse/practice surface.

## Test plan
- [x] Type-check / lint / build / vitest green
- [x] 0 legacy color refs in both files
- [ ] Manual Docker-stack screenshot (deferred to a follow-up screenshot pass)