### PR TITLE
fix(api): Question list dedupe + Grade filter parity (M7-03)

### DIFF
--- a/backend/openshiksha/apps/api/tests/test_question_list_filters.py
+++ b/backend/openshiksha/apps/api/tests/test_question_list_filters.py
@@ -1,0 +1,160 @@
+"""
+Regression tests for the M7-03 remaining slice:
+
+  * `/questions/?search=…` must return one row per question, not one row per
+    matching subpart or tag (the legacy join used to multiply rows).
+  * `/questions/?standard=<number>` filters by *standard number*, matching the
+    Browse endpoint's contract (#194).
+"""
+
+import pytest
+
+from rest_framework.test import APIClient
+
+from openshiksha.apps.core.models import (
+    Board,
+    Chapter,
+    Question,
+    QuestionSubpart,
+    QuestionTag,
+    QuestionType,
+    School,
+    Standard,
+    Subject,
+    User,
+    UserRole,
+)
+
+
+@pytest.fixture
+def teacher_with_questions(db):
+    board = Board.objects.create(name="Q-filter board")
+    school = School.objects.create(name="Q-filter school", board=board)
+    std7 = Standard.objects.create(number=7, description="Class 7")
+    std8 = Standard.objects.create(number=8, description="Class 8")
+    subject = Subject.objects.create(name="Filter Maths")
+    chapter7 = Chapter.objects.create(name="Algebra 7", subject=subject, standard=std7, order=1)
+    chapter8 = Chapter.objects.create(name="Algebra 8", subject=subject, standard=std8, order=1)
+
+    teacher = User.objects.create_user(username="qbank_teacher", password="pass", role=UserRole.TEACHER, school=school)
+
+    # Question with three subparts all matching "polynomial" — pre-fix the join
+    # would have returned this question three times.
+    multi = Question.objects.create(
+        standard=std7,
+        subject=subject,
+        chapter=chapter7,
+        question_type=QuestionType.MCQ,
+        difficulty=2,
+        is_active=True,
+    )
+    for i in range(3):
+        QuestionSubpart.objects.create(
+            question=multi,
+            index=i,
+            subpart_type=QuestionType.MCQ,
+            question_text=f"What is a polynomial? Part {i}",
+            options=[{"key": "A", "text": "a"}, {"key": "B", "text": "b"}],
+            correct_answer={"type": "mcq", "answer": "A"},
+        )
+
+    # Question with two matching tags — same dedup concern.
+    tagged = Question.objects.create(
+        standard=std8,
+        subject=subject,
+        chapter=chapter8,
+        question_type=QuestionType.MCQ,
+        difficulty=3,
+        is_active=True,
+    )
+    tag_a = QuestionTag.objects.create(name="polynomial")
+    tag_b = QuestionTag.objects.create(name="polynomial-special")
+    tagged.tags.add(tag_a, tag_b)
+    QuestionSubpart.objects.create(
+        question=tagged,
+        index=0,
+        subpart_type=QuestionType.MCQ,
+        question_text="Factor x^2 + 4x + 4.",
+        options=[{"key": "A", "text": "a"}, {"key": "B", "text": "b"}],
+        correct_answer={"type": "mcq", "answer": "A"},
+    )
+
+    # A throwaway non-matching question on the other standard, for the Grade filter.
+    other = Question.objects.create(
+        standard=std7,
+        subject=subject,
+        chapter=chapter7,
+        question_type=QuestionType.MCQ,
+        difficulty=1,
+        is_active=True,
+    )
+    QuestionSubpart.objects.create(
+        question=other,
+        index=0,
+        subpart_type=QuestionType.MCQ,
+        question_text="Solve 1 + 1.",
+        options=[{"key": "A", "text": "2"}, {"key": "B", "text": "3"}],
+        correct_answer={"type": "mcq", "answer": "A"},
+    )
+
+    return {
+        "teacher": teacher,
+        "std7": std7,
+        "std8": std8,
+        "multi": multi,
+        "tagged": tagged,
+        "other": other,
+    }
+
+
+def _ids(resp):
+    body = resp.json()
+    results = body.get("results", body)
+    return sorted(q["id"] for q in results)
+
+
+@pytest.mark.django_db
+def test_search_deduplicates_across_subparts(teacher_with_questions):
+    """A question with several matching subparts must appear once."""
+    client = APIClient()
+    client.force_authenticate(teacher_with_questions["teacher"])
+    resp = client.get("/api/v1/questions/?search=polynomial")
+    assert resp.status_code == 200
+    ids = _ids(resp)
+    # Both the multi-subpart question and the tag-matched question should appear,
+    # but each exactly once.
+    assert ids.count(teacher_with_questions["multi"].id) == 1
+    assert ids.count(teacher_with_questions["tagged"].id) == 1
+
+
+@pytest.mark.django_db
+def test_search_deduplicates_across_tags(teacher_with_questions):
+    """A question with two matching tags must appear once."""
+    client = APIClient()
+    client.force_authenticate(teacher_with_questions["teacher"])
+    resp = client.get("/api/v1/questions/?search=polynomial-special")
+    assert resp.status_code == 200
+    ids = _ids(resp)
+    assert ids == [teacher_with_questions["tagged"].id]
+
+
+@pytest.mark.django_db
+def test_standard_filter_matches_standard_number(teacher_with_questions):
+    """`?standard=8` must return Grade-8 questions regardless of standard PK."""
+    client = APIClient()
+    client.force_authenticate(teacher_with_questions["teacher"])
+    resp = client.get("/api/v1/questions/?standard=8")
+    assert resp.status_code == 200
+    ids = _ids(resp)
+    assert ids == [teacher_with_questions["tagged"].id]
+
+
+@pytest.mark.django_db
+def test_filters_combine_with_search(teacher_with_questions):
+    """Search + standard combine; result is still deduplicated."""
+    client = APIClient()
+    client.force_authenticate(teacher_with_questions["teacher"])
+    resp = client.get("/api/v1/questions/?search=polynomial&standard=7")
+    assert resp.status_code == 200
+    ids = _ids(resp)
+    assert ids == [teacher_with_questions["multi"].id]

--- a/backend/openshiksha/apps/api/views/core.py
+++ b/backend/openshiksha/apps/api/views/core.py
@@ -318,13 +318,20 @@ class QuestionViewSet(viewsets.ModelViewSet):
         if subject := params.get("subject"):
             qs = qs.filter(subject_id=subject)
         if standard := params.get("standard"):
-            qs = qs.filter(standard_id=standard)
+            # Match the Browse endpoint (#194): callers send the standard number
+            # (1..12), not the PK. Keeps the QuestionBank's eventual Grade filter
+            # consistent with Browse.
+            qs = qs.filter(standard__number=standard)
         if difficulty := params.get("difficulty"):
             qs = qs.filter(difficulty=difficulty)
         if question_type := params.get("question_type"):
             qs = qs.filter(question_type=question_type)
 
-        return qs
+        # `search_fields` joins through subparts.question_text and tags.name —
+        # a question with two matching subparts (or several matching tags) would
+        # otherwise appear once per match. Deduplicate at the queryset level so
+        # paginated + non-paginated callers both see one row per question.
+        return qs.distinct()
 
     def perform_create(self, serializer):
         school = getattr(self.request.user, "school", None)

--- a/docs/changes/2026-06-04-question-bank-filter-parity.md
+++ b/docs/changes/2026-06-04-question-bank-filter-parity.md
@@ -1,0 +1,37 @@
+# M7-03 (remaining) — Question list filter parity
+
+**Classification:** Fix.
+
+## Summary
+Two correctness bugs in the `/api/v1/questions/` list endpoint, both surfaced
+by the Question Bank UI's growing reliance on it:
+
+1. **Search returned duplicates.** `search_fields` joins through
+   `subparts__question_text` and `tags__name`, so a question with several
+   matching subparts (or several matching tags) appeared once per match.
+2. **Grade filter mismatched.** `?standard=<N>` filtered `standard_id=N` —
+   only correct when a Standard's PK happened to equal its number. The Browse
+   endpoint (#194) already moved to `standard__number`; this brings the
+   QuestionBank endpoint in line.
+
+## Files changed
+- `backend/openshiksha/apps/api/views/core.py` — `QuestionViewSet.get_queryset`
+  ends with `.distinct()` and matches `standard__number` for the Grade filter.
+- `backend/openshiksha/apps/api/tests/test_question_list_filters.py` — new
+  regression tests (4) covering subpart-join dedup, tag-join dedup, standard-
+  number filter, and combined search+standard.
+
+## Verification
+- New tests: 4/4 pass.
+- Full api test suite: 167/167 pass (no other test depended on the buggy
+  behaviour).
+- `python manage.py check` clean.
+
+## What's left in M7-03
+- Assignment-list filtering: currently the student `AssignmentList` groups by
+  status only (overdue / due-soon / upcoming / completed) — no UI filter
+  controls exist. If product wants a "filter by subject room / status" pass on
+  the student or teacher assignment list, it would be a small follow-up.
+
+## Next
+M2-02 mobile nav polish.


### PR DESCRIPTION
## Summary
Two correctness bugs in the \`/api/v1/questions/\` list endpoint, both surfaced by the Question Bank UI:

1. **Search returned duplicates.** \`search_fields\` joins through \`subparts__question_text\` and \`tags__name\`, so a question with several matching subparts (or several matching tags) appeared once per match. Add \`.distinct()\`.
2. **Grade filter mismatched.** \`?standard=<N>\` matched \`standard_id=N\` — only correct when a Standard's PK happened to equal its number. Switch to \`standard__number\` so this endpoint behaves like the Browse endpoint fixed in #194.

## Classification
**Fix.**

## Files changed
- \`backend/openshiksha/apps/api/views/core.py\` — \`QuestionViewSet.get_queryset\` ends with \`.distinct()\` and matches \`standard__number\`.
- \`backend/openshiksha/apps/api/tests/test_question_list_filters.py\` — 4 new regression tests.

## Verification
- New tests: 4/4 pass.
- Full api suite: 167/167 pass — no other test depended on the buggy behaviour.

## Remaining M7-03 scope
Student/Teacher assignment lists currently have no filter UI (they group by status). If product wants filter chips there, it's a small follow-up — flagged in the change doc but out of scope here.

## Test plan
- [x] Search dedup across subparts
- [x] Search dedup across tags
- [x] Grade-number filter
- [x] Combined search + standard