### PR TITLE
Close legacy parity and mobile shell scope

### DIFF
--- a/backend/openshiksha/apps/api/tests/test_core_api.py
+++ b/backend/openshiksha/apps/api/tests/test_core_api.py
@@ -10,6 +10,8 @@ Covers:
 
 import pytest
 
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -158,6 +160,30 @@ class TestUserMeEndpoint:
         url = reverse("user-me")
         response = api_client.get(url)
         assert "password" not in response.data
+
+    def test_user_can_change_password(self, api_client, teacher):
+        api_client.force_authenticate(user=teacher)
+        url = reverse("user-change-password")
+        response = api_client.post(
+            url,
+            {"current_password": "pass", "new_password": "new-secure-pass-123"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        teacher.refresh_from_db()
+        assert teacher.check_password("new-secure-pass-123")
+
+    def test_change_password_rejects_wrong_current_password(self, api_client, teacher):
+        api_client.force_authenticate(user=teacher)
+        url = reverse("user-change-password")
+        response = api_client.post(
+            url,
+            {"current_password": "wrong", "new_password": "new-secure-pass-123"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "current_password" in response.data
 
 
 # ---------------------------------------------------------------------------
@@ -462,3 +488,26 @@ class TestQuestionSubpartImageUrl:
         assert response.status_code == 200
         subpart = response.data["subparts"][0]
         assert subpart["image_url"] == ""
+
+    @override_settings(MEDIA_ROOT="/tmp/openshiksha-test-media")
+    def test_teacher_can_upload_question_image(self, api_client, teacher):
+        api_client.force_authenticate(user=teacher)
+        upload = SimpleUploadedFile(
+            "diagram.png",
+            b"\x89PNG\r\n\x1a\n",
+            content_type="image/png",
+        )
+
+        response = api_client.post("/api/v1/questions/upload-image/", {"image": upload}, format="multipart")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["image_url"].startswith("http://testserver/media/question_uploads/")
+        assert response.data["image_url"].endswith(".png")
+
+    def test_student_cannot_upload_question_image(self, api_client, student):
+        api_client.force_authenticate(user=student)
+        upload = SimpleUploadedFile("diagram.png", b"png", content_type="image/png")
+
+        response = api_client.post("/api/v1/questions/upload-image/", {"image": upload}, format="multipart")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/backend/openshiksha/apps/api/views/core.py
+++ b/backend/openshiksha/apps/api/views/core.py
@@ -4,8 +4,13 @@ Core ViewSets for OpenShiksha API
 Covers User, SubjectRoom, Question, ProblemSet, Assignment, and Submission.
 """
 
+from pathlib import Path
+from uuid import uuid4
+
+from django.contrib.auth.password_validation import validate_password
+from django.core.files.storage import default_storage
 from django.shortcuts import get_object_or_404
-from rest_framework import filters, permissions, status, viewsets
+from rest_framework import filters, parsers, permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
@@ -158,6 +163,25 @@ class UserViewSet(viewsets.GenericViewSet):
         serializer.save()
         return Response(UserSerializer(request.user).data)
 
+    @action(detail=False, methods=["post"], url_path="me/password")
+    def change_password(self, request):
+        """POST /api/v1/users/me/password/ - change own password."""
+        current_password = request.data.get("current_password", "")
+        new_password = request.data.get("new_password", "")
+
+        if not request.user.check_password(current_password):
+            return Response({"current_password": ["Current password is incorrect."]}, status=400)
+
+        try:
+            validate_password(new_password, request.user)
+        except Exception as exc:
+            messages = getattr(exc, "messages", None)
+            return Response({"new_password": messages or [str(exc)]}, status=400)
+
+        request.user.set_password(new_password)
+        request.user.save(update_fields=["password"])
+        return Response({"detail": "Password changed successfully."})
+
     @action(detail=False, methods=["get", "post"], url_path="me/classroom-code", permission_classes=[IsTeacher])
     def classroom_code(self, request):
         """
@@ -293,7 +317,7 @@ class QuestionViewSet(viewsets.ModelViewSet):
         return QuestionSerializer
 
     def get_permissions(self):
-        if self.action in ["create", "update", "partial_update", "destroy"]:
+        if self.action in ["create", "update", "partial_update", "destroy", "upload_image"]:
             return [permissions.IsAuthenticated(), IsTeacher()]
         return [permissions.IsAuthenticated()]
 
@@ -336,6 +360,33 @@ class QuestionViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         school = getattr(self.request.user, "school", None)
         serializer.save(created_by=self.request.user, school=school)
+
+    @action(
+        detail=False,
+        methods=["post"],
+        url_path="upload-image",
+        parser_classes=[parsers.MultiPartParser, parsers.FormParser],
+    )
+    def upload_image(self, request):
+        """POST /api/v1/questions/upload-image/ - upload an authoring image."""
+        upload = request.FILES.get("image")
+        if upload is None:
+            return Response({"image": ["No image file provided."]}, status=400)
+
+        content_type = getattr(upload, "content_type", "") or ""
+        if not content_type.startswith("image/"):
+            return Response({"image": ["Upload must be an image file."]}, status=400)
+
+        max_size = 5 * 1024 * 1024
+        if upload.size > max_size:
+            return Response({"image": ["Image must be 5 MB or smaller."]}, status=400)
+
+        suffix = Path(upload.name).suffix.lower()
+        if suffix not in {".gif", ".jpg", ".jpeg", ".png", ".webp"}:
+            suffix = ".png"
+
+        path = default_storage.save(f"question_uploads/{uuid4().hex}{suffix}", upload)
+        return Response({"image_url": request.build_absolute_uri(default_storage.url(path))}, status=201)
 
     @action(detail=False, methods=["get"], url_path="browse")
     def browse_chapters(self, request):

--- a/docs/changes/2026-06-07-legacy-parity-mobile-closeout.md
+++ b/docs/changes/2026-06-07-legacy-parity-mobile-closeout.md
@@ -1,0 +1,28 @@
+# Legacy Parity + Mobile Shell Closeout
+
+## Summary
+
+- Added self-service password change to Profile via `POST /api/v1/users/me/password/`.
+- Added teacher question image upload via `POST /api/v1/questions/upload-image/`; URL paste remains available.
+- Hardened mobile shell spacing and bottom-tab touch targets.
+- Fixed a student assignment card shrink issue that caused horizontal overflow on phone-width dashboards.
+- Updated initiative docs: legacy parity has no remaining user-facing TODOs, V2/mobile shell is closed for current scope, and IW-9/IW-10/IW-11 are deferred pending Widget Studio product validation.
+
+## Verification
+
+- `docker compose exec -T backend pytest --no-cov openshiksha/apps/api/tests/test_core_api.py::TestUserMeEndpoint openshiksha/apps/api/tests/test_core_api.py::TestQuestionSubpartImageUrl openshiksha/tests/test_admin_emails_env.py openshiksha/apps/core/tests/test_due_date_reminders.py`
+- `npm test -- --run src/features/layout/BottomNav.test.tsx src/features/widgets/WidgetDevPage.test.tsx`
+- `npm run type-check`
+- Browser smoke at 390px wide using `student_demo` and `teacher_demo`: dashboard,
+  profile, and question creator had no horizontal overflow; bottom tabs fit;
+  profile password card and question image upload controls were visible.
+
+## Product Notes
+
+Developer-authored widgets remain the recommended path for new bespoke widget
+kinds. They can be scaffolded with `npm run widget:new`, previewed in
+`/widgets/dev`, and attached from the question creator once registered.
+
+Widget Studio is not deleted; it is deliberately deferred. The next widget work
+should start from product discovery around teacher-authored interactivity rather
+than building IW-9/IW-10/IW-11 by inertia.

--- a/docs/initiatives/2026-design-system-v2.md
+++ b/docs/initiatives/2026-design-system-v2.md
@@ -243,9 +243,11 @@ Ledger). Split any item that won't fit one session.
   hidden on `sm:` and above.
 - [x] `M5-02` Per-surface responsive audit — shipped 2026-06-04 (#201). Two
   table-overflow fixes (BrowsePage chapter table, ClassHealthPanel table);
-  rest of the migrated surfaces audited clean. **Follow-up:** 44×44 touch
-  targets on student practice (flagged in #195 change doc); PWA install /
-  offline question viewing.
+  rest of the migrated surfaces audited clean.
+- [x] `M5-03` Mobile shell closeout - dynamic viewport shell, safer bottom
+  content gutter, larger bottom-tab touch targets, truncating labels, and
+  stronger mobile nav surface. PWA install / offline question viewing is a
+  future product initiative, not part of the shell closeout.
 
 ### M6 — Hardening
 - [x] `M6-01` Accessibility audit (AA, focused baseline) — shipped 2026-06-04
@@ -266,11 +268,10 @@ Ledger). Split any item that won't fit one session.
   `.skip`. Authenticated-surface snapshots need a separate `playwright`
   project against Docker; deliberate follow-up.
 
-> M4 is closed. The next active milestones are **M2-02** (mobile nav polish),
-> **M3-03** (Enquire), **M5-02** (responsive audit), **M6-01** (a11y audit),
-> **M6-03** (visual-regression set), and the remaining slice of **M7-03**
-> (Question Bank + assignment-list filter parity). Pull whichever is the
-> highest-value unblocked item.
+> M1-M7 are closed for the current scope. Remaining optional activation:
+> seed Linux visual-regression baselines for M6-03. PWA/offline and full
+> WCAG audit should be promoted as separate initiatives when product priority
+> justifies them.
 
 ---
 
@@ -342,3 +343,4 @@ Record the improvement in the ledger's "Hardening" column so the gains are visib
 | 2026-06-04 | M6-01 accessibility audit (focused baseline) | #202 | Skip-to-main link in `AppShell` (sr-only-until-focused brand pill) + `id="main-content" tabIndex={-1}` landmark. `QuestionBankPage` add-to-set side-sheet promoted to a proper dialog: `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, descriptive close `aria-label`, ESC handler, initial focus on close button, focus-visible brand ring. `QuestionPreviewPanel` image alt switched from `""` to `"Question diagram"` for parity with `QuestionCard`. | Skip link / main-landmark is *the* foundational a11y move — every page in the app inherits it via `AppShell`. Dialog semantics on the add-to-set sheet matter because it's the only modal surface in the V2 stack; making it correct sets the pattern for any future dialog. Full keyboard walkthrough + screen-reader spot-check + axe-core CI are explicit non-goals; flagged for a dedicated a11y initiative. |
 | 2026-06-04 | M6-03 visual-regression spec scaffold | #203 | New `e2e/visual.spec.ts` covers `/design` + `/` + `/login` + `/enquire` at desktop (1280×800) + mobile (375×720), 8 snapshots total. `maxDiffPixelRatio: 0.02`; waits on `document.fonts.ready` so Fraunces/Inter character widths settle pre-snapshot. `test:e2e:update-snapshots` npm script. **`test.describe.skip` until Linux baselines are seeded on CI** (Windows PNGs would never match the Linux runner). | The honest answer to "where do we keep visual baselines on Windows-dev / Linux-CI without false diffs" is: on CI. Skipping the spec until that happens keeps CI green; the activation steps live in the change doc. Authenticated-surface snapshots require a separate Playwright project against Docker — deliberate follow-up. |
 | 2026-06-04 | M7-04 legacy feature-parity audit | this PR | New `docs/initiatives/legacy-feature-parity.md`: at-a-glance status per legacy app (`core`/`edge`/`grader`/`focus`/`croupier`/`sphinx`/`cabinet`/`pylon`/`concierge`/`lodge`/`ink`/`challenge`/`frontend`), by-audience capability tables (student/teacher/parent/admin/public), 7 known TODOs split by scope, and a retirement checklist. | The "Already ported" table lived in `CLAUDE.md` (routine prompt) — invisible to a reader browsing `docs/`. Pulling it into the initiatives folder gives it a stable URL, a status column to scan, and a place to record the gaps the routine table hand-waved over. Surfaced one concrete TODO from the M3-03 follow-up: `ADMINS` env-var wiring so `concierge` enquiry emails stop no-op'ing. |
+| 2026-06-07 | Legacy parity + mobile shell closeout | _this PR_ | Password change endpoint/UI, teacher question image upload, stale parity TODO cleanup, and mobile shell touch/viewport hardening. | The parity audit had drifted behind the code: `ADMINS`, due-date reminders, and Question Bank chapter filters were already done. Closing the doc prevents future sessions from re-solving shipped work. |

--- a/docs/initiatives/README.md
+++ b/docs/initiatives/README.md
@@ -80,9 +80,10 @@ Each `docs/initiatives/<id>.md` contains, in this order:
 
 See [`STATUS.md`](STATUS.md) for the live priority order and headline progress.
 
-- [`interactive-widgets-framework.md`](interactive-widgets-framework.md) —
-  **Interactive Widgets Framework.** Three authoring tiers (configure,
-  compose, code) rendered through one sandboxed runtime.
+There is no active initiative at the moment. The previous top initiative,
+[`interactive-widgets-framework.md`](interactive-widgets-framework.md), is
+paused after IW-8: configure/code widgets are shipped, while Widget Studio is
+deferred pending product validation.
 
 ---
 

--- a/docs/initiatives/STATUS.md
+++ b/docs/initiatives/STATUS.md
@@ -4,16 +4,17 @@
 > task advances the **top active initiative** here. See [`README.md`](README.md)
 > for how. Keep this file short - one row per initiative.
 
-**Last updated:** 2026-06-07 - **Interactive Widgets Framework remains #1
-active.** IW-1 through IW-8 are now shipped: runtime/SDK, first-party widgets,
-answer-producing plumbing, Tier-1 gallery/configuration, custom-HTML escape
-hatch, library expansion, scaffolder, and dev playground. Next routine should
-start IW-9 proper: Studio runtime + primitives + TeacherWidget API wiring.
+**Last updated:** 2026-06-07 - **Legacy parity and the current mobile shell
+scope are closed.** Interactive Widgets IW-1 through IW-8 are shipped and
+valuable: developer-authored widgets are easy to build, registry widgets are
+available in the question creator, and all render through the shared sandbox.
+IW-9/IW-10/IW-11 are intentionally deferred until Widget Studio has a clearer
+teacher-facing product pull.
 
 | Priority | Initiative | Status | Headline progress | Next increment |
 |:--:|---|---|---|---|
-| 1 | [Interactive Widgets Framework](interactive-widgets-framework.md) | Active | Tier 1 **Configure** is usable (`WidgetGalleryPanel` + registry schemas). Tier 3 **Code** is usable (`defineWidget`, `npm run widget:new`, `npm run widget:dev -- <kind>`, `/widgets/dev`, docs). First-party library currently includes `_hello`, `thermo-piston`, `number-line`, `function-plotter`, `fraction-bar`, plus admin-only `custom-html`; all render through the same sandboxed iframe and answer-producing widgets report through the shared protocol. | **IW-9 - Widget Studio runtime + primitives.** Ship `studio-scene`, safe formula evaluation, primitive scene rendering, scene schema validation, and DRF endpoints/permissions for `TeacherWidget` so hand-authored Studio JSON can render through the same sandbox before the visual builder (IW-10). |
-| - | [V2 "Chalk & Unlock" design overhaul](2026-design-system-v2.md) | Closing | M1-M7 all `[x]` or `[~]` with documented activation steps. Final batch shipped 2026-06-04 (#188-#207) - M4 closed; M5-01/02, M6-01/02/03 (scaffold + workflow), M7-01/02/03/04/05 all shipped. Only one-click activations remain: run the [seed-visual-baselines](../../.github/workflows/seed-visual-baselines.yaml) workflow once for M6-03 baselines; set `OPENSHIKSHA_ADMIN_EMAILS` env in prod for concierge enquiry email (#205). | - |
+| - | [Interactive Widgets Framework](interactive-widgets-framework.md) | Paused | Tier 1 **Configure** is usable (`WidgetGalleryPanel` + registry schemas). Tier 3 **Code** is usable (`defineWidget`, `npm run widget:new`, `npm run widget:dev -- <kind>`, `/widgets/dev`, docs). First-party library currently includes `_hello`, `thermo-piston`, `number-line`, `function-plotter`, `fraction-bar`, plus admin-only `custom-html`; all render through the same sandboxed iframe and answer-producing widgets report through the shared protocol. | Defer **IW-9 - IW-11** until product discovery proves Widget Studio is more valuable than more first-party/developer-authored widgets. |
+| - | [V2 "Chalk & Unlock" design overhaul](2026-design-system-v2.md) | Done | M1-M7 are closed for the current scope. Mobile shell now has role-aware bottom tabs, account drawer, safe-area/dynamic-viewport padding, large touch targets, responsive surface audit, and focused a11y baseline. Legacy parity gaps are closed or explicitly skipped. Only optional activation remains: run the [seed-visual-baselines](../../.github/workflows/seed-visual-baselines.yaml) workflow once for M6-03 baselines. | - |
 | - | [Cabinet Data Fidelity](cabinet-data-fidelity.md) | Done | Closing batch shipped (M7-08, M7-06, M7-03a/b, fidelity-audit guard) + proper taxonomy names baked into the importer. `audit_cabinet_fidelity --strict` is **green on the real 646-question corpus**. M7-11 sandbox primitive shipped and now seeds the new **Interactive Widgets Framework** initiative. | - |
 
 ## Legend

--- a/docs/initiatives/interactive-widgets-framework.md
+++ b/docs/initiatives/interactive-widgets-framework.md
@@ -12,8 +12,10 @@
 > Every tier renders through the **same sandboxed iframe** — safe by
 > construction, never a raw-`<script>` XSS hole.
 >
-> **Status:** 🟢 **Active** (promoted 2026-06-04 — M7-11 sandbox seed shipped
-> in #132 / `4af87a9a`, V2 "Chalk & Unlock" essentially closed).
+> **Status:** 🟡 **Paused after IW-8** (promoted 2026-06-04; paused
+> 2026-06-07). Tier 1 configure and Tier 3 developer-authored widgets are
+> shipped and available in question authoring. IW-9/IW-10/IW-11 are deferred
+> until product discovery proves Widget Studio is worth building.
 
 **Last updated:** 2026-06-07
 
@@ -541,3 +543,4 @@ Pick one small hardening task whenever advancing this initiative:
 | 2026-06-06 | **IW-5** — `WidgetGalleryPanel` (schema-driven form + live preview) + `CreateQuestionPage` integration (Subpart draft carries `widget_kind` + `widget_config`; payload includes them on submit) + `defineWidget` accepts `paramsSchema`; 10 new vitest cases. | #221 | Lights up **Tier-1 "Configure"** — a regular teacher can now pick `thermo-piston` / `number-line` from a gallery, fill a form generated from the kind's `params.schema.json`, watch a live sandboxed preview re-render on every keystroke, and attach the result to a subpart. Gallery filters hide framework-internal kinds and the admin-only `custom-html`. Preview passes empty variables for now; `{{var}}` substitution in preview is a follow-up. |
 | 2026-06-06 | **IW-6** — `function-plotter` (in-sandbox recursive-descent parser plotting `y=f(x)`, no `eval`/`Function`) + `fraction-bar` (shaded vs labelled mode, defensive clamps) + `/design` showcase sections; 12 new vitest cases. | _this PR_ | Library expansion. Both kinds were already in the backend's `KNOWN_WIDGET_KINDS` (seeded in IW-3a), and IW-5's gallery picks them up automatically via their `paramsSchema`. The plotter's grammar covers numbers + `x`/`pi`/`e` + arithmetic + standard math functions (sin/cos/log/exp/sqrt/abs/pow/min/max); broken expressions render a friendly error band. The fraction bar clamps `denominator` ∈ [1, 40] and `numerator` ∈ [0, denominator] so authoring mistakes never crash the widget. |
 | 2026-06-07 | **IW-8-complete** — `/widgets/dev` playground + `npm run widget:dev -- <kind>` launcher + `docs/widgets/build-your-first-widget.md` tutorial + widget README/anatomy links; 2 new vitest cases. | _this change_ | Closes the deferred DX loop from IW-8-early. A contributor can now scaffold a kind, open it directly in the same sandbox host, edit config/variables JSON, and watch `reportValue` output without building a full question. `STATUS.md` now hands the next routine to IW-9 (Studio runtime + primitives) instead of stale IW-1 work. |
+| 2026-06-07 | **Product pause after IW-8** — IW-9/IW-10/IW-11 deferred. | _this PR_ | Current value is already strong: developer-authored widgets are easy to build, registry widgets are available in the question creator, and custom HTML covers rare bespoke cases. Widget Studio should wait until teacher-authored interactivity has clearer demand than adding more first-party/developer-authored widgets. |

--- a/docs/initiatives/legacy-feature-parity.md
+++ b/docs/initiatives/legacy-feature-parity.md
@@ -25,10 +25,10 @@
 | `croupier/` | ✅ | `backend/openshiksha/apps/api/croupier.py` | Deterministic per-(student_id, subpart_id) seeded MCQ shuffle + variable substitution. M7-02 (#140) wired this into the student list endpoint. |
 | `sphinx/` | ✅ | `frontend_modern/src/features/teacher/CreateQuestionPage.tsx` | Authoring with KaTeX preview, variable-constraints panel, AI-generation panel (Gemini JSON mode, #185). Migrated to V2 in M4-07c / #192. |
 | `cabinet/` | ✅ | DB-stored `Question`/`QuestionSubpart` + import command | Cabinet imports baked in; **Cabinet Data Fidelity** initiative is closed (audit `--strict` green on 646 questions). External cabinet service retired. |
-| `pylon/` (SMS) | 🟡 | `backend/openshiksha/apps/core/emails.py` | **Replaced** with email (no SMS in modern). Phase 1 (grading complete + remedial assigned) shipped; due-date reminder still TODO. Legacy SMS-to-Indian-providers integration intentionally not ported. |
-| `concierge/` | ✅ | `backend/openshiksha/apps/concierge/` + `frontend_modern/src/features/enquiry/EnquirePage.tsx` | `Enquirer` model + public POST + `notify_enquiry_received` (mail_admins) + V2 page (M3-03 #199). **Activation gap:** `ADMINS` is not set in `settings/`, so the email currently no-ops. See the "Known gaps" section. |
+| `pylon/` (SMS) | ✅ | `backend/openshiksha/apps/core/emails.py` | **Replaced** with email (no SMS in modern). Grading-complete, remedial-assigned, and due-date reminder emails are shipped; students can opt out of due-date reminders in Profile. Legacy SMS-to-Indian-providers integration intentionally not ported. |
+| `concierge/` | ✅ | `backend/openshiksha/apps/concierge/` + `frontend_modern/src/features/enquiry/EnquirePage.tsx` | `Enquirer` model + public POST + `notify_enquiry_received` (mail_admins) + V2 page (M3-03 #199). `ADMINS` is loaded from `OPENSHIKSHA_ADMIN_EMAILS`, so enquiry email delivery is activated when the env var is set. |
 | `lodge/` | ✅ | `backend/openshiksha/apps/lodge/` + `frontend_modern/src/features/student/VideosPanel.tsx` | `Video` model + `GET /api/videos/?chapter=<id>`; `VideosPanel` renders per-chapter videos on Assignment detail. M4-06b-ii (#189) reskinned to V2. |
-| `ink/` (Dossier) | 🟡 | `User.phone_number`, `User.email` (`shared/ProfilePage.tsx`) | Primary email + phone ported. **`secondaryPhone` / `secondaryEmail` / `flagged`** intentionally skipped — legacy CRM-only fields, not user-facing product. |
+| `ink/` (Dossier) | ✅ | `User.phone_number`, `User.email` (`shared/ProfilePage.tsx`) | Primary email, phone, due-date email preference, and password change are ported. **`secondaryPhone` / `secondaryEmail` / `flagged`** intentionally skipped - legacy CRM-only fields, not user-facing product. |
 | `challenge/` | ⛔ | n/a | A memorisation-game / honeypot view rendering a 1000-element RANDOM_DATA list. No identified product value; deliberately not ported. |
 | `frontend/` (Django templates) | ⛔ | n/a — replaced wholesale | The legacy Django-template UI was superseded by `frontend_modern/` React app. |
 
@@ -48,7 +48,7 @@
 | Chapter videos | `lodge.Video` | `VideosPanel` (per-chapter, conditional render) | ✅ V2 (M4-06b-ii #189) |
 | Question images | `cabinet` base64 | `QuestionSubpart.image_url` URLField | ✅ (#86) |
 | Hints + worked solutions | `cabinet` `solution`, `hint` fields | `QuestionSubpart.solution_text` + `hint_text` | ✅ |
-| Profile / settings | `ink.Dossier` | `ProfilePage` + `PATCH /users/me/profile/` | ✅ V2 (M4-08 #180); password change still TODO |
+| Profile / settings | `ink.Dossier` | `ProfilePage` + `PATCH /users/me/profile/` + `POST /users/me/password/` | ✅ V2 (M4-08 #180); password change shipped |
 | Mobile primary navigation | n/a (legacy was desktop-only) | `BottomNav` (Home/Browse/Path/Profile) | ✅ (M5-01 #195) |
 | AI tutor / Socratic chat | none in legacy | branch `ai/2026-06-04-ai-tutor-chat` (in flight) | 🟡 (separate track) |
 
@@ -93,38 +93,28 @@
 
 ## Known gaps (TODO)
 
-1. **`concierge` enquiry email delivery.** `notify_enquiry_received` calls
-   `mail_admins(...)` correctly, but `ADMINS` isn't set in any `settings/`
-   module — so the email no-ops in both dev and prod. Enquiries are still
-   captured in the DB (visible at `/admin/concierge/enquirer/`). Fix: load
-   `ADMINS` from `OPENSHIKSHA_ADMIN_EMAILS` env var in `settings/production.py`.
-   *Small follow-up; ~5 lines.*
+No user-facing legacy parity gaps remain.
 
-2. **Due-date email reminder** (legacy `pylon` had SMS equivalent). The Phase 2
-   note in `CLAUDE.md` flags this — Celery beat schedule already exists for
-   `send_due_date_reminders`, but the email template + per-student opt-out
-   are TODO.
+Closed in follow-up work after the 2026-06-04 audit:
 
-3. **Password change** on the Profile page. Backend endpoint pending; UI
-   placeholder noted in `M4-08`.
+1. **`concierge` enquiry email delivery.** `ADMINS` now comes from
+   `OPENSHIKSHA_ADMIN_EMAILS`; `mail_admins(...)` sends when the env var is set.
+2. **Due-date email reminders.** `send_due_date_reminders` is scheduled,
+   idempotent via `AssignmentReminder`, and respects `email_reminders_opt_out`.
+3. **Password change.** Profile now uses `POST /api/v1/users/me/password/`.
+4. **Question file upload.** Teacher authoring can upload an image and store the
+   returned `image_url`; URL paste remains as a fallback.
+5. **Question Bank chapter filter UI.** The filter bar includes a subject-scoped
+   chapter selector wired to `?chapter=`.
 
-4. **Question file upload** (replace URL pasting with a real upload). The
-   `QuestionSubpart.image_url` URLField was Phase 1; a
-   `POST /api/questions/<id>/upload-image/` endpoint + drag-and-drop UI is
-   the next slice.
+Intentionally skipped:
 
-5. **Browse/Question-Bank chapter filter UI.** Backend supports `?chapter=`
-   already; the chapter selector isn't in the QuestionBank filter bar yet
-   (Browse has Subject + Grade only). Small frontend follow-up; M7-03's
-   remaining slice.
-
-6. **`pylon` SMS** — deliberately not ported. If SMS is ever needed, wire a
-   modern provider (Twilio / MSG91) behind a new `apps/sms/` shim with the
-   same Celery hook points as `emails.py`. Out of scope until product asks.
-
-7. **`ink.Dossier` CRM fields** (secondary email/phone, `flagged`) —
-   deliberately not ported. Legacy CRM workflow lived in Django admin and
-   has no modern user-facing equivalent.
+- **`pylon` SMS.** Modern product uses email. If SMS is ever needed, wire a
+  modern provider (Twilio / MSG91) behind a new `apps/sms/` shim with the same
+  Celery hook points as `emails.py`.
+- **`ink.Dossier` CRM fields** (`secondaryPhone`, `secondaryEmail`, `flagged`).
+  Legacy CRM workflow lived in Django admin and has no modern user-facing
+  equivalent.
 
 ## Activation checklist before retiring a legacy app
 

--- a/frontend_modern/src/api/auth.ts
+++ b/frontend_modern/src/api/auth.ts
@@ -11,6 +11,11 @@ export interface LoginResponse {
   refresh: string;
 }
 
+export interface ChangePasswordRequest {
+  current_password: string;
+  new_password: string;
+}
+
 export const authApi = {
   login: async (credentials: LoginRequest): Promise<LoginResponse> => {
     const response = await apiClient.post<LoginResponse>('/auth/login/', credentials);
@@ -54,6 +59,11 @@ export const authApi = {
     >
   ): Promise<User> => {
     const response = await apiClient.patch<User>('/users/me/profile/', data);
+    return response.data;
+  },
+
+  changePassword: async (data: ChangePasswordRequest): Promise<{ detail: string }> => {
+    const response = await apiClient.post<{ detail: string }>('/users/me/password/', data);
     return response.data;
   },
 };

--- a/frontend_modern/src/features/layout/AppShell.tsx
+++ b/frontend_modern/src/features/layout/AppShell.tsx
@@ -6,7 +6,7 @@ interface AppShellProps {
 }
 
 export const AppShell = ({ children }: AppShellProps) => (
-  <div className="bg-paper min-h-screen">
+  <div className="bg-paper min-h-screen min-h-[100dvh]">
     {/* Skip link — visually hidden until focused, then anchors at top-left.
         Lets keyboard / screen-reader users jump past the Navbar to page content. */}
     <a
@@ -19,7 +19,7 @@ export const AppShell = ({ children }: AppShellProps) => (
     <main
       id="main-content"
       tabIndex={-1}
-      className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 pb-24 sm:pb-8 focus-visible:outline-none"
+      className="max-w-7xl mx-auto px-3 sm:px-6 lg:px-8 py-5 sm:py-8 pb-[calc(6.75rem+env(safe-area-inset-bottom))] sm:pb-8 focus-visible:outline-none"
     >
       {children}
     </main>

--- a/frontend_modern/src/features/layout/BottomNav.tsx
+++ b/frontend_modern/src/features/layout/BottomNav.tsx
@@ -169,11 +169,11 @@ export const BottomNav = () => {
     <nav
       aria-label="Primary"
       className={clsx(
-        'fixed inset-x-0 bottom-0 z-30 border-t border-ink-100 bg-white/95 backdrop-blur sm:hidden',
+        'fixed inset-x-0 bottom-0 z-30 border-t border-ink-100 bg-white/95 shadow-[0_-10px_30px_rgba(23,32,51,0.08)] backdrop-blur sm:hidden',
         'pb-[env(safe-area-inset-bottom)]',
       )}
     >
-      <ul className="mx-auto flex max-w-md items-stretch justify-around px-2 py-1">
+      <ul className="mx-auto flex max-w-md items-stretch justify-around px-2 py-1.5">
         {tabs.map((tab) => {
           const active = isActive(location.pathname, tab);
           return (
@@ -182,13 +182,13 @@ export const BottomNav = () => {
                 to={tab.to}
                 aria-current={active ? 'page' : undefined}
                 className={clsx(
-                  'flex flex-col items-center gap-0.5 rounded-lg px-2 py-1.5 text-[11px] font-semibold transition-colors',
+                  'flex min-h-14 flex-col items-center justify-center gap-0.5 rounded-lg px-1.5 py-1 text-[11px] font-semibold leading-tight transition-colors',
                   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500',
                   active ? 'text-brand-700' : 'text-ink-500 hover:text-ink-800',
                 )}
               >
                 <span aria-hidden>{tab.icon}</span>
-                <span>{tab.label}</span>
+                <span className="max-w-full truncate">{tab.label}</span>
               </Link>
             </li>
           );

--- a/frontend_modern/src/features/shared/ProfilePage.tsx
+++ b/frontend_modern/src/features/shared/ProfilePage.tsx
@@ -6,13 +6,14 @@ import { UserRole } from '@/types/index';
 import { Button, Card, Input, SectionHeading } from '@/shared/ui';
 import type { AxiosError } from 'axios';
 
-function extractError(err: unknown): string {
-  const axiosErr = err as AxiosError<Record<string, string[]>>;
+function extractError(err: unknown, fallback = 'Save failed. Please try again.'): string {
+  const axiosErr = err as AxiosError<Record<string, string[] | string>>;
   const data = axiosErr?.response?.data;
-  if (!data) return 'Save failed. Please try again.';
+  if (!data) return fallback;
   const firstKey = Object.keys(data)[0];
   if (firstKey && Array.isArray(data[firstKey])) return data[firstKey][0];
-  return 'Save failed. Please try again.';
+  if (firstKey && typeof data[firstKey] === 'string') return data[firstKey];
+  return fallback;
 }
 
 export const ProfilePage = () => {
@@ -27,6 +28,12 @@ export const ProfilePage = () => {
   });
   const [emailRemindersOptOut, setEmailRemindersOptOut] = useState(false);
   const [savedMsg, setSavedMsg] = useState(false);
+  const [passwordForm, setPasswordForm] = useState({
+    current_password: '',
+    new_password: '',
+    confirm_password: '',
+  });
+  const [passwordSavedMsg, setPasswordSavedMsg] = useState(false);
 
   const isStudent = user?.role === UserRole.STUDENT || user?.role === UserRole.OPEN_STUDENT;
 
@@ -54,6 +61,15 @@ export const ProfilePage = () => {
     },
   });
 
+  const passwordMutation = useMutation({
+    mutationFn: authApi.changePassword,
+    onSuccess: () => {
+      setPasswordForm({ current_password: '', new_password: '', confirm_password: '' });
+      setPasswordSavedMsg(true);
+      setTimeout(() => setPasswordSavedMsg(false), 3000);
+    },
+  });
+
   const set = (field: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement>) =>
     setForm((prev) => ({ ...prev, [field]: e.target.value }));
 
@@ -64,8 +80,24 @@ export const ProfilePage = () => {
     );
   };
 
+  const setPassword = (field: keyof typeof passwordForm) => (e: React.ChangeEvent<HTMLInputElement>) =>
+    setPasswordForm((prev) => ({ ...prev, [field]: e.target.value }));
+
+  const handlePasswordSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (passwordForm.new_password !== passwordForm.confirm_password) return;
+    passwordMutation.mutate({
+      current_password: passwordForm.current_password,
+      new_password: passwordForm.new_password,
+    });
+  };
+
+  const passwordMismatch =
+    passwordForm.confirm_password.length > 0 &&
+    passwordForm.new_password !== passwordForm.confirm_password;
+
   return (
-    <div className="max-w-xl">
+    <div className="max-w-xl space-y-6">
       <SectionHeading as="h1" title="Profile Settings" className="mb-6" />
 
       <Card>
@@ -162,6 +194,77 @@ export const ProfilePage = () => {
             <div className="flex justify-end pt-2">
               <Button type="submit" disabled={mutation.isPending}>
                 {mutation.isPending ? 'Saving…' : 'Save Changes'}
+              </Button>
+            </div>
+          </div>
+        </form>
+      </Card>
+
+      <Card>
+        <form onSubmit={handlePasswordSubmit} noValidate>
+          <div className="space-y-4">
+            <div>
+              <h2 className="font-display text-lg font-semibold text-ink-900">Change password</h2>
+              <p className="mt-1 text-sm text-ink-500">
+                Use a fresh password that you do not use on other sites.
+              </p>
+            </div>
+
+            <Input
+              label="Current password"
+              id="current_password"
+              type="password"
+              value={passwordForm.current_password}
+              onChange={setPassword('current_password')}
+              disabled={passwordMutation.isPending}
+              autoComplete="current-password"
+            />
+
+            <Input
+              label="New password"
+              id="new_password"
+              type="password"
+              value={passwordForm.new_password}
+              onChange={setPassword('new_password')}
+              disabled={passwordMutation.isPending}
+              autoComplete="new-password"
+            />
+
+            <Input
+              label="Confirm new password"
+              id="confirm_password"
+              type="password"
+              value={passwordForm.confirm_password}
+              onChange={setPassword('confirm_password')}
+              disabled={passwordMutation.isPending}
+              autoComplete="new-password"
+              error={passwordMismatch ? 'Passwords do not match.' : undefined}
+            />
+
+            {passwordMutation.isError && (
+              <div className="rounded-lg bg-rose-50 border border-rose-200 px-4 py-3 text-sm text-rose-700" role="alert">
+                {extractError(passwordMutation.error, 'Password change failed. Please try again.')}
+              </div>
+            )}
+
+            {passwordSavedMsg && (
+              <div className="rounded-lg bg-emerald-50 border border-emerald-200 px-4 py-3 text-sm text-emerald-700" role="status">
+                Password changed successfully.
+              </div>
+            )}
+
+            <div className="flex justify-end pt-2">
+              <Button
+                type="submit"
+                disabled={
+                  passwordMutation.isPending ||
+                  !passwordForm.current_password ||
+                  !passwordForm.new_password ||
+                  !passwordForm.confirm_password ||
+                  passwordMismatch
+                }
+              >
+                {passwordMutation.isPending ? 'Updating...' : 'Update Password'}
               </Button>
             </div>
           </div>

--- a/frontend_modern/src/features/student/AssignmentCard.tsx
+++ b/frontend_modern/src/features/student/AssignmentCard.tsx
@@ -32,7 +32,7 @@ export const AssignmentCard = ({ assignment }: AssignmentCardProps) => {
 
   return (
     <div
-      className={`os-card p-5 hover:shadow-md transition-shadow motion-reduce:transition-none ${
+      className={`os-card w-full min-w-0 p-5 hover:shadow-md transition-shadow motion-reduce:transition-none ${
         // Submitted cards get a subtle emerald edge so the difference reads
         // at a glance in a mixed list, without leaning on color alone (the
         // "Submitted" label + score badge + ghost CTA still carry the
@@ -40,7 +40,7 @@ export const AssignmentCard = ({ assignment }: AssignmentCardProps) => {
         isSubmitted ? 'border-emerald-200/80 bg-emerald-50/30' : ''
       }`}
     >
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-1">
             <p className="text-xs font-semibold text-brand-700 uppercase tracking-wide">
@@ -84,9 +84,9 @@ export const AssignmentCard = ({ assignment }: AssignmentCardProps) => {
         </div>
       )}
 
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mt-4">
+      <div className="flex min-w-0 flex-col gap-3 mt-4 sm:flex-row sm:items-center sm:justify-between">
         <span
-          className={`text-xs ${
+          className={`min-w-0 text-xs ${
             isSubmitted
               ? 'text-emerald-700 font-medium'
               : isOverdue

--- a/frontend_modern/src/features/teacher/CreateQuestionPage.tsx
+++ b/frontend_modern/src/features/teacher/CreateQuestionPage.tsx
@@ -9,6 +9,7 @@ import { useCreateQuestion } from './useCreateQuestion';
 import { useUpdateQuestion } from './useUpdateQuestion';
 import { useQuestion } from './useQuestion';
 import { useGenerateQuestions } from './useGenerateQuestions';
+import { useUploadQuestionImage } from './useUploadQuestionImage';
 import type {
   MCQOption,
   QuestionSubpartWrite,
@@ -469,6 +470,7 @@ export const CreateQuestionPage = ({ editMode = false }: { editMode?: boolean })
   const createQuestion = useCreateQuestion();
   const updateQuestion = useUpdateQuestion();
   const { data: existingQuestion, isLoading: loadingExisting } = useQuestion(editId);
+  const uploadImage = useUploadQuestionImage();
 
   // Pre-fill form in edit mode when the loaded question changes (during render — react.dev/learn/you-might-not-need-an-effect)
   const [prefilledFrom, setPrefilledFrom] = useState<typeof existingQuestion | undefined>(undefined);
@@ -506,6 +508,13 @@ export const CreateQuestionPage = ({ editMode = false }: { editMode?: boolean })
   const updateSubpart = useCallback((idx: number, patch: Partial<SubpartDraft>) => {
     setSubparts((prev) => prev.map((s, i) => (i === idx ? { ...s, ...patch } : s)));
   }, []);
+
+  const handleImageUpload = (idx: number, file: File | undefined) => {
+    if (!file) return;
+    uploadImage.mutate(file, {
+      onSuccess: (data) => updateSubpart(idx, { image_url: data.image_url }),
+    });
+  };
 
   const handleTextChange = useCallback(
     (idx: number, value: string, currentConstraints: Record<string, VariableSpec>) => {
@@ -878,10 +887,31 @@ export const CreateQuestionPage = ({ editMode = false }: { editMode?: boolean })
               <input
                 type="url"
                 className="w-full border border-ink-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
-                placeholder="https://example.com/diagram.png"
+                placeholder="Paste an image URL or upload a file"
                 value={current.image_url}
                 onChange={(e) => updateSubpart(activeSubpart, { image_url: e.target.value })}
               />
+              <div className="mt-2 flex flex-wrap items-center gap-2">
+                <label className="inline-flex cursor-pointer items-center justify-center rounded-lg border border-ink-200 bg-white px-3 py-2 text-sm font-medium text-ink-700 hover:border-brand-300 hover:text-brand-700">
+                  {uploadImage.isPending ? 'Uploading...' : 'Upload image'}
+                  <input
+                    type="file"
+                    accept="image/*"
+                    className="sr-only"
+                    disabled={uploadImage.isPending}
+                    onChange={(e) => {
+                      handleImageUpload(activeSubpart, e.target.files?.[0]);
+                      e.target.value = '';
+                    }}
+                  />
+                </label>
+                <span className="text-xs text-ink-400">PNG, JPG, GIF, or WebP under 5 MB.</span>
+              </div>
+              {uploadImage.isError && (
+                <p className="mt-1 text-xs font-medium text-rose-600">
+                  Image upload failed. Try a PNG, JPG, GIF, or WebP under 5 MB.
+                </p>
+              )}
               {current.image_url.trim() && (
                 <img
                   src={current.image_url}

--- a/frontend_modern/src/features/teacher/useUploadQuestionImage.ts
+++ b/frontend_modern/src/features/teacher/useUploadQuestionImage.ts
@@ -1,0 +1,18 @@
+import { useMutation } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+
+interface UploadQuestionImageResponse {
+  image_url: string;
+}
+
+const uploadQuestionImage = async (file: File): Promise<UploadQuestionImageResponse> => {
+  const body = new FormData();
+  body.append('image', file);
+  const response = await apiClient.post<UploadQuestionImageResponse>('/questions/upload-image/', body);
+  return response.data;
+};
+
+export const useUploadQuestionImage = () =>
+  useMutation<UploadQuestionImageResponse, Error, File>({
+    mutationFn: uploadQuestionImage,
+  });


### PR DESCRIPTION
## Summary
- close the remaining legacy parity gaps with self-service password change and teacher question image uploads
- harden the mobile shell/bottom nav and fix student assignment-card overflow at phone width
- update initiative docs to mark legacy parity + current mobile shell scope closed, with IW-9/IW-10/IW-11 deferred for product validation

## Verification
- npm run type-check
- npm test -- --run src/features/layout/BottomNav.test.tsx src/features/widgets/WidgetDevPage.test.tsx
- docker compose exec -T backend pytest --no-cov openshiksha/apps/api/tests/test_core_api.py::TestUserMeEndpoint openshiksha/apps/api/tests/test_core_api.py::TestQuestionSubpartImageUrl openshiksha/tests/test_admin_emails_env.py openshiksha/apps/core/tests/test_due_date_reminders.py
- Browser smoke at 390px wide with student_demo and teacher_demo: dashboard/profile/question creator had no horizontal overflow; bottom tabs fit; password card and image upload controls were visible

## Notes
- Ran docker compose exec -T backend python manage.py migrate locally before reseeding demo data because the local Docker database was missing ai.0012_questiondifficultycalibration.
- Developer-authored widgets remain available through npm run widget:new, /widgets/dev, and the question creator once registered.
