### PR TITLE
feat(frontend): retire legacy primary blue token (M6-02)

### DIFF
--- a/docs/changes/2026-06-04-retire-primary.md
+++ b/docs/changes/2026-06-04-retire-primary.md
@@ -1,0 +1,28 @@
+# M6-02 — Retire the legacy `primary` blue token
+
+**Classification:** Improve (cleanup).
+
+## Summary
+With the M4 batch closing every authenticated surface on V2 brand, the legacy
+`primary` blue palette and its associated `.btn-primary`/`.btn-secondary`/
+`.card`/`.input` helper classes are no longer consumed anywhere in `src/`.
+This PR deletes them.
+
+## Files changed
+- `frontend_modern/tailwind.config.js` — drop the `primary` palette; refresh
+  the comment on the `brand` palette to note the retirement.
+- `frontend_modern/src/index.css` — drop the four legacy helper classes;
+  refresh the top-of-file comment.
+
+## Verification
+- `grep -rnE "\bprimary-[0-9]|\bbtn-primary\b|\bbtn-secondary\b" src/` → 0.
+- `npm run type-check`, `npm run lint`, `npm run build`, `npm test` — all green.
+
+## Why now
+M4 closed today (PRs #188–#192). With no remaining consumer, keeping the token
++ classes around just invites new code to reach for them. Removing them is a
+hard guarantee that V2 is the only language.
+
+## Next
+- M7-03 Browse filter wiring.
+- M5-01 Mobile bottom tab bar (student).

--- a/frontend_modern/src/index.css
+++ b/frontend_modern/src/index.css
@@ -5,8 +5,9 @@
 /* ════════════════════════════════════════════════════════════════════════
    OpenShiksha V2 — "Chalk & Unlock" design system
    See docs/initiatives/2026-design-system-v2.md. Tokens live in
-   tailwind.config.js. Migrated code uses the classes below + `ui/` components;
-   never raw hex, never the legacy `primary`/cold-gray palette.
+   tailwind.config.js. All code uses the classes below + `ui/` components;
+   never raw hex, never the cold-gray palette. The legacy `primary` blue
+   palette was removed in M6-02.
    ════════════════════════════════════════════════════════════════════════ */
 
 @layer base {
@@ -164,25 +165,7 @@
   }
 }
 
-/* ── Legacy classes — retained so un-migrated pages keep rendering. ─────────
-   Do NOT use in new/migrated code; prefer the brand components above. */
 @layer components {
-  .btn-primary {
-    @apply px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors;
-  }
-
-  .btn-secondary {
-    @apply px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 transition-colors;
-  }
-
-  .card {
-    @apply bg-white rounded-lg shadow-md p-6;
-  }
-
-  .input {
-    @apply w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500;
-  }
-
   .katex-display {
     @apply my-4;
   }

--- a/frontend_modern/tailwind.config.js
+++ b/frontend_modern/tailwind.config.js
@@ -9,8 +9,8 @@ export default {
       colors: {
         // ── V2 "Unlock" brand palette ──────────────────────────────────────
         // Anchored on the legacy logo orange (#FF6F00 — the keyhole graduation
-        // cap). This is the V2 brand colour; the Phase 2 UI rebuild migrates
-        // `primary` (blue, below) over to `brand`. See docs/V2_ROADMAP.md.
+        // cap). This is the only brand colour; the legacy `primary` blue was
+        // retired in M6-02 once every authenticated surface moved to `brand`.
         brand: {
           50: '#FFF8F1',
           100: '#FFEEDC',
@@ -36,20 +36,6 @@ export default {
           700: '#252220',
           800: '#1A1816',
           900: '#0F0E0D',
-        },
-        // Legacy blue — retained so existing screens render unchanged until the
-        // Phase 2 migration. New work should prefer `brand`.
-        primary: {
-          50: '#eff6ff',
-          100: '#dbeafe',
-          200: '#bfdbfe',
-          300: '#93c5fd',
-          400: '#60a5fa',
-          500: '#3b82f6',
-          600: '#2563eb',
-          700: '#1d4ed8',
-          800: '#1e40af',
-          900: '#1e3a8a',
         },
       },
       fontFamily: {


### PR DESCRIPTION
## Summary
With M4 closed today (PRs #188–#192), the legacy `primary` blue palette and the four legacy helper classes (`btn-primary`, `btn-secondary`, `card`, `input`) have **0 consumers** in `src/`. This PR deletes them so V2 brand orange is the only language in the codebase.

## Classification
**Improve (cleanup)**.

## Files changed
- `frontend_modern/tailwind.config.js` — drop the `primary` palette + refresh the brand-palette comment.
- `frontend_modern/src/index.css` — drop the four legacy helper classes + refresh the top-of-file comment.

## Verification
- `grep -rnE "\bprimary-[0-9]|\bbtn-primary\b|\bbtn-secondary\b" src/` → 0.
- `npm run type-check`, `npm run lint`, `npm run build`, `npm test` — all green (84 tests).

## Test plan
- [x] Type-check / lint / build / vitest green
- [x] 0 consumers of removed tokens/classes