### PR TITLE
fix(enquiry): drop duplicate Back-to-sign-in on success

### DIFF
--- a/frontend_modern/src/features/enquiry/EnquirePage.tsx
+++ b/frontend_modern/src/features/enquiry/EnquirePage.tsx
@@ -46,13 +46,6 @@ export const EnquirePage = () => {
       <AuthLayout
         title="Bring OpenShiksha to your school"
         subtitle="Tell us a little about your school and our team will reach out to set you up."
-        footer={
-          <p>
-            <Link to="/login" className="font-semibold text-brand-700 hover:text-brand-800">
-              ← Back to sign in
-            </Link>
-          </p>
-        }
       >
         <EmptyState
           title="Thank you for your enquiry"


### PR DESCRIPTION
## Summary
After M3-03 (#199) merged, the \`/enquire\` success state was rendering **Back to sign in** twice — once as the \`AuthLayout\` footer link and once as the \`EmptyState\` action button. Keep the \`EmptyState\` button (more discoverable inside the success card) and drop the redundant footer link.

## Files changed
- \`frontend_modern/src/features/enquiry/EnquirePage.tsx\` — 7-line deletion.

## Verification
- Form-state path untouched; the duplicate only existed on the post-submit success branch.
- \`npm run type-check\`, \`npm run lint\`, \`npm run build\`, \`npm test\` — all green (17 / 89).