### PR TITLE
ci(visual): one-click workflow to seed Linux Playwright baselines (M6-03)

### DIFF
--- a/.github/workflows/seed-visual-baselines.yaml
+++ b/.github/workflows/seed-visual-baselines.yaml
@@ -1,0 +1,87 @@
+name: Seed visual-regression baselines
+
+# Manual one-shot workflow that generates Linux Playwright snapshots for
+# e2e/visual.spec.ts and pushes them back to the originating branch. See
+# docs/changes/2026-06-04-visual-regression.md for context.
+#
+# Usage:
+#   1. Push a branch where you want baselines (typically a feature branch
+#      that intentionally changed the visual).
+#   2. Trigger this workflow against that branch from the Actions tab.
+#   3. The job pushes the generated PNGs + a baseline-activation commit
+#      that drops the `test.describe.skip` from visual.spec.ts (only on the
+#      first run; subsequent runs just refresh the PNGs).
+
+on:
+    workflow_dispatch:
+        inputs:
+            branch:
+                description: 'Branch to update baselines on (default: current branch)'
+                required: false
+                default: ''
+
+jobs:
+    seed:
+        name: Generate + commit Linux baselines
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        defaults:
+            run:
+                working-directory: frontend_modern
+        steps:
+            - name: Check out the target branch
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ inputs.branch || github.ref_name }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '20'
+                  cache: 'npm'
+                  cache-dependency-path: frontend_modern/package-lock.json
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Cache Playwright browsers
+              uses: actions/cache@v5
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: playwright-${{ runner.os }}-${{ hashFiles('frontend_modern/package-lock.json') }}
+
+            - name: Install Playwright browsers
+              run: npx playwright install --with-deps chromium
+
+            - name: Drop the .skip from visual.spec.ts (first-run activation)
+              run: |
+                  if grep -q 'test.describe.skip' e2e/visual.spec.ts; then
+                      echo "Activating visual.spec.ts (replacing test.describe.skip with test.describe)"
+                      sed -i 's/test\.describe\.skip(/test.describe(/' e2e/visual.spec.ts
+                  else
+                      echo "visual.spec.ts already activated — only refreshing baselines"
+                  fi
+
+            - name: Generate baselines
+              # --update-snapshots writes (or refreshes) PNGs under
+              # e2e/visual.spec.ts-snapshots/*.png suffixed -chromium-linux.png.
+              run: npx playwright test visual.spec.ts --update-snapshots
+
+            - name: Configure git
+              run: |
+                  git config --global user.name 'github-actions[bot]'
+                  git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+            - name: Commit + push (if anything changed)
+              working-directory: ${{ github.workspace }}
+              run: |
+                  git add frontend_modern/e2e/visual.spec.ts \
+                          frontend_modern/e2e/visual.spec.ts-snapshots
+                  if git diff --cached --quiet; then
+                      echo "No baseline changes to commit."
+                      exit 0
+                  fi
+                  git commit -m "ci(visual): refresh Linux Playwright baselines"
+                  git push origin HEAD:${{ inputs.branch || github.ref_name }}

--- a/docs/changes/2026-06-04-visual-baselines-activation.md
+++ b/docs/changes/2026-06-04-visual-baselines-activation.md
@@ -1,0 +1,69 @@
+# M6-03 — Visual-regression baseline activation
+
+**Classification:** New (CI infrastructure).
+
+## Summary
+Adds a manual GitHub Actions workflow that seeds the Linux Playwright
+baselines for `e2e/visual.spec.ts` (M6-03 / #203). The visual-regression
+infra has been in the repo since #203 but skipped, because Linux baselines
+need to be generated on a Linux runner. This workflow makes activation a
+single-click operation in the GitHub Actions tab.
+
+## Files changed
+- **New** `.github/workflows/seed-visual-baselines.yaml` — `workflow_dispatch`
+  job that:
+  1. Checks out the chosen branch (default: the branch the workflow is
+     dispatched from).
+  2. Installs Node, Playwright chromium, dependencies.
+  3. If `visual.spec.ts` still has `test.describe.skip`, swaps it for
+     `test.describe` (one-time activation).
+  4. Runs `npx playwright test visual.spec.ts --update-snapshots`, writing
+     PNGs to `e2e/visual.spec.ts-snapshots/`.
+  5. Commits and pushes the baselines back to the target branch (only if
+     anything actually changed).
+
+## How to use
+
+### First-time activation (one-shot)
+1. Open the **Actions** tab → **Seed visual-regression baselines** →
+   **Run workflow**.
+2. Pick `modernization` (or any branch you want the baselines committed to).
+3. Wait ~2 min. The workflow auto-commits a `ci(visual): refresh Linux
+   Playwright baselines` commit containing the eight `*-chromium-linux.png`
+   files **and** the `.skip` removal.
+4. From this point on the visual spec runs in the regular `frontend-e2e` CI
+   job and fails the build on any pixel diff above the configured
+   `maxDiffPixelRatio: 0.02` threshold.
+
+### Refreshing after an intentional design change
+1. Land your design PR on a branch.
+2. Open the workflow against that branch.
+3. The workflow re-runs `--update-snapshots`, refreshing the existing PNGs
+   in place; commits + pushes.
+4. The PR diff now includes the visual changes for review.
+
+## Why a separate workflow (not the main CI job)
+- The main `frontend-e2e` job runs on every PR — it should *gate* on the
+  baselines, not regenerate them. Otherwise a real visual regression would
+  silently overwrite the reference instead of failing the build.
+- Separation also means `--update-snapshots` only ever runs when a human
+  explicitly asks for it (via Actions UI), which is the right safety
+  posture for "this change is intentional, commit the new baseline".
+
+## Verification
+- Workflow YAML linted via the standard YAML parser (no `yamllint` in
+  pipeline; the syntax mirrors the existing `ci-cd.yaml` blocks).
+- Manual confirmation pending the first `workflow_dispatch` run.
+
+## Closes M6-03
+With this PR the visual-regression initiative item moves from `~` to `x` in
+the V2 ledger: the scaffold ships in #203, activation ships here. Recurring
+baseline maintenance is now a one-click op.
+
+## Next
+This was the last of the three V2 follow-ups (along with `ADMINS` env
+wiring #205 and the QuestionBank chapter filter #206). The V2 "Chalk &
+Unlock" initiative's backlog is now `[x]` end-to-end except for explicitly
+deferred non-goals (full keyboard walkthrough / screen-reader spot-check /
+axe-core CI gating / authenticated-surface visual snapshots), each of which
+is documented in the backlog with the right owning future initiative.


### PR DESCRIPTION
## Summary
The visual-regression spec (#203) sits **skipped** until Linux Playwright baselines exist. Adds a \`workflow_dispatch\` GitHub Action that, when triggered against a branch:

1. Drops \`test.describe.skip\` from \`visual.spec.ts\` (first run only).
2. Runs \`npx playwright test visual.spec.ts --update-snapshots\` on \`ubuntu-latest\` with chromium installed.
3. Commits + pushes the generated \`*-chromium-linux.png\` files (and the \`.skip\` removal) back to the target branch.

Keeps baseline regeneration off the main CI path so a real visual regression *fails* the build instead of silently overwriting the reference.

## Classification
**New** (CI infrastructure).

## Files changed
- **New** \`.github/workflows/seed-visual-baselines.yaml\` — manual one-shot job.
- **New** \`docs/changes/2026-06-04-visual-baselines-activation.md\` — usage doc.

## Activation steps
1. Actions → **Seed visual-regression baselines** → **Run workflow** → pick \`modernization\`.
2. ~2 min later a \`ci(visual): refresh Linux Playwright baselines\` commit lands with eight \`*-chromium-linux.png\` files + the \`.skip\` removal.
3. \`frontend-e2e\` CI now gates on visual diffs (\`maxDiffPixelRatio: 0.02\`).

To refresh after an intentional design change: re-run the workflow against the branch; the same job updates the PNGs in place and adds them to the PR diff for review.

## Why a separate workflow
- Main CI job runs on every PR — it should **gate** on baselines, not regenerate them.
- Separation means \`--update-snapshots\` only runs when a human explicitly asks for it.

## Closes M6-03
Scaffold in #203 → activation here. The V2 backlog's last \`~\` flips to \`x\`.