### PR TITLE
fix(settings): load ADMINS from OPENSHIKSHA_ADMIN_EMAILS env

### DIFF
--- a/backend/openshiksha/settings/base.py
+++ b/backend/openshiksha/settings/base.py
@@ -231,6 +231,30 @@ EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", "")
 DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "OpenShiksha <noreply@openshiksha.edu.in>")
 EMAIL_SUBJECT_PREFIX = "[OpenShiksha] "
 
+
+# ADMINS — recipients of mail_admins() calls (concierge enquiries, error
+# notifications). Set OPENSHIKSHA_ADMIN_EMAILS to a comma-separated list,
+# optionally with "Name <email>" entries:
+#   OPENSHIKSHA_ADMIN_EMAILS="Ops Team <ops@example.com>,founder@example.com"
+# Without this, mail_admins() silently no-ops — enquiries still land in the
+# DB (admin at /admin/concierge/enquirer/) but no email is sent.
+def _parse_admin_emails(raw: str) -> list[tuple[str, str]]:
+    out: list[tuple[str, str]] = []
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        if "<" in entry and entry.endswith(">"):
+            name, _, addr = entry.partition("<")
+            out.append((name.strip(), addr.rstrip(">").strip()))
+        else:
+            out.append(("", entry))
+    return out
+
+
+ADMINS = _parse_admin_emails(os.getenv("OPENSHIKSHA_ADMIN_EMAILS", ""))
+MANAGERS = ADMINS
+
 # Logging Configuration
 # Ensure the logs directory exists (CI environments and fresh checkouts won't have it)
 (BASE_DIR / "logs").mkdir(exist_ok=True)

--- a/backend/openshiksha/tests/test_admin_emails_env.py
+++ b/backend/openshiksha/tests/test_admin_emails_env.py
@@ -1,0 +1,50 @@
+"""
+Unit test for the ADMINS env-var parser in settings/base.py.
+
+The parser turns a comma-separated `OPENSHIKSHA_ADMIN_EMAILS` value into the
+list-of-tuples Django expects. Without this wiring, `mail_admins()` (called
+by concierge `notify_enquiry_received`) silently no-ops in production.
+"""
+
+from openshiksha.settings.base import _parse_admin_emails
+
+
+def test_empty_returns_empty_list():
+    assert _parse_admin_emails("") == []
+    assert _parse_admin_emails("   ") == []
+
+
+def test_plain_emails():
+    assert _parse_admin_emails("a@x.com,b@y.com") == [
+        ("", "a@x.com"),
+        ("", "b@y.com"),
+    ]
+
+
+def test_named_emails():
+    assert _parse_admin_emails("Ops Team <ops@x.com>,Founder <f@y.com>") == [
+        ("Ops Team", "ops@x.com"),
+        ("Founder", "f@y.com"),
+    ]
+
+
+def test_mixed_named_and_plain():
+    assert _parse_admin_emails("Ops <ops@x.com>,plain@y.com") == [
+        ("Ops", "ops@x.com"),
+        ("", "plain@y.com"),
+    ]
+
+
+def test_extra_whitespace_tolerated():
+    assert _parse_admin_emails("  ops@x.com  ,  Founder <f@y.com>  ") == [
+        ("", "ops@x.com"),
+        ("Founder", "f@y.com"),
+    ]
+
+
+def test_skips_blank_entries():
+    # Trailing comma, double comma, both stripped.
+    assert _parse_admin_emails("a@x.com,,b@y.com,") == [
+        ("", "a@x.com"),
+        ("", "b@y.com"),
+    ]

--- a/docs/changes/2026-06-04-admins-env-wire.md
+++ b/docs/changes/2026-06-04-admins-env-wire.md
@@ -1,0 +1,47 @@
+# ADMINS env-var wiring (concierge enquiry email activation)
+
+**Classification:** Fix.
+
+## Summary
+The legacy-feature-parity audit flagged this as a small follow-up:
+`concierge.emails.notify_enquiry_received` calls `mail_admins(...)`, but
+Django's `ADMINS` setting was never declared anywhere in `settings/`. Result:
+every enquiry no-op'd the email and the team only saw it via the Django
+admin at `/admin/concierge/enquirer/`.
+
+This PR loads `ADMINS` from an `OPENSHIKSHA_ADMIN_EMAILS` env var and parses
+both `email@example.com` and `Name <email@example.com>` formats. Enquiries
+now actually email the team whenever the env var is set.
+
+## Files changed
+- `backend/openshiksha/settings/base.py` — adds a `_parse_admin_emails`
+  helper + reads `OPENSHIKSHA_ADMIN_EMAILS`. `MANAGERS = ADMINS` so Django's
+  generic error mailer also benefits.
+- `backend/openshiksha/tests/__init__.py` — new package marker.
+- `backend/openshiksha/tests/test_admin_emails_env.py` — 6 unit tests
+  covering empty, plain, named, mixed, whitespace, blank-skip parsing.
+
+## Verification
+- New tests: 6/6 pass.
+- Existing `test_enquiry_notifies_admins` (which sets `settings.ADMINS` and
+  checks `mail.outbox`) still passes — confirms the round-trip works once
+  `ADMINS` is populated.
+- `python manage.py check` clean.
+
+## Deployment
+Set `OPENSHIKSHA_ADMIN_EMAILS` in the production env. Examples:
+
+```bash
+# Single recipient
+export OPENSHIKSHA_ADMIN_EMAILS="founder@openshiksha.edu.in"
+
+# Multiple, with optional display names
+export OPENSHIKSHA_ADMIN_EMAILS="Ops Team <ops@openshiksha.edu.in>,founder@openshiksha.edu.in"
+```
+
+Until set, behaviour is unchanged — emails no-op silently and enquiries
+remain visible in the Django admin.
+
+## Next
+Question Bank chapter-filter UI, then M6-03 visual-regression baseline
+activation.


### PR DESCRIPTION
## Summary
The legacy-feature-parity audit (#204) called this out:  \`concierge.emails.notify_enquiry_received\` calls \`mail_admins(...)\`, but Django's \`ADMINS\` setting was never declared anywhere in \`settings/\`. Result: every enquiry no-op'd the email and the team only saw submissions via the Django admin at \`/admin/concierge/enquirer/\`.

## Classification
**Fix.**

## Files changed
- \`backend/openshiksha/settings/base.py\` — adds a \`_parse_admin_emails\` helper + reads \`OPENSHIKSHA_ADMIN_EMAILS\`. \`MANAGERS = ADMINS\` so Django's generic error mailer benefits too.
- **New** \`backend/openshiksha/tests/test_admin_emails_env.py\` — 6 parser unit tests (empty, plain, named, mixed, whitespace, blank-skip).
- **New** \`backend/openshiksha/tests/__init__.py\` — package marker.

## Verification
- New tests: 6/6 pass.
- Existing \`test_enquiry_notifies_admins\` (which sets \`settings.ADMINS\` and checks \`mail.outbox\`) still passes — confirms the round-trip works once \`ADMINS\` is populated.

## Deployment
Set \`OPENSHIKSHA_ADMIN_EMAILS\` in the production env:
\`\`\`bash
# Single
export OPENSHIKSHA_ADMIN_EMAILS="founder@openshiksha.edu.in"
# Multiple, with optional display names
export OPENSHIKSHA_ADMIN_EMAILS="Ops Team <ops@openshiksha.edu.in>,founder@openshiksha.edu.in"
\`\`\`
Until set, behaviour is unchanged — emails no-op silently and enquiries remain visible in the Django admin.