### PR TITLE
polish(ai): weekly reports — AI-generated label + generation error state

### DIFF
--- a/docs/ai-features/polish-backlog.md
+++ b/docs/ai-features/polish-backlog.md
@@ -35,6 +35,35 @@ not fake drafts. With a key set, drafts render as before.
 
 ---
 
+## 2026-06-07 — Weekly class reports: AI-generated label + generation error state
+
+**Surface:** Weekly class reports (teacher dashboard `WeeklyReportPanel`).
+
+**Gaps (checklist #1 error states, #3 copy/tone, #7 provider transparency):**
+1. The LLM-written `summary_text` was shown with **no indication it was
+   AI-generated** — teachers had no signal the narrative came from a model.
+2. When `model_used === 'stub'` (no LLM key — deterministic data-derived
+   fallback), the stub text was presented identically to genuine AI output,
+   violating provider-cascade transparency.
+3. `handleGenerate` **silently swallowed errors**: if the generate POST failed,
+   the panel just reverted to the empty "No weekly summary yet" state with no
+   feedback, so a teacher couldn't tell the click had failed.
+
+**Fix:**
+- Added a small `Badge` on the report card: `✨ AI-generated` (brand tone) for a
+  real LLM, or `Auto-summary` (neutral tone) plus an "AI was unavailable, so this
+  was built directly from your class data" note when `model_used === 'stub'`.
+- Added a friendly inline error message ("Couldn't generate the summary just now.
+  Please try again in a moment.") on generation failure.
+- New test file `WeeklyReportPanel.test.tsx` covers the AI label, the stub
+  auto-summary path, and the generation-error path (checklist #8).
+
+**Verify:** Expand "Weekly AI Summary" on the teacher dashboard. With a provider
+key set the report shows the ✨ AI-generated badge; with no key the stub summary
+shows the Auto-summary badge + note. Trigger a failing generate → red error line.
+
+---
+
 ## Remaining gaps (audit notes — not yet addressed)
 
 - **Natural language explanations** — backend `SubpartExplanationViewSet` is
@@ -42,10 +71,11 @@ not fake drafts. With a key set, drafts render as before.
   `frontend_modern`**. The post-grading student feedback surface appears to be
   unwired in the V2 app. Needs UX placement work (inline after feedback) — sizeable,
   flag before treating as polish vs. feature.
-- **Other generation surfaces** (weekly reports, parent summaries, class summary,
-  interventions) use the same stub-cascade pattern. Audit each for whether the
-  stub model leaks to the UI as if it were real content, mirroring the
-  question-generation fix above. `generate_class_summary` returns
-  `{"text", "model"}` — check the view/UI actually distinguish `model == "stub"`.
+- **Parent summaries (`NarrativeCard`) + interventions (`InterventionsPanel`)**
+  still display LLM narrative text with **no AI-generated / stub badge**, unlike
+  the now-fixed `WeeklyReportPanel`. Both already receive `model_used` from their
+  serializers — apply the same `✨ AI-generated` vs `Auto-summary` badge for
+  consistency (one surface per run). `NarrativeCard` has no badge at all;
+  `InterventionsPanel` only has a footer disclaimer line.
 - **Hint system** — solid: loading ("Thinking of a good hint…"), error, and
   exhausted states all present. Low priority.

--- a/frontend_modern/src/features/teacher/WeeklyReportPanel.test.tsx
+++ b/frontend_modern/src/features/teacher/WeeklyReportPanel.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { WeeklyReportPanel } from './WeeklyReportPanel';
+import type { WeeklyClassReport } from './useWeeklyReport';
+
+const { mockGet, mockPost } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPost: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    get: mockGet,
+    post: mockPost,
+  },
+}));
+
+const REPORT: WeeklyClassReport = {
+  id: 3,
+  subject_room: 1,
+  subject_name: 'Mathematics',
+  classroom_label: 'Std 8 A',
+  week_start: '2026-06-01',
+  week_end: '2026-06-07',
+  summary_text: 'The class practised steadily this week and is improving in algebra.',
+  total_students: 30,
+  active_students: 24,
+  participation_rate: 0.8,
+  ticks_recorded: 312,
+  class_avg_score: 0.74,
+  struggling_chapters: [
+    { chapter_id: 1, chapter_name: 'Fractions', avg_score: 0.42, tick_count: 40 },
+  ],
+  strong_chapters: [{ chapter_id: 2, chapter_name: 'Algebra', avg_score: 0.88, tick_count: 60 }],
+  model_used: 'claude-sonnet-4-6',
+  generated_at: '2026-06-07T10:00:00Z',
+};
+
+function renderPanel() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <WeeklyReportPanel subjectRoomId={1} />
+    </QueryClientProvider>
+  );
+}
+
+describe('WeeklyReportPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not fetch until expanded', () => {
+    mockGet.mockResolvedValue({ data: REPORT });
+    renderPanel();
+    expect(screen.getByText('Weekly AI Summary')).toBeDefined();
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('labels a real LLM report as AI-generated', async () => {
+    mockGet.mockResolvedValue({ data: REPORT });
+    renderPanel();
+
+    fireEvent.click(screen.getByText('Weekly AI Summary'));
+
+    await waitFor(() => expect(screen.getByText(/improving in algebra/)).toBeDefined());
+    expect(screen.getByText('✨ AI-generated')).toBeDefined();
+  });
+
+  it('marks a stub fallback as an auto-summary rather than AI output', async () => {
+    mockGet.mockResolvedValue({ data: { ...REPORT, model_used: 'stub' } });
+    renderPanel();
+
+    fireEvent.click(screen.getByText('Weekly AI Summary'));
+
+    await waitFor(() => expect(screen.getByText('Auto-summary')).toBeDefined());
+    expect(screen.getByText(/AI was unavailable/)).toBeDefined();
+    expect(screen.queryByText('✨ AI-generated')).toBeNull();
+  });
+
+  it('surfaces an error when generation fails instead of silently reverting', async () => {
+    mockGet.mockRejectedValue({ response: { status: 404 } });
+    mockPost.mockRejectedValue(new Error('boom'));
+    renderPanel();
+
+    fireEvent.click(screen.getByText('Weekly AI Summary'));
+
+    await waitFor(() => expect(screen.getByText(/No weekly summary yet/)).toBeDefined());
+    fireEvent.click(screen.getByText('Generate'));
+
+    await waitFor(() => expect(screen.getByText(/Couldn't generate the summary/)).toBeDefined());
+  });
+});

--- a/frontend_modern/src/features/teacher/WeeklyReportPanel.tsx
+++ b/frontend_modern/src/features/teacher/WeeklyReportPanel.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { apiClient } from '@/api/client';
 import { useWeeklyReport } from './useWeeklyReport';
-import { Button } from '@/shared/ui';
+import { Badge, Button } from '@/shared/ui';
 
 const triggerWeeklyReport = async (subjectRoomId: number): Promise<void> => {
   await apiClient.post('/ai/weekly-reports/generate/', { subject_room_id: subjectRoomId });
@@ -17,11 +17,13 @@ interface Props {
 export const WeeklyReportPanel = ({ subjectRoomId }: Props) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
+  const [genError, setGenError] = useState(false);
 
   const { data: report, isLoading, refetch } = useWeeklyReport(subjectRoomId, isExpanded);
 
   const handleGenerate = async () => {
     setIsGenerating(true);
+    setGenError(false);
     try {
       await triggerWeeklyReport(subjectRoomId);
       setTimeout(() => {
@@ -29,9 +31,17 @@ export const WeeklyReportPanel = ({ subjectRoomId }: Props) => {
         setIsGenerating(false);
       }, 2500);
     } catch {
+      // Surface the failure rather than silently reverting to the empty state —
+      // a teacher who clicked "Generate" needs to know it did not work.
+      setGenError(true);
       setIsGenerating(false);
     }
   };
+
+  // The provider cascade falls back to a deterministic, data-derived summary when
+  // no LLM key is configured. That text is still useful, but we must not present
+  // it as genuine AI output (provider-cascade transparency).
+  const isStub = report?.model_used === 'stub';
 
   return (
     <div className="mt-3 border-t border-ink-100 pt-3">
@@ -69,14 +79,30 @@ export const WeeklyReportPanel = ({ subjectRoomId }: Props) => {
             </div>
           )}
 
+          {genError && (
+            <p className="mt-2 rounded-lg bg-rose-50 px-3 py-2 text-xs text-rose-700">
+              Couldn't generate the summary just now. Please try again in a moment.
+            </p>
+          )}
+
           {!isLoading && report && (
             <div className="rounded-xl border border-brand-100 bg-brand-50/60 p-3">
-              <p className="text-xs font-semibold text-brand-800">
-                Week of {formatDate(report.week_start)} – {formatDate(report.week_end)}
-              </p>
+              <div className="flex items-start justify-between gap-2">
+                <p className="text-xs font-semibold text-brand-800">
+                  Week of {formatDate(report.week_start)} – {formatDate(report.week_end)}
+                </p>
+                <Badge tone={isStub ? 'neutral' : 'brand'}>
+                  {isStub ? 'Auto-summary' : '✨ AI-generated'}
+                </Badge>
+              </div>
               <p className="mt-1.5 text-sm leading-relaxed text-ink-700">
                 {report.summary_text}
               </p>
+              {isStub && (
+                <p className="mt-1.5 text-xs text-ink-400">
+                  AI was unavailable, so this was built directly from your class data.
+                </p>
+              )}
 
               <div className="mt-2.5 flex flex-wrap gap-x-4 gap-y-1 text-xs text-ink-500">
                 <span>


### PR DESCRIPTION
## Surface
Weekly class reports (teacher dashboard `WeeklyReportPanel`).

## Gaps fixed
Audited against the 8-point AI-polish checklist:

1. **Copy/tone (#3)** — the LLM-written `summary_text` was shown with no signal it was AI-generated.
2. **Provider transparency (#7)** — when the provider cascade fell back to the deterministic stub (`model_used === 'stub'`, no LLM key), that text was presented identically to genuine AI output.
3. **Error state (#1)** — `handleGenerate` silently swallowed errors; a failed generate POST just reverted to the empty "No weekly summary yet" state with no feedback.

## Before / after
- **Before:** narrative text with no label; stub text indistinguishable from real AI; failed generate looked like "nothing happened".
- **After:**
  - `✨ AI-generated` badge (brand) for a real LLM report.
  - `Auto-summary` badge (neutral) + "AI was unavailable, so this was built directly from your class data." note when the stub ran.
  - Friendly inline error ("Couldn't generate the summary just now. Please try again in a moment.") on generation failure.

## How to verify
Expand **Weekly AI Summary** on the teacher dashboard:
- With a provider key set → report shows the ✨ AI-generated badge.
- With no key (stub) → Auto-summary badge + note.
- Trigger a failing generate → red inline error instead of a silent revert.

## Tests
New `WeeklyReportPanel.test.tsx` covers the AI label, stub auto-summary path, and the generation-error path. `npx vitest run` green; `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)