### PR TITLE
feat(frontend): migrate public Enquire page to V2 (M3-03)

### DIFF
--- a/docs/changes/2026-06-04-enquire-page-v2.md
+++ b/docs/changes/2026-06-04-enquire-page-v2.md
@@ -1,0 +1,46 @@
+# M3-03 — Public Enquire page → V2
+
+**Classification:** Improve.
+
+## Summary
+The public `/enquire` page (prospective schools) was the last un-migrated
+authenticated/unauthenticated surface — it wore the legacy
+`bg-gradient-to-br from-indigo-50 to-blue-100` template + a fake "OS" tile.
+Migrate it to the V2 chalkboard/paper `AuthLayout` shared with Login and
+Register, and rebuild the form on `ui/Input` + `ui/Textarea` + `ui/Button`.
+
+## Files changed
+- `frontend_modern/src/features/enquiry/EnquirePage.tsx`
+
+## What changed
+- Wrapped in `<AuthLayout>` — chalkboard hero on the left, warm paper form
+  panel on the right; mobile fallback compact-brand. Now every external-
+  facing surface (Login, Register, Register-school, Register-open, Enquire)
+  shares one branded flow.
+- Replaced the hand-rolled `Field` component + inline `<textarea>` with the
+  V2 `Input` / `Textarea` primitives (which carry label + hint + error +
+  focus-visible wiring).
+- Submit button → `<Button variant="brand" size="lg" className="w-full">`.
+- Success state → `<EmptyState>` (keyhole motif) inside the same `AuthLayout`.
+- Error banner → `bg-rose-50` + `border-rose-200` + `text-rose-700` instead of
+  the legacy `bg-red-50`.
+- Footer link → brand-orange `Sign in` link (matches Login's pattern).
+
+## What was preserved
+- All form state (`useState` shape), submit payload, `extractError` helper,
+  and the `useEnquireMutation` wiring — pure UI port, no API surface change.
+- Backend `/api/v1/enquire/` endpoint untouched.
+
+## Continuous improvement
+- The Enquire page no longer hand-rolls a form field or success card — both
+  reuse system primitives. This is the second page (after Register) to
+  successfully compose the `AuthLayout` shell, so the pattern is proven for
+  any future external surface.
+
+## Verification
+- `npm run type-check`, `npm run lint`, `npm run build`, `npm test` — all green
+  (17 files / 89 tests).
+- Grep `primary|indigo|blue-|gray-50|text-gray-` in the file → 0.
+
+## Next
+M5-02 per-surface responsive audit.

--- a/frontend_modern/src/features/enquiry/EnquirePage.tsx
+++ b/frontend_modern/src/features/enquiry/EnquirePage.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { AxiosError } from 'axios';
+import { AuthLayout } from '@/features/auth/AuthLayout';
+import { Button, EmptyState, Input, Textarea } from '@/shared/ui';
 import { useEnquireMutation } from './useEnquireMutation';
 
 function extractError(err: unknown): string {
@@ -39,110 +41,114 @@ export const EnquirePage = () => {
     });
   };
 
-  return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-indigo-50 to-blue-100 py-12 px-4">
-      <div className="w-full max-w-lg">
-        <div className="text-center mb-8">
-          <div className="inline-flex items-center justify-center w-16 h-16 bg-indigo-600 rounded-2xl mb-4 shadow-lg">
-            <span className="text-white text-2xl font-bold">OS</span>
-          </div>
-          <h1 className="text-2xl font-bold text-gray-900">Bring OpenShiksha to your school</h1>
-          <p className="text-gray-500 mt-1 text-sm">
-            Tell us about your school and our team will reach out to set you up.
+  if (mutation.isSuccess) {
+    return (
+      <AuthLayout
+        title="Bring OpenShiksha to your school"
+        subtitle="Tell us a little about your school and our team will reach out to set you up."
+        footer={
+          <p>
+            <Link to="/login" className="font-semibold text-brand-700 hover:text-brand-800">
+              ← Back to sign in
+            </Link>
           </p>
-        </div>
+        }
+      >
+        <EmptyState
+          title="Thank you for your enquiry"
+          description="Our team will be in touch shortly."
+          action={
+            <Link to="/login">
+              <Button variant="ghost">← Back to sign in</Button>
+            </Link>
+          }
+        />
+      </AuthLayout>
+    );
+  }
 
-        <div className="bg-white rounded-2xl shadow-xl p-8">
-          {mutation.isSuccess ? (
-            <div className="text-center py-6" role="status">
-              <div className="inline-flex items-center justify-center w-12 h-12 bg-green-100 rounded-full mb-4">
-                <span className="text-green-600 text-2xl">✓</span>
-              </div>
-              <h2 className="text-lg font-semibold text-gray-900">Thank you for your enquiry</h2>
-              <p className="text-gray-500 mt-1 text-sm">
-                Our team will be in touch with you shortly.
-              </p>
-              <Link
-                to="/login"
-                className="inline-block mt-6 text-indigo-600 hover:text-indigo-800 text-sm"
-              >
-                ← Back to sign in
-              </Link>
-            </div>
-          ) : (
-            <form onSubmit={handleSubmit} noValidate>
-              <div className="space-y-4">
-                <Field label="Your Name" id="name" value={form.name} onChange={set('name')} required disabled={mutation.isPending} />
-                <Field label="School / Organization" id="school" value={form.school} onChange={set('school')} required disabled={mutation.isPending} />
-                <Field label="Email" id="email" type="email" value={form.email} onChange={set('email')} required disabled={mutation.isPending} autoComplete="email" />
-                <Field label="Phone (optional)" id="phone" value={form.phone} onChange={set('phone')} disabled={mutation.isPending} autoComplete="tel" />
-                <div>
-                  <label htmlFor="message" className="block text-sm font-medium text-gray-700 mb-1">
-                    Message (optional)
-                  </label>
-                  <textarea
-                    id="message"
-                    value={form.message}
-                    onChange={set('message')}
-                    disabled={mutation.isPending}
-                    rows={3}
-                    className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent text-gray-900 placeholder-gray-400 disabled:bg-gray-50"
-                  />
-                </div>
-
-                {mutation.isError && (
-                  <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700" role="alert">
-                    {extractError(mutation.error)}
-                  </div>
-                )}
-
-                <button
-                  type="submit"
-                  disabled={mutation.isPending || !form.name || !form.school || !form.email}
-                  className="w-full py-2.5 px-4 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white font-semibold rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-                >
-                  {mutation.isPending ? 'Sending…' : 'Send Enquiry'}
-                </button>
-              </div>
-            </form>
-          )}
-        </div>
-
-        <p className="text-center text-sm text-gray-500 mt-4">
-          <Link to="/login" className="text-indigo-600 hover:text-indigo-800">
-            ← Back to sign in
+  return (
+    <AuthLayout
+      title="Bring OpenShiksha to your school"
+      subtitle="Tell us a little about your school and our team will reach out to set you up."
+      footer={
+        <p>
+          Already with us?{' '}
+          <Link to="/login" className="font-semibold text-brand-700 hover:text-brand-800">
+            Sign in
           </Link>
         </p>
-      </div>
-    </div>
+      }
+    >
+      <form onSubmit={handleSubmit} noValidate className="space-y-4">
+        <Input
+          label="Your name"
+          id="name"
+          value={form.name}
+          onChange={set('name')}
+          required
+          disabled={mutation.isPending}
+          autoComplete="name"
+        />
+        <Input
+          label="School or organisation"
+          id="school"
+          value={form.school}
+          onChange={set('school')}
+          required
+          disabled={mutation.isPending}
+          autoComplete="organization"
+        />
+        <Input
+          label="Email"
+          id="email"
+          type="email"
+          value={form.email}
+          onChange={set('email')}
+          required
+          disabled={mutation.isPending}
+          autoComplete="email"
+        />
+        <Input
+          label="Phone"
+          hint="Optional"
+          id="phone"
+          value={form.phone}
+          onChange={set('phone')}
+          disabled={mutation.isPending}
+          autoComplete="tel"
+        />
+        <Textarea
+          label="Anything we should know?"
+          hint="Optional"
+          id="message"
+          value={form.message}
+          onChange={set('message')}
+          disabled={mutation.isPending}
+          rows={3}
+        />
+
+        {mutation.isError && (
+          <div
+            role="alert"
+            className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-medium text-rose-700"
+          >
+            {extractError(mutation.error)}
+          </div>
+        )}
+
+        <Button
+          type="submit"
+          variant="brand"
+          size="lg"
+          className="w-full"
+          disabled={
+            mutation.isPending || !form.name || !form.school || !form.email
+          }
+        >
+          {mutation.isPending ? 'Sending…' : 'Send enquiry'}
+        </Button>
+      </form>
+    </AuthLayout>
   );
 };
-
-interface FieldProps {
-  label: string;
-  id: string;
-  value: string;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  type?: string;
-  required?: boolean;
-  disabled?: boolean;
-  autoComplete?: string;
-}
-
-const Field = ({ label, id, value, onChange, type = 'text', required, disabled, autoComplete }: FieldProps) => (
-  <div>
-    <label htmlFor={id} className="block text-sm font-medium text-gray-700 mb-1">
-      {label} {required && <span className="text-red-500">*</span>}
-    </label>
-    <input
-      id={id}
-      type={type}
-      value={value}
-      onChange={onChange}
-      required={required}
-      disabled={disabled}
-      autoComplete={autoComplete}
-      className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent text-gray-900 placeholder-gray-400 disabled:bg-gray-50 disabled:text-gray-500"
-    />
-  </div>
-);


### PR DESCRIPTION
## Summary
The public \`/enquire\` page (prospective schools) was the last surface still wearing the legacy \`bg-gradient-to-br from-indigo-50 to-blue-100\` template + a fake \"OS\" tile. Wrap it in the shared \`AuthLayout\` (chalkboard hero + paper form panel) and rebuild the form on \`ui/Input\` + \`ui/Textarea\` + \`ui/Button\`. Success state uses \`EmptyState\` (keyhole motif).

Every external-facing surface (Login, Register, Register-school, Register-open, Enquire) now reads as one branded flow.

## Classification
**Improve** — reskin only; backend \`/api/v1/enquire/\` and the mutation hook are untouched.

## Highlights
- \`AuthLayout\` shell (chalkboard left / paper right; mobile compact-brand fallback).
- Hand-rolled \`Field\` component replaced with \`Input\`/\`Textarea\` primitives (carry label + hint + error + focus-visible).
- Submit → \`<Button variant=\"brand\" size=\"lg\" className=\"w-full\">\`.
- Error banner → \`rose-*\` tokens.
- Success → \`<EmptyState>\` inside the same shell with a \"Back to sign in\" CTA.

## Verification
- \`npm run type-check\`, \`npm run lint\`, \`npm run build\`, \`npm test\` — all green (17 files / 89 tests).
- Grep \`primary|indigo|blue-|gray-50|text-gray-\` → 0.

## Test plan
- [x] Type-check / lint / build / vitest
- [x] 0 legacy color refs
- [ ] Manual submit-flow spot-check at \`/enquire\` (follow-up)