### PR TITLE
polish(ai): question generation — show AI-unavailable state instead of stub drafts

### DIFF
--- a/backend/openshiksha/apps/ai/llm_client.py
+++ b/backend/openshiksha/apps/ai/llm_client.py
@@ -543,12 +543,20 @@ def generate_questions(
     question_type: str,
     difficulty: int,
     count: int,
-) -> list[dict]:
+) -> dict:
     """
     Generate question drafts using the same LLM cascade as generate_explanation.
 
-    Returns a list of draft dicts:
-        [{question_text, options, correct_answer, variable_constraints, suggested_tags}]
+    Returns a dict:
+        {
+            "questions": [{question_text, options, correct_answer,
+                           variable_constraints, suggested_tags}, ...],
+            "ai_available": bool,   # False when every provider was exhausted
+                                    # and the deterministic stub was returned
+        }
+
+    Callers should surface ``ai_available is False`` to the user rather than
+    presenting the stub placeholders as genuine drafts.
     """
     prompt = _build_question_gen_prompt(
         topic=topic,
@@ -564,7 +572,7 @@ def generate_questions(
     if anthropic_key:
         try:
             logger.debug("generate_questions: using Anthropic Claude")
-            return _call_anthropic_generate_questions(prompt, anthropic_key)
+            return {"questions": _call_anthropic_generate_questions(prompt, anthropic_key), "ai_available": True}
         except Exception:
             logger.exception("generate_questions: Anthropic failed, trying next provider")
 
@@ -572,7 +580,7 @@ def generate_questions(
     if google_key:
         try:
             logger.debug("generate_questions: using Google AI Studio")
-            return _call_google_generate_questions(prompt, google_key)
+            return {"questions": _call_google_generate_questions(prompt, google_key), "ai_available": True}
         except Exception:
             logger.exception("generate_questions: Google AI Studio call failed, trying next provider")
 
@@ -580,12 +588,12 @@ def generate_questions(
     if _ollama_reachable(ollama_url):
         try:
             logger.debug("generate_questions: using Ollama at %s", ollama_url)
-            return _call_ollama_generate_questions(prompt, ollama_url)
+            return {"questions": _call_ollama_generate_questions(prompt, ollama_url), "ai_available": True}
         except Exception:
             logger.exception("generate_questions: Ollama failed, falling back to stub")
 
     logger.warning("generate_questions: no LLM provider available — returning stub")
-    return _stub_questions(question_type, count)
+    return {"questions": _stub_questions(question_type, count), "ai_available": False}
 
 
 # ─────────────────────────────────────────────────────────────

--- a/backend/openshiksha/apps/ai/tests/test_generate_questions.py
+++ b/backend/openshiksha/apps/ai/tests/test_generate_questions.py
@@ -88,7 +88,8 @@ MOCK_DRAFTS = [
 
 @pytest.mark.django_db
 def test_generate_questions_success(teacher_client, chapter):
-    with patch("openshiksha.apps.ai.views.generate_questions", return_value=MOCK_DRAFTS) as mock_gen:
+    mock_result = {"questions": MOCK_DRAFTS, "ai_available": True}
+    with patch("openshiksha.apps.ai.views.generate_questions", return_value=mock_result) as mock_gen:
         url = "/api/v1/ai/generate-questions/"
         response = teacher_client.post(
             url,
@@ -104,6 +105,7 @@ def test_generate_questions_success(teacher_client, chapter):
 
     assert response.status_code == 200, response.data
     assert "questions" in response.data
+    assert response.data["ai_available"] is True
     assert len(response.data["questions"]) == 1
     q = response.data["questions"][0]
     assert q["question_text"] == MOCK_DRAFTS[0]["question_text"]
@@ -117,6 +119,44 @@ def test_generate_questions_success(teacher_client, chapter):
         difficulty=2,
         count=1,
     )
+
+
+@pytest.mark.django_db
+def test_generate_questions_stub_mode_returns_no_drafts(teacher_client, chapter):
+    """
+    When no LLM provider is configured the cascade falls back to a deterministic
+    stub. The endpoint must report ``ai_available: False`` and withhold the
+    placeholder drafts so the UI never presents stub text as a real question.
+    """
+    stub_result = {
+        "questions": [
+            {
+                "question_text": "Sample mcq question 1 (AI provider unavailable)",
+                "options": [{"key": "A", "text": "Option A"}],
+                "correct_answer": "A",
+                "variable_constraints": None,
+                "suggested_tags": ["sample"],
+            }
+        ],
+        "ai_available": False,
+    }
+    with patch("openshiksha.apps.ai.views.generate_questions", return_value=stub_result):
+        response = teacher_client.post(
+            "/api/v1/ai/generate-questions/",
+            {
+                "topic": "Polynomials",
+                "chapter_id": chapter.id,
+                "question_type": "mcq",
+                "difficulty": 2,
+                "count": 1,
+            },
+            format="json",
+        )
+
+    assert response.status_code == 200, response.data
+    assert response.data["ai_available"] is False
+    # Stub placeholders must NOT leak to the client as real drafts.
+    assert response.data["questions"] == []
 
 
 @pytest.mark.django_db

--- a/backend/openshiksha/apps/ai/views.py
+++ b/backend/openshiksha/apps/ai/views.py
@@ -901,7 +901,7 @@ class GenerateQuestionsViewSet(ViewSet):
         )
 
         try:
-            drafts = generate_questions(
+            result = generate_questions(
                 topic=d["topic"],
                 chapter_name=chapter.name,
                 subject_name=chapter.subject.name,
@@ -919,9 +919,16 @@ class GenerateQuestionsViewSet(ViewSet):
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
 
+        # ``generate_questions`` returns ``ai_available: False`` when no LLM
+        # provider was configured and the deterministic stub was used. Surface
+        # that to the client so the UI shows an "unavailable" state instead of
+        # presenting placeholder text as a real draft (see DraftCard).
+        ai_available = result["ai_available"]
+        drafts = result["questions"] if ai_available else []
+
         out_serializer = GeneratedQuestionDraftSerializer(data=drafts, many=True)
         out_serializer.is_valid()
-        return Response({"questions": out_serializer.data})
+        return Response({"questions": out_serializer.data, "ai_available": ai_available})
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/docs/ai-features/polish-backlog.md
+++ b/docs/ai-features/polish-backlog.md
@@ -1,0 +1,51 @@
+# AI Surfaces — Polish Backlog
+
+Running log of polish work on the existing AI surfaces (no new features). Each
+entry is one focused run against the 8-point polished checklist (error/degradation
+states, loading states, copy/tone, empty states, placement, V2 design, provider
+cascade transparency, test coverage).
+
+---
+
+## 2026-06-05 — AI question generation: stub mode no longer shown as real drafts
+
+**Surface:** AI question generation (teacher `CreateQuestionPage`).
+
+**Gap (checklist #1 & #7 — degradation / provider cascade transparency):**
+When no LLM provider key was configured, the backend cascade fell back to a
+deterministic stub that produced drafts like `"Sample mcq question 1 (AI provider
+unavailable)"`. The endpoint returned these as ordinary drafts with no signal,
+so the teacher saw placeholder text rendered as genuine, clickable "Use this"
+draft cards — and could pre-fill the form with garbage content.
+
+**Fix:**
+- `llm_client.generate_questions()` now returns `{"questions": [...],
+  "ai_available": bool}`; `ai_available` is `False` only when the stub path ran.
+- `GenerateQuestionsViewSet` forwards `ai_available` and withholds the stub
+  drafts (`questions: []`) when AI is unavailable.
+- Frontend `useGenerateQuestions` response type gains `ai_available`;
+  `AIGenerationPanel` shows a warm amber "AI unavailable right now, try again
+  later" notice instead of rendering stub drafts.
+- Added backend test `test_generate_questions_stub_mode_returns_no_drafts` for
+  the fallback path (checklist #8).
+
+**Verify:** Run the teacher question creator with no `ANTHROPIC_API_KEY` /
+`GOOGLE_AI_API_KEY` / Ollama → "Generate" shows the amber unavailable notice,
+not fake drafts. With a key set, drafts render as before.
+
+---
+
+## Remaining gaps (audit notes — not yet addressed)
+
+- **Natural language explanations** — backend `SubpartExplanationViewSet` is
+  registered (`/ai/explanations/`) but is **not consumed anywhere in
+  `frontend_modern`**. The post-grading student feedback surface appears to be
+  unwired in the V2 app. Needs UX placement work (inline after feedback) — sizeable,
+  flag before treating as polish vs. feature.
+- **Other generation surfaces** (weekly reports, parent summaries, class summary,
+  interventions) use the same stub-cascade pattern. Audit each for whether the
+  stub model leaks to the UI as if it were real content, mirroring the
+  question-generation fix above. `generate_class_summary` returns
+  `{"text", "model"}` — check the view/UI actually distinguish `model == "stub"`.
+- **Hint system** — solid: loading ("Thinking of a good hint…"), error, and
+  exhausted states all present. Low priority.

--- a/frontend_modern/src/features/teacher/CreateQuestionPage.tsx
+++ b/frontend_modern/src/features/teacher/CreateQuestionPage.tsx
@@ -201,11 +201,13 @@ const AIGenerationPanel = ({
   const [difficulty, setDifficulty] = useState(2);
   const [count, setCount] = useState(3);
   const [drafts, setDrafts] = useState<GeneratedQuestionDraft[]>([]);
+  const [aiUnavailable, setAiUnavailable] = useState(false);
 
   const generateMutation = useGenerateQuestions();
 
   const handleGenerate = () => {
     if (!chapterId || !topic.trim()) return;
+    setAiUnavailable(false);
     generateMutation.mutate(
       {
         topic: topic.trim(),
@@ -215,7 +217,10 @@ const AIGenerationPanel = ({
         count,
       },
       {
-        onSuccess: (data) => setDrafts(data.questions),
+        onSuccess: (data) => {
+          setDrafts(data.questions);
+          setAiUnavailable(!data.ai_available);
+        },
       }
     );
   };
@@ -327,7 +332,17 @@ const AIGenerationPanel = ({
             </div>
           )}
 
-          {!generateMutation.isPending && drafts.length > 0 && (
+          {!generateMutation.isPending && aiUnavailable && (
+            <div className="flex items-start gap-2 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-xs text-amber-900">
+              <span aria-hidden className="mt-px">⚠️</span>
+              <p>
+                AI question generation is unavailable right now. Please try again
+                in a little while, or write your question by hand below.
+              </p>
+            </div>
+          )}
+
+          {!generateMutation.isPending && !aiUnavailable && drafts.length > 0 && (
             <div className="space-y-3">
               <p className="text-xs font-semibold text-brand-900">
                 {drafts.length} draft{drafts.length > 1 ? 's' : ''} — click "Use this" to pre-fill the form

--- a/frontend_modern/src/features/teacher/useGenerateQuestions.ts
+++ b/frontend_modern/src/features/teacher/useGenerateQuestions.ts
@@ -4,6 +4,12 @@ import type { GenerateQuestionsRequest, GeneratedQuestionDraft } from '@/types/i
 
 interface GenerateQuestionsResponse {
   questions: GeneratedQuestionDraft[];
+  /**
+   * False when the backend's LLM cascade was exhausted and it fell back to the
+   * deterministic stub. In that case `questions` is empty and the UI should
+   * show an "AI unavailable" message rather than rendering placeholder drafts.
+   */
+  ai_available: boolean;
 }
 
 const generateQuestions = async (


### PR DESCRIPTION
## Surface
AI question generation — teacher **Create Question** page (`AIGenerationPanel`).

## Gap (polished checklist #1 degradation & #7 provider-cascade transparency)
When no LLM provider key was configured, the backend cascade (Claude → Gemini → Ollama → stub) fell back to a deterministic **stub** that produced drafts like `"Sample mcq question 1 (AI provider unavailable)"`. The endpoint returned these as ordinary drafts with no signal, so the teacher saw placeholder text rendered as **genuine, clickable "Use this" draft cards** — and could pre-fill the form with junk content.

## Fix
- `llm_client.generate_questions()` now returns `{"questions": [...], "ai_available": bool}`; `ai_available` is `False` only when the stub path ran.
- `GenerateQuestionsViewSet` forwards `ai_available` and **withholds** the stub drafts (`questions: []`) when AI is unavailable.
- Frontend `useGenerateQuestions` response type gains `ai_available`; `AIGenerationPanel` shows a warm amber *"AI question generation is unavailable right now. Please try again in a little while…"* notice instead of rendering stub drafts.
- Added backend test `test_generate_questions_stub_mode_returns_no_drafts` for the fallback path (checklist #8).

## Before / after
- **Before:** no key set → teacher sees fake "Sample mcq question 1 (AI provider unavailable)" cards with a working "Use this" button.
- **After:** no key set → teacher sees a clear amber "AI unavailable, try again later" notice; no fake drafts. With a key set, drafts render exactly as before.

## Verify
1. Run the teacher question creator with **no** `ANTHROPIC_API_KEY` / `GOOGLE_AI_API_KEY` / reachable Ollama → "Generate" shows the amber unavailable notice, not stub drafts.
2. With a provider key set → drafts render and "Use this" pre-fills the form as before.
3. `pytest openshiksha/apps/ai/tests/test_generate_questions.py` → 7 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)