### PR TITLE
fix(student): submitted assignments group as Completed, not Due Soon

### DIFF
--- a/backend/openshiksha/apps/api/serializers/core.py
+++ b/backend/openshiksha/apps/api/serializers/core.py
@@ -581,6 +581,14 @@ class AssignmentSerializer(serializers.ModelSerializer):
     submission_count = serializers.SerializerMethodField()
     student_count = serializers.SerializerMethodField()
     child_submission_status = serializers.SerializerMethodField()
+    # ``my_submission`` is the student's own submission row, surfaced on
+    # *every* assignment payload (list + detail) so the dashboard can group
+    # rows into Due Soon / Overdue / Completed without an extra round-trip
+    # per assignment. Used to be on AssignmentDetailSerializer only, which
+    # meant the list view never knew whether a row was already submitted —
+    # the StudentDashboard couldn't tell the two apart and showed every
+    # assignment as "Start" + "Due in N days", even after grading.
+    my_submission = serializers.SerializerMethodField()
 
     class Meta:
         model = Assignment
@@ -600,8 +608,35 @@ class AssignmentSerializer(serializers.ModelSerializer):
             "student_count",
             "child_submission_status",
             "target_student",
+            "my_submission",
         ]
         read_only_fields = ["assigned_by", "assigned_at", "average_score", "completion_rate"]
+
+    def get_my_submission(self, obj) -> dict | None:
+        """Return the current student's own Submission (if any).
+
+        Returns ``None`` for unauthenticated requests and for non-student
+        roles (teachers and admins don't have a "my" submission against
+        another teacher's assignment). Uses the prefetch cache populated
+        by ``AssignmentViewSet.get_queryset`` so listing N assignments
+        does not fan out into N submission queries.
+        """
+        request = self.context.get("request")
+        if not request or not request.user.is_authenticated:
+            return None
+        user = request.user
+        if getattr(user, "role", None) not in (UserRole.STUDENT, UserRole.OPEN_STUDENT):
+            return None
+        # When the viewset prefetched with a Prefetch(..., to_attr="my_submissions")
+        # filtered to the current user, read it directly to avoid N+1.
+        prefetched = getattr(obj, "my_submissions", None)
+        if prefetched is not None:
+            submission = prefetched[0] if prefetched else None
+        else:
+            submission = obj.submissions.filter(student=user).first()
+        if submission is None:
+            return None
+        return SubmissionSerializer(submission, context=self.context).data
 
     def get_submission_count(self, obj) -> int:
         return obj.submissions.count()
@@ -656,21 +691,13 @@ class AssignmentDetailSerializer(AssignmentSerializer):
     to students via the assignment detail endpoint.
     """
 
+    # ``my_submission`` is inherited from AssignmentSerializer now — the
+    # detail serializer only swaps the problem-set serializer for the
+    # student-safe variant that hides ``correct_answer``.
     problem_set = ProblemSetStudentDetailSerializer(read_only=True)
-    my_submission = serializers.SerializerMethodField()
 
     class Meta(AssignmentSerializer.Meta):
-        fields = AssignmentSerializer.Meta.fields + ["my_submission"]
-
-    def get_my_submission(self, obj) -> dict | None:
-        request = self.context.get("request")
-        if not request or not request.user.is_authenticated:
-            return None
-        try:
-            submission = obj.submissions.get(student=request.user)
-            return SubmissionSerializer(submission, context=self.context).data
-        except Submission.DoesNotExist:
-            return None
+        fields = AssignmentSerializer.Meta.fields
 
 
 class SubmissionSerializer(serializers.ModelSerializer):

--- a/backend/openshiksha/apps/api/tests/test_assignment_api.py
+++ b/backend/openshiksha/apps/api/tests/test_assignment_api.py
@@ -170,6 +170,48 @@ class TestAssignmentPermissions:
         assert response.status_code == status.HTTP_200_OK
         assert response.data["count"] == 1
 
+    def test_assignment_list_includes_my_submission_for_students(self, api_client, student, assignment, db):
+        """Regression for the StudentDashboard "due soon even though submitted"
+        bug: the LIST endpoint must surface ``my_submission`` so the dashboard
+        can group submitted rows into Completed instead of Due Soon. Used to
+        be on the detail serializer only; promoted to the base serializer."""
+        from django.utils import timezone
+
+        from openshiksha.apps.core.models import Submission
+
+        Submission.objects.create(
+            assignment=assignment,
+            student=student,
+            answers={},
+            completion=1.0,
+            submitted_at=timezone.now(),
+        )
+        api_client.force_authenticate(user=student)
+        response = api_client.get(reverse("assignment-list"))
+        assert response.status_code == status.HTTP_200_OK
+        row = response.data["results"][0]
+        assert "my_submission" in row
+        assert row["my_submission"] is not None
+        assert row["my_submission"]["submitted_at"] is not None
+
+    def test_assignment_list_my_submission_is_null_when_unsubmitted(self, api_client, student, assignment):
+        """Unsubmitted assignments must explicitly serialise ``my_submission: null``
+        so the frontend filter doesn't have to infer "missing key" semantics."""
+        api_client.force_authenticate(user=student)
+        response = api_client.get(reverse("assignment-list"))
+        assert response.status_code == status.HTTP_200_OK
+        row = response.data["results"][0]
+        assert row.get("my_submission") is None
+
+    def test_assignment_list_my_submission_is_null_for_teachers(self, api_client, teacher, assignment):
+        """``my_submission`` is a student concept — for teachers the field must
+        return ``null`` rather than leaking the first matched submission."""
+        api_client.force_authenticate(user=teacher)
+        response = api_client.get(reverse("assignment-list"))
+        assert response.status_code == status.HTTP_200_OK
+        row = response.data["results"][0]
+        assert row.get("my_submission") is None
+
 
 class TestSubmissionWorkflow:
     def test_student_can_create_submission(self, api_client, student, assignment):

--- a/backend/openshiksha/apps/api/views/core.py
+++ b/backend/openshiksha/apps/api/views/core.py
@@ -695,12 +695,27 @@ class AssignmentViewSet(viewsets.ModelViewSet):
         )
 
         if user.role in [UserRole.STUDENT, UserRole.OPEN_STUDENT]:
-            from django.db.models import Q
+            from django.db.models import Prefetch, Q
 
-            return qs.filter(
-                subject_room__students=user,
-                subject_room__is_active=True,
-            ).filter(Q(target_student=None) | Q(target_student=user))
+            from openshiksha.apps.core.models import Submission
+
+            # Prefetch only *this* student's submission per assignment so
+            # AssignmentSerializer.get_my_submission can read it off the
+            # cache without falling into N+1 over a class-sized list.
+            return (
+                qs.filter(
+                    subject_room__students=user,
+                    subject_room__is_active=True,
+                )
+                .filter(Q(target_student=None) | Q(target_student=user))
+                .prefetch_related(
+                    Prefetch(
+                        "submissions",
+                        queryset=Submission.objects.filter(student=user),
+                        to_attr="my_submissions",
+                    )
+                )
+            )
         elif user.role == UserRole.TEACHER:
             return qs.filter(assigned_by=user)
         elif user.role == UserRole.ADMIN:

--- a/frontend_modern/src/features/student/AssignmentCard.tsx
+++ b/frontend_modern/src/features/student/AssignmentCard.tsx
@@ -20,10 +20,26 @@ export const AssignmentCard = ({ assignment }: AssignmentCardProps) => {
     ? `Overdue by ${formatDistanceToNow(dueDate)}`
     : `Due ${formatDistanceToNow(dueDate, { addSuffix: true })}`;
 
+  // Submitted assignments surface *when* they were submitted instead of the
+  // due date — once you've turned it in, the due date is irrelevant and the
+  // student wants to know "did I do this recently?" at a glance.
+  const submittedLabel =
+    isSubmitted && my_submission?.submitted_at
+      ? `Submitted ${formatDistanceToNow(parseISO(my_submission.submitted_at), { addSuffix: true })}`
+      : 'Submitted';
+
   const cta = isSubmitted ? 'Review' : completion > 0 ? 'Continue' : 'Start';
 
   return (
-    <div className="os-card p-5 hover:shadow-md transition-shadow motion-reduce:transition-none">
+    <div
+      className={`os-card p-5 hover:shadow-md transition-shadow motion-reduce:transition-none ${
+        // Submitted cards get a subtle emerald edge so the difference reads
+        // at a glance in a mixed list, without leaning on color alone (the
+        // "Submitted" label + score badge + ghost CTA still carry the
+        // signal for users with reduced color vision).
+        isSubmitted ? 'border-emerald-200/80 bg-emerald-50/30' : ''
+      }`}
+    >
       <div className="flex items-start justify-between gap-4">
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-1">
@@ -71,10 +87,14 @@ export const AssignmentCard = ({ assignment }: AssignmentCardProps) => {
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mt-4">
         <span
           className={`text-xs ${
-            isOverdue && !isSubmitted ? 'text-rose-600 font-medium' : 'text-ink-400'
+            isSubmitted
+              ? 'text-emerald-700 font-medium'
+              : isOverdue
+                ? 'text-rose-600 font-medium'
+                : 'text-ink-400'
           }`}
         >
-          {isSubmitted ? 'Submitted' : dueDateLabel}
+          {isSubmitted ? submittedLabel : dueDateLabel}
         </span>
         <Button
           variant={isSubmitted ? 'ghost' : 'brand'}

--- a/frontend_modern/src/features/student/StudentDashboard.tsx
+++ b/frontend_modern/src/features/student/StudentDashboard.tsx
@@ -75,10 +75,18 @@ export const StudentDashboard = () => {
         />
       )}
 
-      {assignments && assignments.length > 0 && <AssignmentList assignments={assignments} />}
-
-      <RecommendationsPanel />
-      <DueForReviewPanel />
+      {/*
+        The major dashboard surfaces are separated by the same 32 px (mt-8)
+        gutter the V2 spacing scale uses elsewhere. Without it the
+        "Due Soon" assignment cards sit flush against the recommendations
+        panel, which read as one merged block rather than discrete
+        sections (regression spotted on the live student view).
+      */}
+      <div className="space-y-8">
+        {assignments && assignments.length > 0 && <AssignmentList assignments={assignments} />}
+        <RecommendationsPanel />
+        <DueForReviewPanel />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Fixes three issues spotted on the live student dashboard:

1. **Submitted assignments showed up under "Due Soon"** with a "Start" CTA and a "Due in 3 days" label (screenshot in the issue). Root cause: `AssignmentSerializer` (the LIST endpoint) never exposed `my_submission` — only `AssignmentDetailSerializer` did. So the dashboard's grouping logic `a.my_submission?.submitted_at` could never tell submitted from unsubmitted.
2. **Spacing between "Due Soon" assignment cards and "What to Practice Next"** was zero — the three dashboard panels were flush siblings, reading as one merged block instead of discrete sections.
3. **Submitted assignment cards** showed only "Submitted" with no timestamp and no at-a-glance visual differentiation from unsubmitted cards in a mixed list.

## Backend

- Move `my_submission` from `AssignmentDetailSerializer` down to the base `AssignmentSerializer` so list + detail both surface it. Only populate for student / open-student roles; null for teachers and admins (it's a "my" concept).
- Prefetch in `AssignmentViewSet.get_queryset` using `Prefetch(submissions, queryset=filter(student=user), to_attr="my_submissions")` so listing N assignments doesn't fan out into N submission queries.
- **3 new regression tests** in `test_assignment_api.py`:
  - submitted rows surface `submitted_at` on the list payload
  - unsubmitted rows return `null` explicitly (not missing key)
  - teachers get `null`, not someone else's submission

## Frontend

- `StudentDashboard` wraps `AssignmentList` + `RecommendationsPanel` + `DueForReviewPanel` in a `space-y-8` div (matches the V2 spacing scale).
- `AssignmentCard` now shows **"Submitted X ago"** (parsed from `submitted_at`) instead of just "Submitted", in `text-emerald-700`.
- Card gets a subtle `border-emerald-200/80 + bg-emerald-50/30` edge when submitted so the difference reads at a glance — score badge + ghost "Review" CTA already carried the signal, this just sharpens it.

## Test plan

- [x] Backend: 842 tests pass (839 + 3 new)
- [x] Frontend: type-check / lint / 10 student tests all clean
- [x] Live verification on Docker dev: submitted thermo assignment now lands under "Completed" with the new emerald-tinted card + "Submitted 2 minutes ago" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)