### PR TITLE
feat(frontend): Question Bank chapter filter UI (M7-03 final)

### DIFF
--- a/docs/changes/2026-06-04-qbank-chapter-filter.md
+++ b/docs/changes/2026-06-04-qbank-chapter-filter.md
@@ -1,0 +1,36 @@
+# M7-03 (final slice) — Question Bank chapter filter UI
+
+**Classification:** Improve.
+
+## Summary
+Closes the remaining M7-03 UI gap: the QuestionBank backend already supported
+`?chapter=<id>` but the filter bar didn't expose it. Adds a third **Chapter**
+`<Select>` scoped to the currently-selected subject.
+
+## Files changed
+- `frontend_modern/src/features/teacher/QuestionBankPage.tsx`
+
+## What changed
+- Imports `useChapters` (already in the codebase; scoped to a subject).
+- New `selectedChapter` state, wired into `useQuestionList` as the
+  `chapter` filter param. `hasFilters` and `clearFilters` updated to
+  include it.
+- New `<Select>` rendered below the Subject/Difficulty row. Disabled until a
+  subject is picked (with `hint="Pick a subject first"` for discoverability)
+  — a chapter belongs to a subject, so listing every chapter across every
+  subject is overwhelming.
+- Subject change drops the chapter selection so we never filter against a
+  stale chapter id.
+
+## What was preserved
+- All existing search/subject/difficulty wiring; the focused-question
+  reconciliation; the AddToProblemSet sheet behaviour.
+
+## Verification
+- `npm run type-check`, `npm run lint`, `npm run build`, `npm test` — all
+  green (17 / 89).
+- Backend already supports `?chapter=<id>` (see `QuestionViewSet.get_queryset`
+  in `views/core.py`); no new tests required.
+
+## Next
+M6-03 visual-regression baseline activation. Then the V2 initiative is done.

--- a/frontend_modern/src/features/teacher/QuestionBankPage.tsx
+++ b/frontend_modern/src/features/teacher/QuestionBankPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuestionList } from './useQuestionList';
 import { useSubjects } from './useSubjects';
+import { useChapters } from './useChapters';
 import { useProblemSets } from './useProblemSets';
 import { useAddQuestionToProblemSet } from './useAddQuestionToProblemSet';
 import { previewFromQuestionText } from './previewFromQuestionText';
@@ -275,15 +276,23 @@ export const QuestionBankPage = () => {
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const [selectedSubject, setSelectedSubject] = useState<number | ''>('');
+  const [selectedChapter, setSelectedChapter] = useState<number | ''>('');
   const [selectedDifficulty, setSelectedDifficulty] = useState<number | ''>('');
   const [focusedQuestionId, setFocusedQuestionId] = useState<number | null>(null);
   const [modalQuestion, setModalQuestion] = useState<Question | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const { data: subjects } = useSubjects();
+  // Chapter list is scoped to the selected subject; disabled until a subject
+  // is picked (otherwise it would offer chapters from across every subject
+  // the teacher can see, which makes the picker overwhelming).
+  const { data: chapters } = useChapters(
+    selectedSubject !== '' ? (selectedSubject as number) : undefined,
+  );
   const { data: questions, isLoading } = useQuestionList({
     search: debouncedSearch || undefined,
     subject: selectedSubject !== '' ? (selectedSubject as number) : undefined,
+    chapter: selectedChapter !== '' ? (selectedChapter as number) : undefined,
     difficulty: selectedDifficulty !== '' ? (selectedDifficulty as number) : undefined,
   });
 
@@ -294,12 +303,16 @@ export const QuestionBankPage = () => {
   };
 
   const hasFilters =
-    !!search || selectedSubject !== '' || selectedDifficulty !== '';
+    !!search ||
+    selectedSubject !== '' ||
+    selectedChapter !== '' ||
+    selectedDifficulty !== '';
 
   const clearFilters = () => {
     setSearch('');
     setDebouncedSearch('');
     setSelectedSubject('');
+    setSelectedChapter('');
     setSelectedDifficulty('');
   };
 
@@ -353,9 +366,13 @@ export const QuestionBankPage = () => {
             <div className="grid grid-cols-2 gap-2">
               <Select
                 value={selectedSubject}
-                onChange={(e) =>
-                  setSelectedSubject(e.target.value ? Number(e.target.value) : '')
-                }
+                onChange={(e) => {
+                  const next = e.target.value ? Number(e.target.value) : '';
+                  setSelectedSubject(next);
+                  // Chapter belongs to a subject — drop the selection when the
+                  // subject changes so we don't filter against a stale chapter id.
+                  setSelectedChapter('');
+                }}
               >
                 <option value="">All subjects</option>
                 {(subjects ?? []).map((s) => (
@@ -378,6 +395,22 @@ export const QuestionBankPage = () => {
                 ))}
               </Select>
             </div>
+            <Select
+              value={selectedChapter}
+              onChange={(e) =>
+                setSelectedChapter(e.target.value ? Number(e.target.value) : '')
+              }
+              disabled={selectedSubject === ''}
+              hint={selectedSubject === '' ? 'Pick a subject first' : undefined}
+            >
+              <option value="">All chapters</option>
+              {(chapters ?? []).map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                  {c.standard_number !== undefined ? ` · Grade ${c.standard_number}` : ''}
+                </option>
+              ))}
+            </Select>
             {hasFilters && (
               <button
                 type="button"


### PR DESCRIPTION
## Summary
Closes the remaining M7-03 UI gap: the QuestionBank backend already supported \`?chapter=<id>\` but the filter bar didn't expose it. Adds a third **Chapter** \`<Select>\` scoped to the currently-selected subject.

## Classification
**Improve.**

## Highlights
- New \`selectedChapter\` state wired into \`useQuestionList\` as the \`chapter\` filter param.
- New \`<Select>\` below the Subject/Difficulty row; disabled until a subject is picked (hint: \"Pick a subject first\") — a chapter belongs to a subject, so listing every chapter across every subject is overwhelming.
- Subject change drops the chapter selection so we never filter against a stale chapter id.
- \`hasFilters\` and \`clearFilters\` updated.

## Verification
- \`npm run type-check\`, \`npm run lint\`, \`npm run build\`, \`npm test\` — all green (17 / 89).

## Test plan
- [x] Type-check / lint / build / vitest
- [ ] Manual: pick a subject → chapter list populates; clear subject → chapter resets to All. (Follow-up).