### PR TITLE
Rework teacher dashboard: fix join code, student preview, declutter

### DIFF
--- a/backend/openshiksha/apps/api/tests/test_problemset_api.py
+++ b/backend/openshiksha/apps/api/tests/test_problemset_api.py
@@ -314,3 +314,72 @@ class TestAddQuestionToProblemSet:
         url = f"/api/v1/problem-sets/{problem_set.pk}/add-question/"
         response = api_client.post(url, {"question_id": 99999}, format="json")
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestProblemSetStudentPreview:
+    """Tests for GET /api/v1/problem-sets/<id>/preview/ (view-as-student)."""
+
+    def test_teacher_can_preview_with_questions(self, api_client, teacher, problem_set, question):
+        api_client.force_authenticate(user=teacher)
+        url = f"/api/v1/problem-sets/{problem_set.pk}/preview/"
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["id"] == problem_set.pk
+        assert len(response.data["questions"]) == 1
+        assert response.data["questions"][0]["id"] == question.pk
+        assert len(response.data["questions"][0]["subparts"]) == 1
+
+    def test_preview_hides_correct_answer(self, api_client, teacher, problem_set):
+        """The student serializer must never leak the correct answer."""
+        api_client.force_authenticate(user=teacher)
+        url = f"/api/v1/problem-sets/{problem_set.pk}/preview/"
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        subpart = response.data["questions"][0]["subparts"][0]
+        assert "correct_answer" not in subpart
+
+    def test_student_cannot_preview(self, api_client, student, problem_set):
+        api_client.force_authenticate(user=student)
+        url = f"/api/v1/problem-sets/{problem_set.pk}/preview/"
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_preview_unknown_set_returns_404(self, api_client, teacher):
+        api_client.force_authenticate(user=teacher)
+        response = api_client.get("/api/v1/problem-sets/99999/preview/")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestClassroomCodeForSubjectTeacher:
+    """The join code must work for a subject teacher who is *not* the homeroom
+    ``class_teacher`` — the dashboard surfaces it per subject room."""
+
+    def test_subject_teacher_can_generate_code(self, api_client, teacher, classroom, subject_room):
+        # `teacher` runs `subject_room` in `classroom` but is NOT its class_teacher.
+        assert classroom.class_teacher_id is None
+        api_client.force_authenticate(user=teacher)
+        url = "/api/v1/users/me/classroom-code/"
+        response = api_client.post(url, {"classroom_id": classroom.pk}, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["code"]
+        assert response.data["classroom_id"] == classroom.pk
+
+    def test_subject_teacher_sees_code_in_list(self, api_client, teacher, classroom, subject_room):
+        api_client.force_authenticate(user=teacher)
+        url = "/api/v1/users/me/classroom-code/"
+        api_client.post(url, {"classroom_id": classroom.pk}, format="json")
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert any(c["classroom_id"] == classroom.pk for c in response.data)
+
+    def test_unrelated_teacher_cannot_generate_code(self, api_client, school, classroom):
+        outsider = User.objects.create_user(
+            username="outsider_teacher",
+            password="pass",
+            role=UserRole.TEACHER,
+            school=school,
+        )
+        api_client.force_authenticate(user=outsider)
+        url = "/api/v1/users/me/classroom-code/"
+        response = api_client.post(url, {"classroom_id": classroom.pk}, format="json")
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/openshiksha/apps/api/views/core.py
+++ b/backend/openshiksha/apps/api/views/core.py
@@ -185,24 +185,37 @@ class UserViewSet(viewsets.GenericViewSet):
     @action(detail=False, methods=["get", "post"], url_path="me/classroom-code", permission_classes=[IsTeacher])
     def classroom_code(self, request):
         """
-        GET  — returns all active join codes for classrooms taught by this teacher.
+        GET  — returns all active join codes for classrooms this teacher can manage.
         POST — generates a new code for a specified classroom (body: {classroom_id}).
+
+        A classroom is manageable by its homeroom ``class_teacher`` **and** by any
+        teacher who runs a ``SubjectRoom`` inside it. The dashboard surfaces the
+        join code per subject room, so a subject teacher (who is usually *not*
+        the homeroom teacher) must be able to generate and read it — otherwise
+        the widget silently 404s for them.
         """
-        from django.shortcuts import get_object_or_404
+        from django.db.models import Q
 
         from openshiksha.apps.api.serializers.core import ClassroomInviteCodeSerializer
         from openshiksha.apps.core.models import ClassRoom, ClassroomInviteCode
 
+        manageable = Q(class_teacher=request.user) | Q(subject_rooms__teacher=request.user)
+
         if request.method == "GET":
-            codes = ClassroomInviteCode.objects.filter(
-                classroom__class_teacher=request.user, is_active=True
-            ).select_related("classroom")
+            codes = (
+                ClassroomInviteCode.objects.filter(is_active=True)
+                .filter(Q(classroom__class_teacher=request.user) | Q(classroom__subject_rooms__teacher=request.user))
+                .select_related("classroom")
+                .distinct()
+            )
             return Response(ClassroomInviteCodeSerializer(codes, many=True).data)
 
         classroom_id = request.data.get("classroom_id")
         if not classroom_id:
             return Response({"detail": "classroom_id is required."}, status=400)
-        classroom = get_object_or_404(ClassRoom, id=classroom_id, class_teacher=request.user)
+        classroom = ClassRoom.objects.filter(manageable, id=classroom_id).distinct().first()
+        if classroom is None:
+            return Response({"detail": "Classroom not found, or you do not teach in it."}, status=404)
         ClassroomInviteCode.objects.filter(classroom=classroom).update(is_active=False)
         code = ClassroomInviteCode.objects.create(
             classroom=classroom,
@@ -643,7 +656,10 @@ class ProblemSetViewSet(viewsets.ModelViewSet):
         return ProblemSetSerializer
 
     def get_permissions(self):
-        if self.action in ["create", "update", "partial_update", "destroy"]:
+        # `preview` (view-as-student) is a teacher-only authoring aid — this
+        # overridden get_permissions takes precedence over the @action's own
+        # permission_classes, so it must be listed here explicitly.
+        if self.action in ["create", "update", "partial_update", "destroy", "preview"]:
             return [permissions.IsAuthenticated(), IsTeacher()]
         return [permissions.IsAuthenticated()]
 
@@ -671,6 +687,22 @@ class ProblemSetViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         school = getattr(self.request.user, "school", None)
         serializer.save(school=school, created_by=self.request.user)
+
+    @action(detail=True, methods=["get"], url_path="preview")
+    def preview(self, request, pk=None):
+        """
+        GET /api/v1/problem-sets/<id>/preview/
+
+        Renders the set **exactly as a student sees it** — correct answers
+        stripped, ``{{var}}`` tokens substituted, and MCQ options shuffled via
+        the same student serializer the assignment page uses. Read-only; lets a
+        teacher sanity-check a set before assigning it.
+        """
+        from openshiksha.apps.api.serializers.core import ProblemSetStudentDetailSerializer
+
+        problem_set = get_object_or_404(self.get_queryset(), pk=pk)
+        serializer = ProblemSetStudentDetailSerializer(problem_set, context={"request": request})
+        return Response(serializer.data)
 
     @action(detail=True, methods=["post"], url_path="add-question")
     def add_question(self, request, pk=None):

--- a/frontend_modern/src/App.tsx
+++ b/frontend_modern/src/App.tsx
@@ -22,6 +22,7 @@ import { TeacherDashboard } from './features/teacher/TeacherDashboard';
 import { CreateAssignmentPage } from './features/teacher/CreateAssignmentPage';
 import { CreateQuestionPage } from './features/teacher/CreateQuestionPage';
 import { CreateProblemSetPage } from './features/teacher/CreateProblemSetPage';
+import { ProblemSetPreviewPage } from './features/teacher/ProblemSetPreviewPage';
 import { TeacherAssignmentDetailPage } from './features/teacher/TeacherAssignmentDetailPage';
 import { QuestionBankPage } from './features/teacher/QuestionBankPage';
 import { ParentDashboard } from './features/parent/ParentDashboard';
@@ -192,6 +193,17 @@ function App() {
             <ProtectedRoute>
               <AppShell>
                 <CreateProblemSetPage />
+              </AppShell>
+            </ProtectedRoute>
+          }
+        />
+
+        <Route
+          path="/teacher/problem-sets/:id/preview"
+          element={
+            <ProtectedRoute>
+              <AppShell>
+                <ProblemSetPreviewPage />
               </AppShell>
             </ProtectedRoute>
           }

--- a/frontend_modern/src/features/teacher/ProblemSetPreviewPage.tsx
+++ b/frontend_modern/src/features/teacher/ProblemSetPreviewPage.tsx
@@ -1,0 +1,105 @@
+import { useNavigate, useParams } from 'react-router-dom';
+import { useProblemSetPreview } from './useProblemSetPreview';
+import { QuestionCard } from '../student/QuestionCard';
+import { Button, EmptyState, LoadingSpinner } from '@/shared/ui';
+
+/**
+ * Read-only "view as student" preview of a problem set.
+ *
+ * Renders each question through the **same `<QuestionCard>` students use** on
+ * the assignment page — correct answers stripped, `{{var}}` substituted, MCQs
+ * shuffled (the backend's student serializer does all of that). Inputs are
+ * locked via `isSubmitted` so nothing can be typed or submitted: a teacher is
+ * inspecting, not solving.
+ */
+export const ProblemSetPreviewPage = () => {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const setId = id ? Number(id) : null;
+  const { data, isLoading, isError } = useProblemSetPreview(setId);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <LoadingSpinner size="lg" />
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="mx-auto max-w-2xl px-4 py-10">
+        <EmptyState
+          title="Couldn't load this preview"
+          description="The problem set may have been removed, or you may not have access to it."
+          action={<Button onClick={() => navigate('/teacher')}>Back to dashboard</Button>}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 px-4 py-8">
+      {/* Read-only student-preview banner */}
+      <div className="flex flex-wrap items-center gap-3 rounded-xl border border-brand-200 bg-brand-50 px-4 py-3">
+        <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-brand-100 text-brand-700">
+          <svg viewBox="0 0 20 20" className="h-4 w-4" fill="currentColor">
+            <path d="M10 4C5.5 4 2 7.5 1 10c1 2.5 4.5 6 9 6s8-3.5 9-6c-1-2.5-4.5-6-9-6zm0 9a3 3 0 110-6 3 3 0 010 6z" />
+          </svg>
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold text-brand-900">Student preview · read-only</p>
+          <p className="text-xs text-brand-700">
+            This is exactly how students see the set — answers hidden, variables filled in. You
+            can't type or submit here.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => navigate(-1)}
+          className="text-sm font-medium text-brand-700 hover:text-brand-900"
+        >
+          ← Back
+        </button>
+      </div>
+
+      {/* Set header */}
+      <div>
+        <h1 className="font-display text-2xl font-semibold text-ink-900">{data.title}</h1>
+        <p className="mt-1 text-sm text-ink-500">
+          {data.subject_name && <span>{data.subject_name}</span>}
+          {data.chapter_name && <span> · {data.chapter_name}</span>}
+          <span> · {data.question_count} question{data.question_count !== 1 ? 's' : ''}</span>
+          {data.estimated_minutes != null && <span> · ~{data.estimated_minutes} min</span>}
+        </p>
+      </div>
+
+      {/* Questions — rendered exactly as a student sees them, locked */}
+      {data.questions.length === 0 ? (
+        <EmptyState
+          title="This set has no questions yet"
+          description="Add questions to the set, then preview again."
+        />
+      ) : (
+        <div className="space-y-4">
+          {data.questions.map((q, i) => (
+            <QuestionCard
+              key={q.id}
+              question={q}
+              questionNumber={i + 1}
+              answers={{}}
+              onAnswerChange={() => {}}
+              isSubmitted
+            />
+          ))}
+        </div>
+      )}
+
+      <div className="flex justify-end border-t border-ink-100 pt-5">
+        <Button variant="ghost" onClick={() => navigate('/teacher')}>
+          Back to dashboard
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/frontend_modern/src/features/teacher/TeacherDashboard.tsx
+++ b/frontend_modern/src/features/teacher/TeacherDashboard.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSubjectRooms } from './useSubjectRooms';
 import { useTeacherAssignments } from './useTeacherAssignments';
+import { useProblemSets } from './useProblemSets';
 import { ClassHealthPanel } from './ClassHealthPanel';
 import { WeeklyReportPanel } from './WeeklyReportPanel';
 import { InterventionsPanel } from './InterventionsPanel';
@@ -54,42 +56,84 @@ const AssignmentRow = ({ assignment }: { assignment: Assignment }) => {
   );
 };
 
+/**
+ * The four analytics panels used to render eagerly inside every subject-room
+ * card — four data-fetching panels per room, stacked open, on first paint.
+ * They now live behind one disclosure and only mount (and fetch) when a teacher
+ * actually opens them. Default state of a room card is lean: identity + assign.
+ */
+const RoomInsights = ({ subjectRoomId }: { subjectRoomId: number }) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="mt-4 border-t border-ink-100 pt-3">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-1.5 text-left text-xs font-semibold text-ink-600 transition-colors hover:text-ink-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded"
+      >
+        <span className="text-ink-400">{open ? '▾' : '▸'}</span>
+        {open ? 'Hide class insights' : 'View class insights'}
+      </button>
+      {open && (
+        <div className="mt-3 space-y-3">
+          <ClassHealthPanel subjectRoomId={subjectRoomId} />
+          <WeeklyReportPanel subjectRoomId={subjectRoomId} />
+          <InterventionsPanel subjectRoomId={subjectRoomId} />
+          <QuestionQualityPanel subjectRoomId={subjectRoomId} />
+        </div>
+      )}
+    </div>
+  );
+};
+
 export const TeacherDashboard = () => {
   const navigate = useNavigate();
   const { data: subjectRooms, isLoading: roomsLoading } = useSubjectRooms();
   const { data: assignments, isLoading: assignmentsLoading } = useTeacherAssignments();
+  const { data: problemSets, isLoading: setsLoading } = useProblemSets();
 
   const totalStudents = (subjectRooms ?? []).reduce((sum, r) => sum + r.student_count, 0);
   const openCount = (assignments ?? []).filter((a) => !isOverdue(a.due_at)).length;
 
+  // The join code is per *classroom*, but a teacher can run several subject
+  // rooms inside the same classroom. Dedupe so we show one code per classroom
+  // instead of a duplicate widget under every subject room.
+  const uniqueClassrooms = Array.from(
+    new Map(
+      (subjectRooms ?? []).map((r) => [r.classroom, { id: r.classroom, name: r.classroom_display }]),
+    ).values(),
+  );
+
   return (
-    <div className="mx-auto max-w-2xl space-y-8 px-4 py-8">
+    <div className="mx-auto max-w-3xl space-y-8 px-4 py-8">
       {/* Header */}
       <div className="flex flex-wrap items-end justify-between gap-4">
         <div className="min-w-0">
           <h1 className="font-display text-3xl font-semibold text-ink-900">Teacher dashboard</h1>
           <p className="mt-1 text-sm text-ink-500">
-            Manage your subject rooms and assignments.
+            Your rooms, problem sets, and assignments in one place.
           </p>
         </div>
         <div className="flex flex-wrap justify-end gap-2">
           <Button variant="ghost" size="sm" onClick={() => navigate('/teacher/questions/new')}>
-            + New question
+            + Question
           </Button>
           <Button variant="ghost" size="sm" onClick={() => navigate('/teacher/problem-sets/new')}>
             + Problem set
           </Button>
           <Button size="sm" onClick={() => navigate('/teacher/assignments/new')}>
-            + New assignment
+            + Assignment
           </Button>
         </div>
       </div>
 
       {/* Headline stats */}
       {(subjectRooms?.length ?? 0) > 0 && (
-        <Card className="grid grid-cols-2 gap-6 sm:grid-cols-3">
+        <Card className="grid grid-cols-2 gap-6 sm:grid-cols-4">
           <Stat label="Subject rooms" value={subjectRooms?.length ?? 0} />
           <Stat label="Students" value={totalStudents} />
+          <Stat label="Problem sets" value={problemSets?.length ?? 0} />
           <Stat label="Open assignments" value={openCount} />
         </Card>
       )}
@@ -110,36 +154,108 @@ export const TeacherDashboard = () => {
           <div className="space-y-3">
             {subjectRooms.map((room) => (
               <Card key={room.id} padded={false} className="p-5">
-                <div className="flex items-center justify-between">
-                  <div>
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
                     <p className="font-semibold text-ink-900">{room.subject_name}</p>
                     <p className="text-sm text-ink-500">{room.classroom_display}</p>
                   </div>
-                  <div className="text-right">
-                    <p className="text-sm font-medium text-ink-700">
+                  <div className="flex shrink-0 items-center gap-3">
+                    <span className="text-sm text-ink-500">
                       {room.student_count} student{room.student_count !== 1 ? 's' : ''}
-                    </p>
-                    <button
-                      onClick={() => navigate('/teacher/assignments/new')}
-                      className="mt-0.5 text-xs font-semibold text-brand-700 hover:text-brand-800"
-                    >
-                      Assign problem set
-                    </button>
+                    </span>
+                    <Button size="sm" onClick={() => navigate('/teacher/assignments/new')}>
+                      Assign
+                    </Button>
                   </div>
                 </div>
-                <ClassHealthPanel subjectRoomId={room.id} />
-                <WeeklyReportPanel subjectRoomId={room.id} />
-                <InterventionsPanel subjectRoomId={room.id} />
-                <QuestionQualityPanel subjectRoomId={room.id} />
-                <ClassroomCodeWidget
-                  classroomId={room.classroom}
-                  classroomName={room.classroom_display}
-                />
+                <RoomInsights subjectRoomId={room.id} />
               </Card>
             ))}
           </div>
         )}
       </section>
+
+      {/* Problem sets — with student preview */}
+      {(subjectRooms?.length ?? 0) > 0 && (
+        <section className="space-y-3">
+          <SectionHeading
+            title="Problem sets"
+            as="h2"
+            action={
+              <button
+                type="button"
+                onClick={() => navigate('/teacher/problem-sets/new')}
+                className="text-sm font-medium text-brand-700 hover:text-brand-800"
+              >
+                + New set
+              </button>
+            }
+          />
+          {setsLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <LoadingSpinner size="lg" />
+            </div>
+          ) : !problemSets || problemSets.length === 0 ? (
+            <EmptyState
+              title="No problem sets yet"
+              description="Build a set of questions you can assign to any of your rooms."
+              action={
+                <Button onClick={() => navigate('/teacher/problem-sets/new')}>
+                  Build a problem set
+                </Button>
+              }
+            />
+          ) : (
+            <div className="space-y-2">
+              {problemSets.map((ps) => (
+                <Card key={ps.id} padded={false} className="p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="truncate font-semibold text-ink-900">{ps.title}</p>
+                      <p className="mt-0.5 text-xs text-ink-500">
+                        {ps.subject_name} · {ps.chapter_name} · {ps.question_count} question
+                        {ps.question_count !== 1 ? 's' : ''}
+                        {ps.estimated_minutes != null && ` · ~${ps.estimated_minutes} min`}
+                      </p>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-2">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => navigate(`/teacher/problem-sets/${ps.id}/preview`)}
+                      >
+                        Preview as student
+                      </Button>
+                      <Button size="sm" onClick={() => navigate('/teacher/assignments/new')}>
+                        Assign
+                      </Button>
+                    </div>
+                  </div>
+                </Card>
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+
+      {/* Classroom join codes — one per classroom (deduped) */}
+      {uniqueClassrooms.length > 0 && (
+        <section className="space-y-3">
+          <SectionHeading
+            title="Class join codes"
+            as="h2"
+            description="Share a code so students can join the classroom themselves."
+          />
+          <div className="space-y-3">
+            {uniqueClassrooms.map((c) => (
+              <Card key={c.id} padded={false} className="p-4">
+                <p className="font-semibold text-ink-900">{c.name}</p>
+                <ClassroomCodeWidget classroomId={c.id} classroomName={c.name} />
+              </Card>
+            ))}
+          </div>
+        </section>
+      )}
 
       {/* Assignments */}
       <section className="space-y-3">

--- a/frontend_modern/src/features/teacher/useProblemSetPreview.ts
+++ b/frontend_modern/src/features/teacher/useProblemSetPreview.ts
@@ -1,0 +1,34 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+import type { Question } from '@/types/index';
+
+/**
+ * A problem set rendered exactly as a student sees it — correct answers
+ * stripped, `{{var}}` tokens substituted, MCQ options shuffled. Backed by
+ * `GET /problem-sets/<id>/preview/` (teacher-only, read-only).
+ */
+export interface ProblemSetStudentPreview {
+  id: number;
+  title: string;
+  description: string;
+  number: number;
+  subject_name: string;
+  chapter_name: string;
+  estimated_minutes: number | null;
+  question_count: number;
+  questions: Question[];
+}
+
+const fetchPreview = async (id: number): Promise<ProblemSetStudentPreview> => {
+  const res = await apiClient.get<ProblemSetStudentPreview>(`/problem-sets/${id}/preview/`);
+  return res.data;
+};
+
+export const useProblemSetPreview = (id: number | null) => {
+  return useQuery<ProblemSetStudentPreview>({
+    queryKey: ['problem-set-preview', id],
+    queryFn: () => fetchPreview(id as number),
+    enabled: id != null,
+    staleTime: 60 * 1000,
+  });
+};


### PR DESCRIPTION
## What & why

The teacher dashboard had three problems: the classroom join code didn't work, every subject-room card was crammed with always-open analytics panels, and there was no way to see a problem set the way a student does.

### 1. Fixed the classroom join code (real bug)
The dashboard surfaces the join code **per subject room**, but the backend only authorized the classroom's homeroom `class_teacher`. A subject teacher is almost never the homeroom teacher, so `GET` returned nothing and `POST` 404'd silently.
- `classroom_code` now authorizes a teacher who is the `class_teacher` **or** runs any subject room in the classroom.
- Codes are deduped to **one per classroom** in their own "Class join codes" section (previously a duplicate widget appeared under every subject room sharing a classroom).

### 2. "Preview as student" — read-only, exactly as a student sees it
- New `GET /problem-sets/<id>/preview/` (teacher-only) reuses the existing `ProblemSetStudentDetailSerializer`: correct answers stripped, `{{var}}` substituted, MCQs shuffled.
- New `ProblemSetPreviewPage` at `/teacher/problem-sets/:id/preview` **reuses the student `QuestionCard`** locked (`isSubmitted`) with a "Student preview · read-only" banner.

### 3. Decluttered the dashboard
- The four analytics panels no longer mount/fetch eagerly per room — they sit behind one **"View class insights"** disclosure.
- New **"Problem sets"** section lists sets with **Preview as student** + **Assign** actions.

## Notes
- `ProblemSetViewSet` overrides `get_permissions()`, which silently ignores `@action(permission_classes=...)` — so `"preview"` had to be added to the teacher-only branch there (a test proves students get 403).

## Tests
- Backend: +7 tests (preview auth, answer-hiding, subject-teacher join code happy + 404 paths). 20/20 pass in `test_problemset_api.py`.
- Frontend: `tsc` clean, teacher + QuestionCard suites green, production build succeeds.
- black + flake8 + isort clean (pre-commit passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)