### PR TITLE
perf(PERF-03): route-level React.lazy code-splitting

### DIFF
--- a/docs/changes/2026-06-07-perf-03-route-lazy.md
+++ b/docs/changes/2026-06-07-perf-03-route-lazy.md
@@ -1,0 +1,63 @@
+# PERF-03 — Route-level `React.lazy` code-splitting
+
+**Date:** 2026-06-07
+**Initiative:** Performance Budget
+**Classification:** Improve
+
+## Summary
+
+The big entry-chunk cut. Converts every route page in `src/App.tsx` to
+`React.lazy` behind one top-level `<Suspense>` so the K-12 student opening
+`/login` on a budget Android phone no longer downloads the teacher authoring
+surface, parent insights, admin classroom manager, or the dev-only widget
+playground / design-system page.
+
+Eager imports (small, on the critical first-paint path):
+`LoginPage`, `RegisterPage`, `RegisterSchoolPage`, `RegisterOpenPage`,
+`HomePage`, `AppShell`, `ProtectedRoute`, `NotFoundPage`, `LoadingSpinner`,
+`ErrorBoundary`, `UserRole`.
+
+Lazy imports (everything else — 22 route pages):
+`StudentDashboard`, `AssignmentDetailPage`, `ProficiencyPage`,
+`LearningPathPage`, `SRSDrillPage`, `BrowsePage`, `BrowsePracticePage`,
+`ProfilePage`, `TeacherDashboard`, `CreateAssignmentPage`, `CreateQuestionPage`,
+`CreateProblemSetPage`, `ProblemSetPreviewPage`, `TeacherAssignmentDetailPage`,
+`QuestionBankPage`, `ParentDashboard`, `ParentInsightsPage`,
+`ParentInsightsLandingPage`, `AdminDashboard`, `ClassroomManagePage`,
+`EnquirePage`, `DesignSystemPage`, `WidgetDevPage`.
+
+A typed `lazyNamed(loader, name)` helper preserves component props through the
+default-export shim, so `<CreateQuestionPage editMode={true} />` type-checks
+correctly.
+
+## Results — entry chunk
+
+| Stage                                          | Size      | Gzip      |
+| ---------------------------------------------- | --------- | --------- |
+| Baseline (no chunking)                         | 855.15 kB | 247.44 kB |
+| Post-PERF-01 (vendor split)                    | 353.05 kB |  91.53 kB |
+| **Post-PERF-03 (this PR — route lazy)**        | **131.41 kB** | **40.98 kB** |
+
+That's an 84% drop in entry-JS gzip from baseline. Per-route chunks land
+between 1–32 kB each so a user only pays for the page they actually visit.
+
+## Why a single top-level `<Suspense>`
+
+One boundary, one `LoadingSpinner` fallback — there's no need for per-route
+suspense because every route already mounts inside `AppShell` (or is a thin
+auth page). The fallback briefly flashes during chunk fetch and resolves on
+arrival. The existing `ErrorBoundary` continues to wrap everything.
+
+## Tests
+
+- `npm run type-check` — green (the `lazyNamed` helper's conditional return
+  type preserves component prop shapes through the lazy boundary).
+- `npm run lint` — green.
+- `npm test -- --run` — 31 files / 194 tests pass.
+- `npm run build` — green; emits 23 per-route chunks + the shrunken entry.
+
+## Next steps
+
+- PERF-04: lazy-load KaTeX behind `RichContent` so non-math routes never pay
+  for the 257 kB `vendor-katex` chunk.
+- PERF-06: lock the post-cut size in with a CI bundle-size budget guard.

--- a/frontend_modern/src/App.tsx
+++ b/frontend_modern/src/App.tsx
@@ -1,39 +1,60 @@
+import { lazy, Suspense } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { useAuth } from './shared/hooks/useAuth';
 import { LoginPage } from './features/auth/LoginPage';
 import { RegisterPage } from './features/auth/RegisterPage';
 import { RegisterSchoolPage } from './features/auth/RegisterSchoolPage';
 import { RegisterOpenPage } from './features/auth/RegisterOpenPage';
-import { EnquirePage } from './features/enquiry/EnquirePage';
-import { DesignSystemPage } from './features/design/DesignSystemPage';
-import { WidgetDevPage } from './features/widgets/WidgetDevPage';
 import { HomePage } from './features/home/HomePage';
 import { AppShell } from './features/layout/AppShell';
 import { ProtectedRoute } from './features/layout/ProtectedRoute';
-import { StudentDashboard } from './features/student/StudentDashboard';
-import { AssignmentDetailPage } from './features/student/AssignmentDetailPage';
-import { ProficiencyPage } from './features/student/ProficiencyPage';
-import { LearningPathPage } from './features/student/LearningPathPage';
-import { SRSDrillPage } from './features/student/SRSDrillPage';
-import { BrowsePage } from './features/student/BrowsePage';
-import { BrowsePracticePage } from './features/student/BrowsePracticePage';
-import { ProfilePage } from './features/shared/ProfilePage';
-import { TeacherDashboard } from './features/teacher/TeacherDashboard';
-import { CreateAssignmentPage } from './features/teacher/CreateAssignmentPage';
-import { CreateQuestionPage } from './features/teacher/CreateQuestionPage';
-import { CreateProblemSetPage } from './features/teacher/CreateProblemSetPage';
-import { ProblemSetPreviewPage } from './features/teacher/ProblemSetPreviewPage';
-import { TeacherAssignmentDetailPage } from './features/teacher/TeacherAssignmentDetailPage';
-import { QuestionBankPage } from './features/teacher/QuestionBankPage';
-import { ParentDashboard } from './features/parent/ParentDashboard';
-import { ParentInsightsPage } from './features/parent/ParentInsightsPage';
-import { ParentInsightsLandingPage } from './features/parent/ParentInsightsLandingPage';
-import { AdminDashboard } from './features/admin/AdminDashboard';
-import { ClassroomManagePage } from './features/admin/ClassroomManagePage';
+import { NotFoundPage } from './features/shared/NotFoundPage';
 import { UserRole } from './types/index';
 import { LoadingSpinner } from './shared/components/LoadingSpinner';
 import { ErrorBoundary } from './shared/ui';
-import { NotFoundPage } from './features/shared/NotFoundPage';
+
+// Route-level code-splitting. Every page below is loaded on demand so a cold
+// open of /login (the K-12 student's first impression on a budget Android phone)
+// never downloads the teacher authoring surface, the admin classroom manager,
+// or the dev-only widget playground. Auth + home stay eager because they sit on
+// the critical first-paint path. See docs/initiatives/performance-budget.md.
+const lazyNamed = <T extends Record<string, unknown>, K extends keyof T>(
+  loader: () => Promise<T>,
+  name: K,
+): T[K] extends React.ComponentType<infer P> ? React.LazyExoticComponent<React.ComponentType<P>> : never =>
+  lazy(() => loader().then((m) => ({ default: m[name] as unknown as React.ComponentType<unknown> }))) as never;
+
+const EnquirePage = lazyNamed(() => import('./features/enquiry/EnquirePage'), 'EnquirePage');
+const DesignSystemPage = lazyNamed(() => import('./features/design/DesignSystemPage'), 'DesignSystemPage');
+const WidgetDevPage = lazyNamed(() => import('./features/widgets/WidgetDevPage'), 'WidgetDevPage');
+const StudentDashboard = lazyNamed(() => import('./features/student/StudentDashboard'), 'StudentDashboard');
+const AssignmentDetailPage = lazyNamed(() => import('./features/student/AssignmentDetailPage'), 'AssignmentDetailPage');
+const ProficiencyPage = lazyNamed(() => import('./features/student/ProficiencyPage'), 'ProficiencyPage');
+const LearningPathPage = lazyNamed(() => import('./features/student/LearningPathPage'), 'LearningPathPage');
+const SRSDrillPage = lazyNamed(() => import('./features/student/SRSDrillPage'), 'SRSDrillPage');
+const BrowsePage = lazyNamed(() => import('./features/student/BrowsePage'), 'BrowsePage');
+const BrowsePracticePage = lazyNamed(() => import('./features/student/BrowsePracticePage'), 'BrowsePracticePage');
+const ProfilePage = lazyNamed(() => import('./features/shared/ProfilePage'), 'ProfilePage');
+const TeacherDashboard = lazyNamed(() => import('./features/teacher/TeacherDashboard'), 'TeacherDashboard');
+const CreateAssignmentPage = lazyNamed(() => import('./features/teacher/CreateAssignmentPage'), 'CreateAssignmentPage');
+const CreateQuestionPage = lazyNamed(() => import('./features/teacher/CreateQuestionPage'), 'CreateQuestionPage');
+const CreateProblemSetPage = lazyNamed(() => import('./features/teacher/CreateProblemSetPage'), 'CreateProblemSetPage');
+const ProblemSetPreviewPage = lazyNamed(() => import('./features/teacher/ProblemSetPreviewPage'), 'ProblemSetPreviewPage');
+const TeacherAssignmentDetailPage = lazyNamed(() => import('./features/teacher/TeacherAssignmentDetailPage'), 'TeacherAssignmentDetailPage');
+const QuestionBankPage = lazyNamed(() => import('./features/teacher/QuestionBankPage'), 'QuestionBankPage');
+const ParentDashboard = lazyNamed(() => import('./features/parent/ParentDashboard'), 'ParentDashboard');
+const ParentInsightsPage = lazyNamed(() => import('./features/parent/ParentInsightsPage'), 'ParentInsightsPage');
+const ParentInsightsLandingPage = lazyNamed(() => import('./features/parent/ParentInsightsLandingPage'), 'ParentInsightsLandingPage');
+const AdminDashboard = lazyNamed(() => import('./features/admin/AdminDashboard'), 'AdminDashboard');
+const ClassroomManagePage = lazyNamed(() => import('./features/admin/ClassroomManagePage'), 'ClassroomManagePage');
+
+function RouteFallback() {
+  return (
+    <div className="flex items-center justify-center min-h-[40vh]">
+      <LoadingSpinner size="lg" />
+    </div>
+  );
+}
 
 function App() {
   const { isAuthenticated, isLoading, user } = useAuth();
@@ -57,6 +78,7 @@ function App() {
   return (
     <Router>
       <ErrorBoundary>
+      <Suspense fallback={<RouteFallback />}>
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
@@ -300,6 +322,7 @@ function App() {
         <Route path="/" element={isAuthenticated ? <Navigate to={defaultPath} replace /> : <HomePage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
+      </Suspense>
       </ErrorBoundary>
     </Router>
   );


### PR DESCRIPTION
## Classification
**Improve** — frontend-only; no API or backend changes.

## Summary
Converts every route page in `src/App.tsx` to `React.lazy` behind one
top-level `<Suspense>`. K-12 students opening `/login` on a budget Android
phone no longer download the teacher authoring surface, admin classroom manager,
parent insights, or the dev-only widget playground / design-system page.

**Eager** (small, critical-path): `LoginPage`, `RegisterPage`,
`RegisterSchoolPage`, `RegisterOpenPage`, `HomePage`, `AppShell`,
`ProtectedRoute`, `NotFoundPage`, `LoadingSpinner`, `ErrorBoundary`,
`UserRole`.

**Lazy** (22 pages): student / teacher / parent / admin dashboards + their
sub-routes + `EnquirePage`, `DesignSystemPage`, `WidgetDevPage`.

A typed `lazyNamed(loader, name)` helper preserves component prop shapes
through the default-export shim so e.g. `<CreateQuestionPage editMode={true} />`
still type-checks.

## Results — entry chunk
| Stage                        | Size      | Gzip      |
| ---------------------------- | --------- | --------- |
| Baseline                     | 855.15 kB | 247.44 kB |
| Post-PERF-01 (vendor split)  | 353.05 kB |  91.53 kB |
| **Post-PERF-03 (this PR)**   | **131.41 kB** | **40.98 kB** |

That's an 84% drop in entry-JS gzip from baseline. Per-route chunks land
between 1–32 kB each.

## Verification
- `npm run type-check` / `npm run lint` / `npm test -- --run` (31 files,
  194 tests) / `npm run build` — all green; emits 23 per-route chunks plus
  the shrunken entry.

## Stack note
Built on \#251 (PERF-01); merge after PERF-01.

## Change doc
[docs/changes/2026-06-07-perf-03-route-lazy.md](docs/changes/2026-06-07-perf-03-route-lazy.md)