### PR TITLE
docs(v2): legacy parity audit + close M7-04 + record 2026-06-04 batch 2

### DIFF
--- a/docs/changes/2026-06-04-legacy-parity-audit.md
+++ b/docs/changes/2026-06-04-legacy-parity-audit.md
@@ -1,0 +1,45 @@
+# M7-04 — Legacy feature-parity audit
+
+**Classification:** Docs.
+
+## Summary
+The first proper M7-04 deliverable: a single audit doc that maps **every
+legacy Django 1.11 app** to its modern Django 4.2 + React equivalent, calls
+out gaps as ⏳ TODO or 🟡 partial, and gives a deletion checklist for any
+legacy app the team decides to retire.
+
+## Files changed
+- **New** `docs/initiatives/legacy-feature-parity.md` — source-of-truth audit.
+
+## Why now
+Most of the legacy mapping lived in `CLAUDE.md`'s routine prompt as a "Already
+ported / What's left" table. That prompt is invisible to a reader browsing
+`docs/`, and the table is bullets without a status column, so it's hard to
+*scan* the modern app's parity surface. Pulling the audit into
+`docs/initiatives/` gives it a stable URL, lets contributors tick rows as ports
+land, and surfaces the gaps the routine table hand-waved over.
+
+## What it captures
+- An at-a-glance row per legacy app (`core`, `edge`, `grader`, `focus`,
+  `croupier`, `sphinx`, `cabinet`, `pylon`, `concierge`, `lodge`, `ink`,
+  `challenge`, `frontend`) with a ✅ / 🟡 / ⛔ / ⏳ status, modern home, and
+  one-line notes.
+- Four "by audience" tables — Student, Teacher, Parent, Admin — that walk the
+  capabilities a user can actually exercise, with PR links to every V2 port.
+- A public/marketing table for `/`, `/login`, `/register/*`, `/enquire`.
+- Seven concrete TODOs split into "small follow-up" vs. "out of scope until
+  product asks" — the first one (concierge enquiry email no-op because
+  `ADMINS` is unset) is exactly the question that came up while shipping
+  M3-03.
+- A retirement checklist so anyone proposing `git rm -r <legacy_app>/` knows
+  the gate.
+
+## Verification
+- Docs-only change; no code touched.
+- Cross-checked against `CLAUDE.md` mapping and recent PR history.
+
+## Next
+This is the last M5/M6/M7 backlog row from today's "make PRs for all of these
+top to bottom" pass. The V2 initiative status board (`STATUS.md`) and the
+ledger in `2026-design-system-v2.md` are now both up to date; the parity audit
+is the durable answer for "what does the modern app still owe the legacy app?"

--- a/docs/initiatives/2026-design-system-v2.md
+++ b/docs/initiatives/2026-design-system-v2.md
@@ -154,7 +154,11 @@ Ledger). Split any item that won't fit one session.
 ### M2 — Global shell  *(every page inherits this — do first)*
 - [x] `M2-01` Reskin **App Shell** (`AppShell` + `Navbar`): real `<Logo/>`, warm
   paper background, brand active-nav (chalk underline), warm user menu.
-- [ ] `M2-02` Mobile nav polish: brand hamburger sheet, role chips, safe-area.
+- [x] `M2-02` Mobile nav polish — shipped 2026-06-04 (#198). Hamburger sheet
+  repurposed as an Account drawer (now that M5-01 bottom tabs carry primary
+  nav); tokens swept; `aria-current` / `aria-haspopup` / dynamic
+  hamburger-label / focus-visible rings / ESC closes both dropdowns; safe-area
+  inset top.
 - [x] `M2-03` Global states: branded `LoadingSpinner`, `NotFoundPage` (404 route),
   `ErrorBoundary` shipped 2026-06-02. Toast theming deferred (no toast lib
   currently wired — add when first needed).
@@ -163,7 +167,10 @@ Ledger). Split any item that won't fit one session.
 - [x] `M3-01` **Login** → chalkboard-left / paper-right brand layout (flagship).
 - [x] `M3-02` Register + Register-school + Register-open migrated to the V2
   chalkboard/paper layout 2026-06-02, using new `ui/Input`.
-- [ ] `M3-03` Public **Enquire** page (prospective schools) — credible + warm.
+- [x] `M3-03` Public **Enquire** page — shipped 2026-06-04 (#199 + #200 follow-up
+  for a duplicate "Back to sign in" link). Composed via the shared `AuthLayout`
+  (chalkboard hero + paper form); uses `ui/Input`/`Textarea`/`Button`; success
+  state via `EmptyState` keyhole motif.
 - [x] `M3-04` **Home page** at `/` — legacy-inspired (chalkboard hero →
   Practice/Evaluate/Analyse → mission + teacher photo → "Start now" → features),
   new branding, legacy hero images, branded Login CTA. Logo links home everywhere.
@@ -192,12 +199,15 @@ Ledger). Split any item that won't fit one session.
   Tokens now substitute deterministically per `(student_id, subpart_id)`; 4 new
   regression tests; 777 backend tests passing.
 - [~] `M7-03` **List-page filtering / search / sort actually works.** Browse
-  Grade filter wired correctly 2026-06-04 (#194 — backend was matching
-  `standard_id` against a *standard number*; switched to `standard__number`,
-  4 regression tests). **Remaining:** Question Bank filters/search + assignment-
-  list filters still need a parity pass.
-- [ ] `M7-04` **Feature-parity audit vs. legacy.** Walk the legacy app surface by
-  surface; log every capability the modern frontend is missing into this backlog.
+  Grade filter (#194) + Question Bank search-dedup + Grade filter parity (#197)
+  shipped 2026-06-04. **Remaining:** Question Bank chapter-filter *UI* (backend
+  already supports `?chapter=`); assignment-list filters (student/teacher
+  views currently group by status only — no UI controls). Both small frontend
+  follow-ups.
+- [x] `M7-04` **Feature-parity audit vs. legacy** — shipped 2026-06-04 in
+  [`legacy-feature-parity.md`](legacy-feature-parity.md). At-a-glance table
+  per legacy app, by-audience capability tables, known TODO list (7 items),
+  and a deletion checklist for retiring a legacy app.
 - [x] `M7-05` **`seed_demo_data` idempotency.** Fixed 2026-06-02 (#141) — the
   command was crashing with `MultipleObjectsReturned` on any DB with cabinet
   imports because `Question.get_or_create(school, standard, subject, chapter,
@@ -231,14 +241,30 @@ Ledger). Split any item that won't fit one session.
   Role-aware (Student/Open: Home/Browse/Path/Profile · Teacher: Home/Questions/Profile ·
   Parent: Home/Profile · Admin: School/Profile). Above `env(safe-area-inset-bottom)`;
   hidden on `sm:` and above.
-- [ ] `M5-02` Per-surface responsive audit of migrated M4 pages.
+- [x] `M5-02` Per-surface responsive audit — shipped 2026-06-04 (#201). Two
+  table-overflow fixes (BrowsePage chapter table, ClassHealthPanel table);
+  rest of the migrated surfaces audited clean. **Follow-up:** 44×44 touch
+  targets on student practice (flagged in #195 change doc); PWA install /
+  offline question viewing.
 
 ### M6 — Hardening
-- [ ] `M6-01` Accessibility audit (AA) across migrated surfaces.
+- [x] `M6-01` Accessibility audit (AA, focused baseline) — shipped 2026-06-04
+  (#202). Skip-to-main link + `id="main-content"` landmark; full dialog
+  semantics on the QuestionBank add-to-set sheet (role=dialog, aria-modal,
+  aria-labelledby, ESC, initial focus on close); image alt parity on
+  QuestionPreviewPanel. **Follow-up:** keyboard walkthrough, screen-reader
+  spot-check (VoiceOver/NVDA), CreateQuestionPage tab-order audit, axe-core
+  CI gating — promote to its own initiative if scope grows.
 - [x] `M6-02` Retire the legacy `primary` (blue) token — shipped 2026-06-04 (#193).
   Palette + the four legacy helper classes (`.btn-primary`, `.btn-secondary`,
   `.card`, `.input`) deleted; 0 src/ consumers verified before merge.
-- [ ] `M6-03` Visual-regression screenshots of `/design` + key pages.
+- [~] `M6-03` Visual-regression screenshots — spec shipped 2026-06-04 (#203).
+  Playwright `visual.spec.ts` covers `/design`, `/`, `/login`, `/enquire` at
+  desktop + mobile; describe block is `.skip`-d until Linux baseline PNGs are
+  generated on CI (Windows-generated PNGs would never match the CI runner).
+  Activation = one CI run with `--update-snapshots` + commit + remove the
+  `.skip`. Authenticated-surface snapshots need a separate `playwright`
+  project against Docker; deliberate follow-up.
 
 > M4 is closed. The next active milestones are **M2-02** (mobile nav polish),
 > **M3-03** (Enquire), **M5-02** (responsive audit), **M6-01** (a11y audit),
@@ -309,3 +335,10 @@ Record the improvement in the ledger's "Hardening" column so the gains are visib
 | 2026-06-04 | M6-02 retire `primary` blue token | #193 | Deleted `primary-*` palette + `.btn-primary` / `.btn-secondary` / `.card` / `.input` legacy helper classes; refreshed the V2-brand and top-of-file comments. 0 `src/` consumers of the removed tokens/classes verified beforehand. | M4 closing immediately unlocked M6-02 — once the last surface lands on V2 there's nothing left holding the legacy palette in place. Worth doing as its own atomic cleanup PR so the deletion is reviewable. |
 | 2026-06-04 | M7-03 browse Grade filter fix | #194 | Backend `browse_chapters` matches `standard__number` (the dropdown sends standard *numbers* 1..12, not PKs); 4 regression tests covering standard, subject, combined, unfiltered; 163 api tests pass. | The endpoint had always been wrong — only worked by coincidence on dev DBs where Standard PK happened to equal `number`. Surfaced because M4-06b-i made the Browse filter UI visible/branded. Question Bank + assignment-list filter parity still on the M7-03 backlog. |
 | 2026-06-04 | M5-01 mobile bottom tab bar | #195 | New `BottomNav.tsx` (~170 LOC, role-aware, inline SVG icons, `aria-current` + `aria-label="Primary"`, focus-visible brand ring); above `env(safe-area-inset-bottom)`; hidden `sm:` and up. 5 vitest tests cover role tab sets + prefix-match active highlight. `AppShell` now adds `pb-24 sm:pb-8` so content clears the bar. | Hamburger menu intentionally kept for secondary actions (Profile, Sign out, deep-links like Proficiency) — the bottom bar is for *primary* navigation, not a total replacement. That separation keeps the surface area small and the tabs uncluttered. |
+| 2026-06-04 | M7-03 Question list dedupe + Grade filter parity | #197 | `QuestionViewSet.get_queryset` ends with `.distinct()` (search across `subparts__question_text` + `tags__name` no longer multiplies rows); standard filter matches `standard__number` to mirror Browse (#194). 4 new regression tests; 167 api tests pass. | Surfaced once the Question Bank UI exercised search seriously — the same kind of join-multiplies-rows bug Django emits whenever a `search_fields` walks an M2M/reverse-FK. `.distinct()` at the queryset tail is the cheapest reliable fix; the regression tests lock it in. |
+| 2026-06-04 | M2-02 mobile nav polish + a11y | #198 | Hamburger sheet repurposed as an Account drawer (identity row, Profile, student-only My Progress, Sign out — no longer duplicating the bottom-tab primary nav). Tokens swept (`gray-*`→`ink-*`, `red-*`→`rose-*`). `aria-label="Top"` on `<nav>`; `aria-current="page"` on active desktop links; `aria-haspopup="menu"` + `role="menu"`/`menuitem` on the avatar dropdown; dynamic hamburger `aria-label`; ESC closes both dropdowns + returns focus to the toggle; focus-visible brand rings throughout; `pt-[env(safe-area-inset-top)]`. | A11y plumbing added at the `Navbar` level (one ESC handler, one focus-visible utility) so the rest of the app inherits the behaviour without per-component wiring. Mobile sheet shrinking to "account only" was the right move *because* M5-01 had just shipped — the bottom bar carries the primary nav. |
+| 2026-06-04 | M3-03 Public Enquire page → V2 | #199 + #200 | `EnquirePage` wraps in shared `AuthLayout`; form rebuilt on `ui/Input`/`Textarea`/`Button`; success state uses `EmptyState` keyhole motif; rose-* error banner. Follow-up #200 removed a duplicate "Back to sign in" link from the success state's footer. | Last external-facing surface still on the legacy indigo gradient — wrapping it in `AuthLayout` proved the pattern composes for any new public page in minutes. The duplicate-link follow-up was a 5-min visual bug surfaced by the user immediately after merge; treated as its own atomic PR. |
+| 2026-06-04 | M5-02 per-surface responsive audit | #201 | BrowsePage chapter table → `overflow-x-auto` + `min-w-[24rem]` floor so long chapter names don't squash the Practice button. ClassHealthPanel table wrapped in `-mx-1 overflow-x-auto` + `min-w-[22rem]` to absorb long chapter names and wide X/Y counts. Rest of M4 surfaces audited clean. | The dashboards/Profile/Proficiency surfaces inherited their responsive rhythm from `Stat`/`SectionHeading`/`grid-cols-1 sm:grid-cols-N` — *because* they're composed from primitives, the audit found nothing to fix in them. Tables (raw `<table>` markup, not a primitive yet) were the only weak point — argues for a `Table` primitive sometime. |
+| 2026-06-04 | M6-01 accessibility audit (focused baseline) | #202 | Skip-to-main link in `AppShell` (sr-only-until-focused brand pill) + `id="main-content" tabIndex={-1}` landmark. `QuestionBankPage` add-to-set side-sheet promoted to a proper dialog: `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, descriptive close `aria-label`, ESC handler, initial focus on close button, focus-visible brand ring. `QuestionPreviewPanel` image alt switched from `""` to `"Question diagram"` for parity with `QuestionCard`. | Skip link / main-landmark is *the* foundational a11y move — every page in the app inherits it via `AppShell`. Dialog semantics on the add-to-set sheet matter because it's the only modal surface in the V2 stack; making it correct sets the pattern for any future dialog. Full keyboard walkthrough + screen-reader spot-check + axe-core CI are explicit non-goals; flagged for a dedicated a11y initiative. |
+| 2026-06-04 | M6-03 visual-regression spec scaffold | #203 | New `e2e/visual.spec.ts` covers `/design` + `/` + `/login` + `/enquire` at desktop (1280×800) + mobile (375×720), 8 snapshots total. `maxDiffPixelRatio: 0.02`; waits on `document.fonts.ready` so Fraunces/Inter character widths settle pre-snapshot. `test:e2e:update-snapshots` npm script. **`test.describe.skip` until Linux baselines are seeded on CI** (Windows PNGs would never match the Linux runner). | The honest answer to "where do we keep visual baselines on Windows-dev / Linux-CI without false diffs" is: on CI. Skipping the spec until that happens keeps CI green; the activation steps live in the change doc. Authenticated-surface snapshots require a separate Playwright project against Docker — deliberate follow-up. |
+| 2026-06-04 | M7-04 legacy feature-parity audit | this PR | New `docs/initiatives/legacy-feature-parity.md`: at-a-glance status per legacy app (`core`/`edge`/`grader`/`focus`/`croupier`/`sphinx`/`cabinet`/`pylon`/`concierge`/`lodge`/`ink`/`challenge`/`frontend`), by-audience capability tables (student/teacher/parent/admin/public), 7 known TODOs split by scope, and a retirement checklist. | The "Already ported" table lived in `CLAUDE.md` (routine prompt) — invisible to a reader browsing `docs/`. Pulling it into the initiatives folder gives it a stable URL, a status column to scan, and a place to record the gaps the routine table hand-waved over. Surfaced one concrete TODO from the M3-03 follow-up: `ADMINS` env-var wiring so `concierge` enquiry emails stop no-op'ing. |

--- a/docs/initiatives/STATUS.md
+++ b/docs/initiatives/STATUS.md
@@ -4,11 +4,11 @@
 > task advances the **top active initiative** here. See [`README.md`](README.md)
 > for how. Keep this file short — one row per initiative.
 
-**Last updated:** 2026-06-04 — **M4 closed** (every authenticated surface on V2). Same-day bonus: M6-02 (retire `primary`), M7-03 (Browse Grade filter), and M5-01 (mobile bottom tab bar) all shipped. See PRs #188–#195.
+**Last updated:** 2026-06-04 — V2 milestones largely closed. Today's second batch shipped M7-03 remaining (#197), M2-02 (#198), M3-03 (#199), Enquire-success fix (#200), M5-02 (#201), M6-01 (#202), M6-03 (#203) and M7-04 (this doc PR). See [legacy-feature-parity.md](legacy-feature-parity.md) for the new parity audit.
 
 | Priority | Initiative | Status | Headline progress | Next increment |
 |:--:|---|---|---|---|
-| 1 | [V2 "Chalk & Unlock" design overhaul](2026-design-system-v2.md) | 🟢 Active | **M1, M2-01, M2-03, M3-01/02/04, M4 (all of it), M5-01, M6-02, M7-01/02/05 done.** Only `M2-02` (mobile nav polish), `M3-03` (public Enquire), `M4` design-polish, `M5-02` (responsive audit), `M6-01` (a11y audit), `M6-03` (visual-regression set), and remaining `M7-03` (Question Bank + assignment-list filter parity) / `M7-04` (legacy-feature-parity audit) remain. **The whole product wears one branded language; the legacy `primary` blue palette no longer exists in the repo.** | Pull the highest-value remaining unblocked item. Strongest candidates: **M2-02** (now that bottom tabs cover primary nav, the hamburger menu can shrink to a secondary tray), **M3-03** (Enquire — visible to prospective schools), **M7-03** (finish list-page filter parity on Question Bank + assignment lists), or **M6-01** (AA audit across the now-coherent V2 surfaces). |
+| 1 | [V2 "Chalk & Unlock" design overhaul](2026-design-system-v2.md) | 🟢 Active | **M1, M2 (01+02+03), M3 (01+02+03+04), M4 (all), M5-01, M6-01, M6-02, M6-03 infra, M7-01/02/03/04/05 done.** The product wears one branded language end-to-end; the legacy `primary` blue is gone; tables overflow safely on mobile; the navbar is a11y-clean; a skip-link lands keyboard users on `<main>`; the AddToProblemSet dialog has full modal semantics; visual-regression spec is in place (baselines pending CI seed). **Remaining:** `M5-02` follow-ups (touch-target audit, PWA), `M6-03` baseline activation (commit Linux PNGs and unskip), `M7-03` Question Bank chapter-filter UI + assignment-list filters. | Pick from: **commit `M6-03` Linux baselines via CI** (small, unblocks visual-regression gating); **`ADMINS` env-var wiring** so concierge enquiry email stops no-op'ing (5 lines, called out in the parity audit); **Question Bank chapter-filter UI** (final M7-03 slice); or promote the **Accessibility Pass** backlog item to its own initiative now that a baseline a11y audit exists. |
 | — | [Cabinet Data Fidelity](cabinet-data-fidelity.md) (M7-03/06/08) | ✅ Done | Closing batch shipped (M7-08, M7-06, M7-03a/b, fidelity-audit guard) + proper taxonomy names baked into the importer. `audit_cabinet_fidelity --strict` is **green on the real 646-question corpus** (0 wrong-widget, 0 token leaks, 0 placeholders, every id→1 Q). Residuals: image count 138 (<500, follow-up) and the additive **M7-11 interactive widget** (in progress). | — |
 
 ## Legend
@@ -33,5 +33,8 @@ becomes the right next bet.
   offline-tolerant question viewing.
 - **AI tutor surface** — student-facing conversational help over the existing
   hint + explanation backends.
-- **Accessibility pass** — WCAG 2.1 AA across the migrated V2 surfaces.
+- **Accessibility pass** — WCAG 2.1 AA across the migrated V2 surfaces. A
+  focused baseline pass landed 2026-06-04 (M6-01 #202) — skip link, dialog
+  semantics, image alts. Promote to its own initiative when ready for a
+  full audit (keyboard walkthrough, screen-reader spot-check, axe-core CI).
 - **Performance budget** — route-level code-splitting, image/font optimisation.

--- a/docs/initiatives/legacy-feature-parity.md
+++ b/docs/initiatives/legacy-feature-parity.md
@@ -1,0 +1,149 @@
+# Legacy Feature-Parity Audit (M7-04)
+
+> Source-of-truth audit of every legacy Django 1.11 app against its modern
+> Django 4.2 + React equivalent. Open this when scoping a port, when triaging
+> "does the modern app do X?", or when planning to retire a legacy app.
+>
+> Generated: 2026-06-04. Owner of edits: any contributor finishing a port —
+> tick the row and link the PR.
+
+## Legend
+
+- ✅ **Ported** — full behaviour lives in the modern stack.
+- 🟡 **Partial** — covered partially; missing slice noted in the row.
+- ⛔ **Skipped** — intentionally not ported (reason in the row).
+- ⏳ **TODO** — not yet ported, on the modern backlog.
+
+## At-a-glance
+
+| Legacy app | Status | Modern home | Notes |
+|---|:--:|---|---|
+| `core/` | ✅ | `backend/openshiksha/apps/core/` | Board/School/Standard/Subject/Chapter/ClassRoom/SubjectRoom/Question/QuestionSubpart/Assignment/Submission all ported. GenericFK → direct FK; `UserInfo`/`SchoolProfile` merged into `User`/`School`. |
+| `edge/` | ✅ | `backend/openshiksha/apps/edge/` | Tick + StudentProficiency + SubjectRoomProficiency + SubjectRoomQuestionMistake all ported, plus modern additions (percentile snapshots, regression field, `StudentProficiencySnapshot` time-series). |
+| `grader/` | ✅ | `backend/openshiksha/apps/core/tasks.py::grade_submission` | Per-submission real-time grading replaces nightly batch. |
+| `focus/` | ✅ | `ProblemSet.is_remedial` + `_create_remedial_assignment()` + `target_student` FK | Per-student remedials of *only* the wrong questions (PR #84/#87). |
+| `croupier/` | ✅ | `backend/openshiksha/apps/api/croupier.py` | Deterministic per-(student_id, subpart_id) seeded MCQ shuffle + variable substitution. M7-02 (#140) wired this into the student list endpoint. |
+| `sphinx/` | ✅ | `frontend_modern/src/features/teacher/CreateQuestionPage.tsx` | Authoring with KaTeX preview, variable-constraints panel, AI-generation panel (Gemini JSON mode, #185). Migrated to V2 in M4-07c / #192. |
+| `cabinet/` | ✅ | DB-stored `Question`/`QuestionSubpart` + import command | Cabinet imports baked in; **Cabinet Data Fidelity** initiative is closed (audit `--strict` green on 646 questions). External cabinet service retired. |
+| `pylon/` (SMS) | 🟡 | `backend/openshiksha/apps/core/emails.py` | **Replaced** with email (no SMS in modern). Phase 1 (grading complete + remedial assigned) shipped; due-date reminder still TODO. Legacy SMS-to-Indian-providers integration intentionally not ported. |
+| `concierge/` | ✅ | `backend/openshiksha/apps/concierge/` + `frontend_modern/src/features/enquiry/EnquirePage.tsx` | `Enquirer` model + public POST + `notify_enquiry_received` (mail_admins) + V2 page (M3-03 #199). **Activation gap:** `ADMINS` is not set in `settings/`, so the email currently no-ops. See the "Known gaps" section. |
+| `lodge/` | ✅ | `backend/openshiksha/apps/lodge/` + `frontend_modern/src/features/student/VideosPanel.tsx` | `Video` model + `GET /api/videos/?chapter=<id>`; `VideosPanel` renders per-chapter videos on Assignment detail. M4-06b-ii (#189) reskinned to V2. |
+| `ink/` (Dossier) | 🟡 | `User.phone_number`, `User.email` (`shared/ProfilePage.tsx`) | Primary email + phone ported. **`secondaryPhone` / `secondaryEmail` / `flagged`** intentionally skipped — legacy CRM-only fields, not user-facing product. |
+| `challenge/` | ⛔ | n/a | A memorisation-game / honeypot view rendering a 1000-element RANDOM_DATA list. No identified product value; deliberately not ported. |
+| `frontend/` (Django templates) | ⛔ | n/a — replaced wholesale | The legacy Django-template UI was superseded by `frontend_modern/` React app. |
+
+## Capabilities — by audience
+
+### Student
+
+| Capability | Legacy | Modern | Status |
+|---|---|---|---|
+| Practice + auto-grade an assignment | `core` + `grader` | `AssignmentDetailPage` + `grade_submission` Celery task | ✅ |
+| Per-student MCQ shuffle + variable substitution | `croupier` | `QuestionWithSubpartsStudentSerializer` | ✅ (M7-02 / #140) |
+| Self-directed Browse by board → subject → chapter | new in modern | `BrowsePage` + `BrowsePracticePage` | ✅ V2 (#188) — Grade filter parity fixed (M7-03 #194 / #197) |
+| Per-chapter mastery / proficiency view | `edge.StudentProficiency` | `ProficiencyPage` (sparklines from `StudentProficiencySnapshot`) | ✅ V2 (M4-06a #183) |
+| Targeted remedial assignments | `focus` | `ProblemSet.is_remedial` + auto-assigned per-student | ✅ |
+| Streaks + grace day + milestone tiers | none in legacy | `StudentStreak` + `StreakBadge` | ✅ (modern addition) |
+| Spaced repetition drill | none in legacy | `apps/ai/` SM-2 engine + `/student/srs/drill` | ✅ (modern addition; M4-05 V2 #185) |
+| Chapter videos | `lodge.Video` | `VideosPanel` (per-chapter, conditional render) | ✅ V2 (M4-06b-ii #189) |
+| Question images | `cabinet` base64 | `QuestionSubpart.image_url` URLField | ✅ (#86) |
+| Hints + worked solutions | `cabinet` `solution`, `hint` fields | `QuestionSubpart.solution_text` + `hint_text` | ✅ |
+| Profile / settings | `ink.Dossier` | `ProfilePage` + `PATCH /users/me/profile/` | ✅ V2 (M4-08 #180); password change still TODO |
+| Mobile primary navigation | n/a (legacy was desktop-only) | `BottomNav` (Home/Browse/Path/Profile) | ✅ (M5-01 #195) |
+| AI tutor / Socratic chat | none in legacy | branch `ai/2026-06-04-ai-tutor-chat` (in flight) | 🟡 (separate track) |
+
+### Teacher
+
+| Capability | Legacy | Modern | Status |
+|---|---|---|---|
+| Author questions (LaTeX preview + variables) | `sphinx` | `CreateQuestionPage` + `RichContent` | ✅ V2 (#192) |
+| Edit existing question | server-rendered form | `/teacher/questions/:id/edit` (reuses `CreateQuestionPage` in edit mode) | ✅ |
+| AI-assisted question generation | none | Gemini JSON-mode panel in `CreateQuestionPage` | ✅ (#185, hardened V2 #192) |
+| Question bank (browse / search / filter) | `cabinet` browse views | `QuestionBankPage` + `useQuestionList` | ✅ V2; search dedup + standard-number filter fixed (M7-03 #197) |
+| Compose problem sets | `core` admin | `CreateProblemSetPage` (preview-driven) | ✅ V2 |
+| Compose assignments | `core` | `CreateAssignmentPage` | ✅ V2 |
+| Class health + weekly summary | mostly server reports | `ClassHealthPanel` + `WeeklyReportPanel` (AI-summarised) | ✅ V2 (M4-07a #190) |
+| Per-assignment submission/score breakdown | `core` admin | `TeacherAssignmentDetailPage` | ✅ V2 (M4-07b #191) |
+| Classroom join code | none in legacy | `ClassroomInviteCode` + `ClassroomCodeWidget` | ✅ V2 (M4-07a #190) |
+
+### Parent
+
+| Capability | Legacy | Modern | Status |
+|---|---|---|---|
+| Parent–child link | `core.Home` | `User.children` M2M | ✅ |
+| Child proficiency trend + assignment view | none in legacy | Parent dashboard with sparklines + activity panels | ✅ V2 (M4-02 #181) |
+
+### Admin (school)
+
+| Capability | Legacy | Modern | Status |
+|---|---|---|---|
+| Manage classrooms (list, create, edit) | `core` admin via Django | `AdminDashboard` + `ClassroomManagePage` | ✅ V2 (M4-04 #182) |
+| Manage students per classroom | Django admin | UI in `ClassroomManagePage` (enroll / remove) | ✅ V2 |
+| Manage SubjectRooms (assign teachers) | Django admin | covered via `ClassroomManagePage` | ✅ V2 |
+| `school-teachers` list (enrollment picker) | Django admin | `GET /users/school-teachers/` | ✅ |
+
+### Public / marketing
+
+| Capability | Legacy | Modern | Status |
+|---|---|---|---|
+| Marketing home (Practice / Evaluate / Analyse) | legacy `frontend/` Django templates | `HomePage` (V2 chalkboard hero + sections) | ✅ |
+| Login (branded) | legacy template | V2 chalkboard/paper `LoginPage` | ✅ |
+| Register (Open / School / Open student) | partial in legacy | three V2 register pages composing `AuthLayout` | ✅ |
+| Enquire (prospective schools) | `concierge` template | V2 `EnquirePage` composing `AuthLayout` | ✅ V2 (M3-03 #199) |
+
+## Known gaps (TODO)
+
+1. **`concierge` enquiry email delivery.** `notify_enquiry_received` calls
+   `mail_admins(...)` correctly, but `ADMINS` isn't set in any `settings/`
+   module — so the email no-ops in both dev and prod. Enquiries are still
+   captured in the DB (visible at `/admin/concierge/enquirer/`). Fix: load
+   `ADMINS` from `OPENSHIKSHA_ADMIN_EMAILS` env var in `settings/production.py`.
+   *Small follow-up; ~5 lines.*
+
+2. **Due-date email reminder** (legacy `pylon` had SMS equivalent). The Phase 2
+   note in `CLAUDE.md` flags this — Celery beat schedule already exists for
+   `send_due_date_reminders`, but the email template + per-student opt-out
+   are TODO.
+
+3. **Password change** on the Profile page. Backend endpoint pending; UI
+   placeholder noted in `M4-08`.
+
+4. **Question file upload** (replace URL pasting with a real upload). The
+   `QuestionSubpart.image_url` URLField was Phase 1; a
+   `POST /api/questions/<id>/upload-image/` endpoint + drag-and-drop UI is
+   the next slice.
+
+5. **Browse/Question-Bank chapter filter UI.** Backend supports `?chapter=`
+   already; the chapter selector isn't in the QuestionBank filter bar yet
+   (Browse has Subject + Grade only). Small frontend follow-up; M7-03's
+   remaining slice.
+
+6. **`pylon` SMS** — deliberately not ported. If SMS is ever needed, wire a
+   modern provider (Twilio / MSG91) behind a new `apps/sms/` shim with the
+   same Celery hook points as `emails.py`. Out of scope until product asks.
+
+7. **`ink.Dossier` CRM fields** (secondary email/phone, `flagged`) —
+   deliberately not ported. Legacy CRM workflow lived in Django admin and
+   has no modern user-facing equivalent.
+
+## Activation checklist before retiring a legacy app
+
+When the urge to delete `legacy_app/` strikes:
+
+- [ ] Confirm every row in the matching "by audience" table above is ✅ (or
+  ⛔ with a reason captured here).
+- [ ] Run `audit_cabinet_fidelity --strict` (cabinet) or the relevant
+  parity test, if one exists.
+- [ ] `git grep -F "from <legacy_app>" backend/` returns zero hits.
+- [ ] Migration plan for any `legacy_app` rows still in the production DB
+  (most teams retain them as a read-only archive — fine).
+- [ ] Open a PR titled `chore: retire legacy <name>` that deletes the
+  package and updates this doc's row to ⛔ with a "retired YYYY-MM-DD #N" tag.
+
+## How this audit was produced
+
+A pass over each legacy app's `models.py` + `views.py` (where present)
+against the modern `backend/openshiksha/apps/<name>/` and `frontend_modern/
+src/features/`. Where CLAUDE.md already had a definitive answer (the
+"Already ported" table in the routine prompt), this doc mirrors it; where it
+was silent or out-of-date, the legacy code was the source of truth.


### PR DESCRIPTION
## Summary
The first proper **M7-04** deliverable, plus a sweep of the V2 initiative ledger to reflect today's second batch of merged PRs.

## Files changed
- **New** \`docs/initiatives/legacy-feature-parity.md\` — at-a-glance status per legacy app (\`core\`/\`edge\`/\`grader\`/\`focus\`/\`croupier\`/\`sphinx\`/\`cabinet\`/\`pylon\`/\`concierge\`/\`lodge\`/\`ink\`/\`challenge\`/\`frontend\`), by-audience capability tables (student/teacher/parent/admin/public), 7 concrete TODOs split by scope, and a retirement checklist for any legacy app the team decides to delete.
- \`docs/initiatives/STATUS.md\` — headline rewritten; the Accessibility-Pass backlog entry now notes today's #202 baseline.
- \`docs/initiatives/2026-design-system-v2.md\` — M2-02, M3-03, M5-02, M6-01, M6-03 (~), M7-04 ticked in the backlog; **6 append-only ledger rows** for today's second batch (#197 / #198 / #199+#200 / #201 / #202 / #203 / this PR).
- **New** \`docs/changes/2026-06-04-legacy-parity-audit.md\` — change doc.

## Closes M7-04
The "Already ported" table lived in the routine prompt (\`CLAUDE.md\`) and was invisible to anyone browsing \`docs/\`. Pulling it into the initiatives folder gives it a stable URL, a status column to scan, and a place to record gaps the routine table glossed over.

Surfaced one concrete TODO from yesterday's M3-03 question about email delivery: **\`ADMINS\` is unset, so \`concierge.emails.notify_enquiry_received\` no-ops in both dev and prod.** Captured as a small follow-up.

## Verification
Docs-only.

## Test plan
- [x] Cross-checked against \`CLAUDE.md\` mapping + recent PR history.
- [x] Every status emoji has a corresponding row/notes block.