### PR TITLE
feat(frontend): add mobile bottom tab bar (M5-01)

### DIFF
--- a/docs/changes/2026-06-04-mobile-bottom-nav.md
+++ b/docs/changes/2026-06-04-mobile-bottom-nav.md
@@ -1,0 +1,52 @@
+# M5-01 — Mobile bottom tab bar
+
+**Classification:** New.
+
+## Summary
+Adds a persistent **bottom tab bar** on mobile (`<sm`) so the primary
+navigation is always within thumb reach. Tabs are role-aware:
+
+- **Student / Open student** — Home · Browse · Path · Profile
+- **Teacher** — Home · Questions · Profile
+- **Parent** — Home · Profile
+- **Admin** — School · Profile
+
+On `sm:` and above the bottom bar is hidden and the existing Navbar links
+take over.
+
+## Files changed
+- `frontend_modern/src/features/layout/BottomNav.tsx` — new component
+  (~170 LOC), inline SVG icons, role-aware tab list, prefix-match for
+  highlighting nested routes (e.g. `/student/browse/chapter/42` highlights
+  Browse), `aria-current="page"` on the active tab, `aria-label="Primary"` on
+  the `<nav>`, focus-visible brand ring.
+- `frontend_modern/src/features/layout/AppShell.tsx` — render `<BottomNav />`
+  and add `pb-24 sm:pb-8` on `<main>` so page content clears the bar on
+  mobile.
+- `frontend_modern/src/features/layout/BottomNav.test.tsx` — 5 unit tests
+  covering: unauth render-nothing; STUDENT tab set; prefix-match highlight on
+  a nested route; TEACHER tab set; OPEN_STUDENT identical to STUDENT.
+
+## Why this matters
+The legacy hamburger menu hides the primary nav behind a tap. With a bottom
+tab bar, switching between Home / Browse / Path costs one thumb tap — the
+table-stakes feel for an app a teenager uses every day. The hamburger menu
+is kept for secondary actions (Profile, Sign out, the rare "Proficiency"
+deep-link).
+
+## Design notes
+- Surface: `bg-white/95 backdrop-blur` over a `border-t border-ink-100`.
+  Sits above `env(safe-area-inset-bottom)` so it clears the iOS home
+  indicator.
+- Active tab: `text-brand-700`; inactive: `text-ink-500` with hover lift.
+- One primary action per surface still holds — the active tab is the only
+  brand-orange element on the strip.
+
+## Verification
+- `npm run type-check`, `npm run lint`, `npm run build` — green.
+- `npm test` — 17 files / 89 tests pass (was 84; +5 from this PR).
+
+## Next
+- M2-02 mobile nav polish — consider replacing the hamburger entirely if the
+  bottom bar covers everything users actually reach.
+- M5-02 — touch-target audit (44×44 minimum) on student practice pages.

--- a/frontend_modern/src/features/layout/AppShell.tsx
+++ b/frontend_modern/src/features/layout/AppShell.tsx
@@ -1,3 +1,4 @@
+import { BottomNav } from './BottomNav';
 import { Navbar } from './Navbar';
 
 interface AppShellProps {
@@ -7,8 +8,9 @@ interface AppShellProps {
 export const AppShell = ({ children }: AppShellProps) => (
   <div className="bg-paper min-h-screen">
     <Navbar />
-    <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 pb-24 sm:pb-8">
       {children}
     </main>
+    <BottomNav />
   </div>
 );

--- a/frontend_modern/src/features/layout/BottomNav.test.tsx
+++ b/frontend_modern/src/features/layout/BottomNav.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi, describe, it, expect } from 'vitest';
+import { BottomNav } from './BottomNav';
+import { UserRole } from '@/types/index';
+
+const mockUseAuth = vi.fn();
+vi.mock('@/shared/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+const renderAt = (pathname: string) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[pathname]}>
+        <BottomNav />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
+
+describe('<BottomNav />', () => {
+  it('renders nothing when the user is not signed in', () => {
+    mockUseAuth.mockReturnValue({ user: undefined });
+    const { container } = renderAt('/');
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows the four student tabs for a STUDENT', () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, username: 'a', role: UserRole.STUDENT },
+    });
+    renderAt('/student');
+    expect(screen.getByRole('link', { name: /Home/i })).toHaveAttribute('href', '/student');
+    expect(screen.getByRole('link', { name: /Browse/i })).toHaveAttribute(
+      'href',
+      '/student/browse',
+    );
+    expect(screen.getByRole('link', { name: /Path/i })).toHaveAttribute(
+      'href',
+      '/student/learning-path',
+    );
+    expect(screen.getByRole('link', { name: /Profile/i })).toHaveAttribute('href', '/profile');
+  });
+
+  it('marks the matching tab as the current page (prefix match for Browse)', () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, username: 'a', role: UserRole.STUDENT },
+    });
+    renderAt('/student/browse/chapter/42');
+    const browse = screen.getByRole('link', { name: /Browse/i });
+    expect(browse).toHaveAttribute('aria-current', 'page');
+    const home = screen.getByRole('link', { name: /Home/i });
+    expect(home).not.toHaveAttribute('aria-current');
+  });
+
+  it('shows the teacher set for a TEACHER', () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, username: 't', role: UserRole.TEACHER },
+    });
+    renderAt('/teacher');
+    expect(screen.getByRole('link', { name: /Questions/i })).toHaveAttribute(
+      'href',
+      '/teacher/questions',
+    );
+    expect(screen.queryByRole('link', { name: /Browse/i })).not.toBeInTheDocument();
+  });
+
+  it('treats OPEN_STUDENT the same as STUDENT', () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, username: 'o', role: UserRole.OPEN_STUDENT },
+    });
+    renderAt('/student');
+    expect(screen.getByRole('link', { name: /Browse/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Path/i })).toBeInTheDocument();
+  });
+});

--- a/frontend_modern/src/features/layout/BottomNav.tsx
+++ b/frontend_modern/src/features/layout/BottomNav.tsx
@@ -1,0 +1,199 @@
+import { ReactNode } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import clsx from 'clsx';
+import { useAuth } from '@/shared/hooks/useAuth';
+import { UserRole } from '@/types/index';
+
+interface Tab {
+  to: string;
+  label: string;
+  icon: ReactNode;
+  /** Match by prefix so nested routes still highlight the parent tab. */
+  matchPrefix?: boolean;
+}
+
+const HomeIcon = () => (
+  <svg
+    aria-hidden
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="h-5 w-5"
+  >
+    <path d="M3 11l9-7 9 7" />
+    <path d="M5 10v10h14V10" />
+  </svg>
+);
+
+const BrowseIcon = () => (
+  <svg
+    aria-hidden
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="h-5 w-5"
+  >
+    <path d="M4 5h16M4 12h16M4 19h10" />
+  </svg>
+);
+
+const PathIcon = () => (
+  <svg
+    aria-hidden
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="h-5 w-5"
+  >
+    <path d="M5 4v6a4 4 0 0 0 4 4h6a4 4 0 0 1 4 4v2" />
+    <circle cx="5" cy="4" r="1.6" fill="currentColor" stroke="none" />
+    <circle cx="19" cy="20" r="1.6" fill="currentColor" stroke="none" />
+  </svg>
+);
+
+const QuestionsIcon = () => (
+  <svg
+    aria-hidden
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="h-5 w-5"
+  >
+    <path d="M9 8a3 3 0 1 1 4.5 2.6c-.9.5-1.5 1.1-1.5 2.4" />
+    <circle cx="12" cy="17" r="0.9" fill="currentColor" stroke="none" />
+  </svg>
+);
+
+const PersonIcon = () => (
+  <svg
+    aria-hidden
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="h-5 w-5"
+  >
+    <circle cx="12" cy="8" r="3.4" />
+    <path d="M4.5 20a7.5 7.5 0 0 1 15 0" />
+  </svg>
+);
+
+const SchoolIcon = () => (
+  <svg
+    aria-hidden
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="h-5 w-5"
+  >
+    <path d="M3 9l9-4 9 4-9 4-9-4z" />
+    <path d="M7 11v4c0 1.7 2.2 3 5 3s5-1.3 5-3v-4" />
+  </svg>
+);
+
+const tabsFor = (role: UserRole | undefined): Tab[] => {
+  switch (role) {
+    case UserRole.STUDENT:
+    case UserRole.OPEN_STUDENT:
+      return [
+        { to: '/student', label: 'Home', icon: <HomeIcon /> },
+        { to: '/student/browse', label: 'Browse', icon: <BrowseIcon />, matchPrefix: true },
+        {
+          to: '/student/learning-path',
+          label: 'Path',
+          icon: <PathIcon />,
+          matchPrefix: true,
+        },
+        { to: '/profile', label: 'Profile', icon: <PersonIcon /> },
+      ];
+    case UserRole.TEACHER:
+      return [
+        { to: '/teacher', label: 'Home', icon: <HomeIcon /> },
+        {
+          to: '/teacher/questions',
+          label: 'Questions',
+          icon: <QuestionsIcon />,
+          matchPrefix: true,
+        },
+        { to: '/profile', label: 'Profile', icon: <PersonIcon /> },
+      ];
+    case UserRole.PARENT:
+      return [
+        { to: '/parent', label: 'Home', icon: <HomeIcon />, matchPrefix: true },
+        { to: '/profile', label: 'Profile', icon: <PersonIcon /> },
+      ];
+    case UserRole.ADMIN:
+      return [
+        { to: '/admin', label: 'School', icon: <SchoolIcon />, matchPrefix: true },
+        { to: '/profile', label: 'Profile', icon: <PersonIcon /> },
+      ];
+    default:
+      return [];
+  }
+};
+
+const isActive = (pathname: string, tab: Tab): boolean =>
+  tab.matchPrefix ? pathname.startsWith(tab.to) : pathname === tab.to;
+
+/**
+ * Persistent bottom tab bar on mobile (`<sm`). Sits above the
+ * `safe-area-inset-bottom` so it clears the iOS home indicator. Hidden on
+ * `sm:` and above where the in-Navbar links take over.
+ */
+export const BottomNav = () => {
+  const { user } = useAuth();
+  const location = useLocation();
+
+  if (!user) return null;
+  const tabs = tabsFor(user.role);
+  if (tabs.length === 0) return null;
+
+  return (
+    <nav
+      aria-label="Primary"
+      className={clsx(
+        'fixed inset-x-0 bottom-0 z-30 border-t border-ink-100 bg-white/95 backdrop-blur sm:hidden',
+        'pb-[env(safe-area-inset-bottom)]',
+      )}
+    >
+      <ul className="mx-auto flex max-w-md items-stretch justify-around px-2 py-1">
+        {tabs.map((tab) => {
+          const active = isActive(location.pathname, tab);
+          return (
+            <li key={tab.to} className="flex-1">
+              <Link
+                to={tab.to}
+                aria-current={active ? 'page' : undefined}
+                className={clsx(
+                  'flex flex-col items-center gap-0.5 rounded-lg px-2 py-1.5 text-[11px] font-semibold transition-colors',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500',
+                  active ? 'text-brand-700' : 'text-ink-500 hover:text-ink-800',
+                )}
+              >
+                <span aria-hidden>{tab.icon}</span>
+                <span>{tab.label}</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+};


### PR DESCRIPTION
## Summary
Adds a persistent, role-aware **bottom tab bar** on mobile (`<sm:`) so primary navigation is always within thumb reach.

| Role | Tabs |
|---|---|
| Student / Open student | Home · Browse · Path · Profile |
| Teacher | Home · Questions · Profile |
| Parent | Home · Profile |
| Admin | School · Profile |

On `sm:` and above the bottom bar is hidden and the existing Navbar links take over. The hamburger menu stays for secondary actions (Profile, Sign out, Proficiency deep-link).

## Classification
**New** component.

## Files changed
- **New** `frontend_modern/src/features/layout/BottomNav.tsx` (~170 LOC) — inline SVG icons, role-aware tab list, prefix-match highlighting for nested routes (e.g. `/student/browse/chapter/42` highlights Browse), `aria-current=\"page\"`, `aria-label=\"Primary\"`, focus-visible brand ring.
- `frontend_modern/src/features/layout/AppShell.tsx` — mount `<BottomNav />` and add `pb-24 sm:pb-8` on `<main>` so content clears the bar on mobile.
- **New** `frontend_modern/src/features/layout/BottomNav.test.tsx` — 5 vitest tests.

## Design notes
- `bg-white/95 backdrop-blur` over a `border-t border-ink-100`.
- Above `env(safe-area-inset-bottom)` so it clears the iOS home indicator.
- Active tab → `text-brand-700`; inactive → `text-ink-500`.
- One brand-orange element per surface still holds — only the active tab is orange.

## Verification
- `npm run type-check`, `npm run lint`, `npm run build` — green.
- `npm test` — 17 files / **89 tests pass** (+5 from this PR; baseline was 84).

## Test plan
- [x] Unit tests cover role tab sets + prefix-match active highlight + unauth render-nothing.
- [ ] Manual mobile-viewport screenshot at 375px (follow-up screenshot pass).