### PR TITLE
feat(frontend): accessibility audit + skip link + dialog semantics (M6-01)

### DIFF
--- a/docs/changes/2026-06-04-a11y-audit.md
+++ b/docs/changes/2026-06-04-a11y-audit.md
@@ -1,0 +1,90 @@
+# M6-01 — Accessibility audit (focused pass)
+
+**Classification:** Fix + audit doc.
+
+## Summary
+A focused AA pass over the V2 surfaces. Three concrete code fixes; the rest of
+the migrated surfaces were already in good shape after M2-02 (#198), M5-01
+(#195), and M4 close, so the bulk of M6-01's remaining value is recording the
+clean bill in this doc.
+
+## Files changed
+- `frontend_modern/src/features/layout/AppShell.tsx` — adds a **skip-to-main**
+  link + `id="main-content"` / `tabIndex={-1}` landmark on `<main>`.
+- `frontend_modern/src/features/teacher/QuestionBankPage.tsx` — the
+  Add-to-set side-sheet now has proper modal-dialog semantics
+  (`role="dialog"`, `aria-modal="true"`, `aria-labelledby`), ESC-to-close,
+  initial focus on the close button, and a focus-visible brand ring.
+- `frontend_modern/src/features/teacher/QuestionPreviewPanel.tsx` — image
+  subparts had `alt=""` (treated as decorative). Switched to the
+  `"Question diagram"` alt used elsewhere; the image is real content.
+
+## What changed in detail
+
+### 1. Skip link + main landmark
+A keyboard / screen-reader user landing on any page now sees an offscreen
+*Skip to main content* link as the first focusable element. Pressing Tab once
+reveals it (brand-orange pill, top-left); Enter jumps focus past the Navbar
+into `<main id="main-content" tabIndex={-1}>`. This is the canonical pattern
+WCAG 2.4.1 expects on every page.
+
+### 2. Add-to-set dialog
+The QuestionBankPage's `AddToProblemSetSheet` looked like a dialog but had
+none of the semantics:
+
+| Before | After |
+|---|---|
+| `<div>` with no role | `role="dialog" aria-modal="true" aria-labelledby="add-to-set-title"` |
+| Title node had no id | `<h3 id="add-to-set-title">` |
+| `aria-label="Close"` (ambiguous; users hear "Close" with no context) | `aria-label="Close add-to-set dialog"` |
+| No ESC handler | `keydown` listener closes on Escape |
+| Focus stayed on the trigger | Initial focus moves to the close button (announces the dialog) |
+| Close button had no focus-visible ring | Branded `focus-visible:ring-2 ring-brand-500` |
+
+### 3. Question-preview image alt
+`QuestionPreviewPanel` is a *preview* of what students will see — the image
+is real question content, not decoration. Changed `alt=""` to
+`alt="Question diagram"` for consistency with `QuestionCard` (which
+correctly labels its images).
+
+## Other surfaces checked (already clean)
+
+- **Navbar** (M2-02 / #198) — `aria-label="Top"`, `aria-haspopup`,
+  `aria-controls`, dynamic hamburger `aria-label`, `aria-current="page"` on
+  active links, focus-visible rings, ESC-closes-and-returns-focus.
+- **BottomNav** (M5-01 / #195) — `aria-label="Primary"`, `aria-current`,
+  focus-visible rings, shape-distinct icons.
+- **LearningPathPage** — keyhole / check / lock icons are *shape-distinct*
+  (not colour-only) so colour-blind users can tell completed / current /
+  locked apart.
+- **AlertsPanel / ClassHealthPanel** — severity dots accompanied by a text
+  label (Struggling / At Risk / Proficient), satisfying "don't rely on
+  colour alone".
+- **Form primitives** (`Input` / `Textarea` / `Select`) — programmatic
+  label-for, `aria-invalid`, `aria-describedby` hint/error wiring.
+- **`<RichContent>`** — `DOMPurify`-sanitised HTML + KaTeX renders into
+  semantic HTML; KaTeX itself emits MathML alongside the HTML for screen
+  readers.
+- **Reduced-motion** — `index.css` `@media (prefers-reduced-motion: reduce)`
+  globally collapses transitions/animations to ~0ms; individual chevron
+  rotations were already gated with `motion-reduce:transition-none`.
+- **Focus ring** — `:focus-visible` brand-orange ring with a paper-coloured
+  inner halo on every focusable element (via `index.css`).
+- **Color contrast** — V2 palette anchors (brand-700/800 on white,
+  ink-700/800 on paper) clear AA at the body sizes used.
+
+## Not done in this PR (deliberate scope cap)
+- A **full keyboard walkthrough** of every page — flagged as a follow-up
+  manual session; needs to be done at viewport sizes too.
+- A **screen-reader spot-check** (VoiceOver / NVDA) — same; manual.
+- Tab-order audit of the `CreateQuestionPage` multi-subpart tabs — likely
+  fine but worth verifying by hand.
+- An axe-core CI integration — bigger scope; should be its own initiative
+  step.
+
+## Verification
+- `npm run type-check`, `npm run lint`, `npm run build`, `npm test` — all
+  green (17 files / 89 tests).
+
+## Next
+M6-03 visual-regression screenshot set.

--- a/frontend_modern/src/features/layout/AppShell.tsx
+++ b/frontend_modern/src/features/layout/AppShell.tsx
@@ -7,8 +7,20 @@ interface AppShellProps {
 
 export const AppShell = ({ children }: AppShellProps) => (
   <div className="bg-paper min-h-screen">
+    {/* Skip link — visually hidden until focused, then anchors at top-left.
+        Lets keyboard / screen-reader users jump past the Navbar to page content. */}
+    <a
+      href="#main-content"
+      className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-3 focus:z-50 focus:rounded-md focus:bg-brand-600 focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-white focus:shadow-lift focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-300"
+    >
+      Skip to main content
+    </a>
     <Navbar />
-    <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 pb-24 sm:pb-8">
+    <main
+      id="main-content"
+      tabIndex={-1}
+      className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 pb-24 sm:pb-8 focus-visible:outline-none"
+    >
       {children}
     </main>
     <BottomNav />

--- a/frontend_modern/src/features/teacher/QuestionBankPage.tsx
+++ b/frontend_modern/src/features/teacher/QuestionBankPage.tsx
@@ -109,15 +109,23 @@ const AddToProblemSetSheet = ({
   const { data: problemSets, isLoading } = useProblemSets(question.subject);
   const addQuestion = useAddQuestionToProblemSet();
   const [success, setSuccess] = useState(false);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
 
-  // Lock body scroll while sheet is open
+  // Lock body scroll + listen for ESC to close (a11y: AAA modal dialog pattern).
   useEffect(() => {
     const original = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    // Move focus into the dialog so a screen reader announces it.
+    closeButtonRef.current?.focus();
     return () => {
       document.body.style.overflow = original;
+      document.removeEventListener('keydown', onKey);
     };
-  }, []);
+  }, [onClose]);
 
   const handleAdd = () => {
     if (!selectedPsId) return;
@@ -132,21 +140,30 @@ const AddToProblemSetSheet = ({
       className="fixed inset-0 z-50 flex justify-end bg-ink-900/40 backdrop-blur-sm"
       onClick={(e) => e.target === e.currentTarget && onClose()}
     >
-      <div className="flex h-full w-full max-w-md flex-col bg-paper shadow-lift">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="add-to-set-title"
+        className="flex h-full w-full max-w-md flex-col bg-paper shadow-lift"
+      >
         <div className="flex items-center justify-between border-b border-ink-100 px-6 py-5">
           <div>
             <p className="text-xs font-semibold uppercase tracking-widest text-brand-600">
               Add to set
             </p>
-            <h3 className="font-display text-lg font-semibold text-ink-900">
+            <h3
+              id="add-to-set-title"
+              className="font-display text-lg font-semibold text-ink-900"
+            >
               Question #{question.id}
             </h3>
           </div>
           <button
+            ref={closeButtonRef}
             type="button"
             onClick={onClose}
-            aria-label="Close"
-            className="rounded-full p-1.5 text-ink-400 hover:bg-ink-100 hover:text-ink-800"
+            aria-label="Close add-to-set dialog"
+            className="rounded-full p-1.5 text-ink-400 transition-colors hover:bg-ink-100 hover:text-ink-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
           >
             <svg viewBox="0 0 16 16" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2">
               <path d="M4 4l8 8M12 4l-8 8" strokeLinecap="round" />

--- a/frontend_modern/src/features/teacher/QuestionPreviewPanel.tsx
+++ b/frontend_modern/src/features/teacher/QuestionPreviewPanel.tsx
@@ -52,7 +52,7 @@ const SubpartPreview = ({
       {subpart.image_url && (
         <img
           src={subpart.image_url}
-          alt=""
+          alt="Question diagram"
           className="mt-4 max-h-64 rounded-lg border border-ink-100 object-contain"
         />
       )}
@@ -180,4 +180,3 @@ export const QuestionPreviewPanel = ({
     </Card>
   );
 };
-


### PR DESCRIPTION
## Summary
Focused AA pass over the V2 surfaces. Three concrete code fixes; the rest of the migrated surfaces audit clean (recorded in the change doc).

## Classification
**Fix + audit doc.**

## Fixes

### 1. Skip link + main landmark (\`AppShell.tsx\`)
A keyboard / screen-reader user landing on any page now sees an off-screen *Skip to main content* link as the first focusable element. Pressing Tab once reveals it (brand-orange pill, top-left); Enter jumps focus past the Navbar into \`<main id=\"main-content\" tabIndex={-1}>\`. WCAG 2.4.1.

### 2. Add-to-set dialog (\`QuestionBankPage.tsx\`)
The QuestionBankPage's \`AddToProblemSetSheet\` looked like a dialog but had none of the semantics:

| Before | After |
|---|---|
| \`<div>\` no role | \`role=\"dialog\" aria-modal=\"true\" aria-labelledby=\"add-to-set-title\"\` |
| Title node had no id | \`<h3 id=\"add-to-set-title\">\` |
| \`aria-label=\"Close\"\` (ambiguous) | \`aria-label=\"Close add-to-set dialog\"\` |
| No ESC handler | \`keydown\` listener closes on Escape |
| Focus stayed on the trigger | Initial focus moves to the close button |
| No focus-visible ring | Branded \`focus-visible:ring-2 ring-brand-500\` |

### 3. Question-preview image alt (\`QuestionPreviewPanel.tsx\`)
\`QuestionPreviewPanel\` is a *preview* of what students will see — the image is real content, not decoration. Switched \`alt=\"\"\` to \`alt=\"Question diagram\"\` for parity with \`QuestionCard\`.

## Audit notes (clean, no changes)
- **Navbar** (M2-02 #198) — \`aria-label\` / \`aria-haspopup\` / \`aria-controls\` / dynamic hamburger label / \`aria-current\` / focus-visible rings / ESC-closes-and-returns-focus.
- **BottomNav** (M5-01 #195) — \`aria-label=\"Primary\"\`, \`aria-current\`, shape-distinct icons.
- **LearningPathPage** — keyhole/check/lock are *shape-distinct*, not colour-only.
- **AlertsPanel / ClassHealthPanel** — severity dots accompanied by text labels.
- **Form primitives** (\`Input\`/\`Textarea\`/\`Select\`) — programmatic label-for, \`aria-invalid\`, \`aria-describedby\` wiring.
- **\`<RichContent>\`** — sanitised semantic HTML; KaTeX emits MathML for screen readers.
- **Reduced-motion** — global \`prefers-reduced-motion\` rule in \`index.css\`.
- **Focus ring** — \`:focus-visible\` brand-orange ring on every focusable element.
- **Colour contrast** — V2 palette anchors clear AA at body sizes.

## Not done (deliberate scope cap)
- Full manual keyboard walkthrough + screen-reader spot-check (VoiceOver / NVDA).
- Tab-order audit of the CreateQuestionPage multi-subpart tabs.
- axe-core CI integration — own initiative step.

## Verification
- \`npm run type-check\`, \`npm run lint\`, \`npm run build\`, \`npm test\` — all green (17 / 89).