### PR TITLE
feat(e2e): visual-regression spec for V2 public surfaces (M6-03)

### DIFF
--- a/docs/changes/2026-06-04-visual-regression.md
+++ b/docs/changes/2026-06-04-visual-regression.md
@@ -1,0 +1,76 @@
+# M6-03 — Visual-regression screenshot set
+
+**Classification:** New (test infrastructure).
+
+## Summary
+Lay down the Playwright visual-regression test framework over the V2 public
+surfaces — `/design`, `/`, `/login`, `/enquire` — at both desktop (1280×800)
+and mobile (375×720) viewports. The spec is **skipped by default** until
+Linux baselines have been generated and committed on CI (Windows-generated
+PNGs would never match a Linux CI runner). The infra is in place; activation
+is a documented one-step follow-up.
+
+## Files changed
+- **New** `frontend_modern/e2e/visual.spec.ts` — 4 surfaces × 2 viewports = 8
+  Playwright snapshots, gated by `test.describe.skip` until baselines exist.
+- `frontend_modern/package.json` — adds `test:e2e:update-snapshots` script
+  for regenerating baselines after an intentional design change.
+
+## How activation works
+1. On the **Linux** runner (or the existing CI `frontend-e2e` job), check
+   out this branch and run:
+   ```bash
+   cd frontend_modern
+   npm ci
+   npx playwright install --with-deps chromium
+   npm run test:e2e:update-snapshots -- visual.spec.ts
+   ```
+2. Commit the generated PNGs under
+   `frontend_modern/e2e/visual.spec.ts-snapshots/` (suffix
+   `-chromium-linux.png`).
+3. Remove the `.skip` from `test.describe.skip` in `visual.spec.ts` in the
+   same commit. CI is now gating.
+4. Subsequent intentional design changes: re-run
+   `npm run test:e2e:update-snapshots` and commit the updated PNGs alongside
+   the design change PR.
+
+## Why "public, backend-free" surfaces only
+The existing `playwright.config.ts` runs against `vite preview` — no Django
+backend is booted. Authenticated dashboards (Student, Teacher, Parent, Admin,
+Profile, Proficiency, …) require the Docker stack + seeded DB and belong in
+a separate `playwright` project (gated on a Docker compose job). That's a
+M6-03 follow-up; the four public surfaces here are the immediate value
+since they're the first impression every parent / prospective school sees.
+
+## Design choices
+- **Both viewports.** Mobile (375) catches the regressions the eye misses on
+  the dev laptop — exactly the layouts BottomNav (#195) and Navbar polish
+  (#198) most influenced. Desktop captures the showcase rhythm.
+- **`maxDiffPixelRatio: 0.02`.** Generous enough to absorb sub-pixel font
+  anti-aliasing between Linux kernels / Playwright versions; tight enough to
+  catch a real layout regression.
+- **Waits on `document.fonts.ready`** before snapshotting — Fraunces +
+  Inter load over the network in CI and would otherwise shift character
+  widths mid-paint.
+- **Wait on the page's `h1`** rather than `networkidle` — `/design` and the
+  marketing surfaces don't fire any network after initial paint, so
+  `networkidle` would hang.
+
+## What this does *not* cover (yet)
+- **Authenticated surfaces** — dashboards, Profile, Proficiency, Assignment
+  detail, SRS drill, Browse-Practice, Question Bank, CreateQuestion, the
+  Teacher panels. Needs the Docker stack + a `playwright` project that
+  authenticates as a demo user.
+- **`/register`, `/register/school`, `/register/open`** — also public but
+  share the chalkboard/paper `AuthLayout` already covered by `/login`. Adding
+  them is a one-line change once baselines are seeded.
+- **A11y regression coverage** — that's the existing `a11y.spec.ts` over
+  axe-core; this PR is purely visual.
+
+## Verification
+- `npm run type-check`, `npm run lint` — green.
+- `npx playwright test --list` — confirms the 8 snapshot test cases are
+  registered (and currently skipped).
+
+## Next
+M7-04 legacy feature-parity audit.

--- a/frontend_modern/e2e/visual.spec.ts
+++ b/frontend_modern/e2e/visual.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+
+// Visual-regression baseline for V2 "Chalk & Unlock" public surfaces.
+//
+// Snapshots live next to this spec under `visual.spec.ts-snapshots/`. They
+// are platform-suffixed by Playwright (e.g. `-chromium-linux.png`); the CI
+// project runs only `chromium` on Linux, so checked-in baselines are CI's
+// reference. To intentionally update a baseline after a design change run:
+//
+//     npm run test:e2e:update-snapshots
+//
+// Only **public, backend-free** routes are covered here. Login/Register/Enquire
+// render their initial paint without an API call; we wait for a stable header
+// element instead of network idle. Authenticated surfaces (dashboards) need
+// the Docker stack and are out of scope until we add a backend-attached
+// project to playwright.config.ts.
+//
+// `maxDiffPixelRatio` gives us a generous tolerance for sub-pixel font
+// anti-aliasing differences across CI runners while still catching real
+// layout regressions.
+const DIFF_TOLERANCE = { maxDiffPixelRatio: 0.02 };
+
+const DESKTOP = { width: 1280, height: 800 };
+const MOBILE = { width: 375, height: 720 };
+
+interface Surface {
+  /** Snapshot file slug (no extension). */
+  slug: string;
+  /** Route to navigate to. */
+  path: string;
+  /** A locator that, once visible, indicates the page has painted. */
+  ready: string;
+}
+
+const SURFACES: Surface[] = [
+  // The living showcase — if any V2 primitive regresses, the diff lights up here.
+  { slug: 'design', path: '/design', ready: 'h1' },
+  // Marketing / first-impression chalkboard hero.
+  { slug: 'home', path: '/', ready: 'h1' },
+  // Auth flow — flagship of the chalkboard/paper layout.
+  { slug: 'login', path: '/login', ready: 'h1' },
+  // Public enquiry form (M3-03).
+  { slug: 'enquire', path: '/enquire', ready: 'h1' },
+];
+
+// Skipped by default: the spec is in place but no baselines have been
+// committed yet (PNGs must be generated on the same OS the CI runner uses,
+// or pixel diffs are unavoidable). To activate:
+//   1. On a Linux runner (or via the CI job below) run
+//        `npm run test:e2e:update-snapshots`
+//   2. Commit the generated `e2e/visual.spec.ts-snapshots/*-chromium-linux.png`
+//      files alongside removing the `.skip` here.
+// Tracked as a follow-up in docs/changes/2026-06-04-visual-regression.md.
+test.describe.skip('visual regression — V2 public surfaces', () => {
+  for (const surface of SURFACES) {
+    test(`${surface.slug} — desktop`, async ({ page }) => {
+      await page.setViewportSize(DESKTOP);
+      await page.goto(surface.path);
+      await expect(page.locator(surface.ready).first()).toBeVisible();
+      // Let webfonts settle so character widths don't shift the layout.
+      await page.evaluate(() => document.fonts.ready);
+      await expect(page).toHaveScreenshot(`${surface.slug}-desktop.png`, DIFF_TOLERANCE);
+    });
+
+    test(`${surface.slug} — mobile (375)`, async ({ page }) => {
+      await page.setViewportSize(MOBILE);
+      await page.goto(surface.path);
+      await expect(page.locator(surface.ready).first()).toBeVisible();
+      await page.evaluate(() => document.fonts.ready);
+      await expect(page).toHaveScreenshot(`${surface.slug}-mobile.png`, DIFF_TOLERANCE);
+    });
+  }
+});

--- a/frontend_modern/package.json
+++ b/frontend_modern/package.json
@@ -14,7 +14,8 @@
     "test": "vitest",
     "test:watch": "vitest --watch",
     "test:coverage": "vitest --coverage",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:e2e:update-snapshots": "playwright test --update-snapshots"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.101.0",


### PR DESCRIPTION
## Summary
Lay down the Playwright visual-regression test framework over the V2 public surfaces — \`/design\`, \`/\`, \`/login\`, \`/enquire\` — at both **desktop (1280×800)** and **mobile (375×720)** viewports. 8 snapshots total.

The spec is **skipped by default** until Linux baselines have been generated and committed on CI (Windows-generated PNGs would never match the Linux runner). One-step activation is documented in the change doc.

## Classification
**New** (test infrastructure).

## Files changed
- **New** \`frontend_modern/e2e/visual.spec.ts\` — 4 surfaces × 2 viewports, \`maxDiffPixelRatio: 0.02\`, waits on \`document.fonts.ready\` so Fraunces/Inter character widths settle pre-snapshot.
- \`frontend_modern/package.json\` — adds \`test:e2e:update-snapshots\` script.

## Activation steps (one-time)
1. Linux runner / CI:
   \`\`\`bash
   cd frontend_modern
   npx playwright install --with-deps chromium
   npm run test:e2e:update-snapshots -- visual.spec.ts
   \`\`\`
2. Commit the generated \`e2e/visual.spec.ts-snapshots/*-chromium-linux.png\`.
3. Remove \`.skip\` from \`test.describe.skip\` in the same commit. CI now gates.

## Why public surfaces only
\`playwright.config.ts\` runs against \`vite preview\` — no backend. Authenticated dashboards need the Docker stack + seeded DB and belong in a separate Playwright project. That's the next M6-03 follow-up.

## Verification
- \`npm run type-check\`, \`npm run lint\` — green.
- \`npx playwright test --list\` confirms the 8 cases are registered (skipped).