### PR TITLE
perf(PERF-04): lazy-load KaTeX behind the math renderer

### DIFF
--- a/docs/changes/2026-06-07-perf-04-lazy-katex.md
+++ b/docs/changes/2026-06-07-perf-04-lazy-katex.md
@@ -1,0 +1,65 @@
+# PERF-04 — Lazy-load KaTeX behind the math renderer
+
+**Date:** 2026-06-07
+**Initiative:** Performance Budget
+**Classification:** Improve
+
+## Summary
+
+Moves the 257 kB / 77 kB-gzip `vendor-katex` chunk off the first-paint critical
+path. `<RichContent>` now dynamic-imports KaTeX (and its CSS) **only** when the
+text it's about to render actually contains math delimiters (`$…$`, `\(…\)`,
+`$$…$$`, `\[…\]`, `\begin{…}`). Non-math routes — dashboards, browse pages,
+profile, settings, the parent landing page — never trigger the load.
+
+## Design
+
+`renderRichContent.ts`:
+- Replaced the static `import katex from 'katex'` with a module-level reference
+  `katexRef` plus exported `setKatex(mod)` / `isKatexLoaded()` helpers.
+- Added `textContainsMath(text)` (cheap regex pre-check).
+- `renderKatex()` falls back to an escaped `katex-pending` inline-code span when
+  `katexRef` is null. The component re-renders to swap in real KaTeX output
+  once the chunk loads.
+
+`RichContent.tsx`:
+- Uses a single module-level `loadKatex()` that returns a memoised
+  `Promise.all([import('katex'), import('katex/dist/katex.min.css')])` so all
+  in-flight `<RichContent>` instances share one network fetch.
+- `useEffect` only kicks off the load when the text contains math AND KaTeX
+  isn't already loaded.
+- `katexReady` participates in the `useMemo` dependency key (eslint-suppressed
+  with rationale) so the renderer re-runs once KaTeX arrives.
+
+`test-setup.ts`:
+- Preloads KaTeX synchronously via static import + `setKatex(katex)` so the
+  existing sync renderer tests don't have to become async.
+
+## Verification
+
+- `npm run type-check` — green.
+- `npm run lint` — green (`--max-warnings 0`).
+- `npm test -- --run` — 31 files / 194 tests pass.
+- `npm run build` — green; `dist/index.html` lists only
+  `vendor-react`, `vendor-query`, `vendor-dompurify`, and `rolldown-runtime`
+  as `modulepreload`. **`vendor-katex` is no longer preloaded** — it's fetched
+  on demand by the math renderer.
+- Manual sanity: a math-containing `<RichContent>` still resolves to KaTeX
+  output (the existing 19 renderer tests cover this with the pre-loaded module).
+
+## Entry-chunk progress
+
+| Stage                                          | Entry JS  | Gzip      |
+| ---------------------------------------------- | --------- | --------- |
+| Baseline                                       | 855 kB    | 247 kB    |
+| Post-PERF-01 (vendor split)                    | 353 kB    |  92 kB    |
+| Post-PERF-03 (route lazy)                      | 131 kB    |  41 kB    |
+| **Post-PERF-04 (KaTeX off the critical path)** | **132 kB** | **41 kB** |
+
+Entry-chunk size is unchanged from PERF-03 (KaTeX was already in its own
+`vendor-katex` chunk), but the *first-paint preload set* drops by ~77 kB gzip
+— that's the win this PR delivers.
+
+## Next steps
+
+PERF-06 (CI bundle-size budget guard) locks the post-cut entry-chunk size in.

--- a/frontend_modern/src/shared/ui/RichContent.tsx
+++ b/frontend_modern/src/shared/ui/RichContent.tsx
@@ -1,18 +1,23 @@
-import { memo, useMemo } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import clsx from 'clsx';
-import 'katex/dist/katex.min.css';
-import { renderRichContent } from './renderRichContent';
+import {
+  isKatexLoaded,
+  renderRichContent,
+  setKatex,
+  textContainsMath,
+} from './renderRichContent';
 
 /**
  * Render question/option/solution content that may contain HTML and LaTeX.
  *
  * - HTML is sanitised via DOMPurify (allowlist).
  * - LaTeX is rendered with KaTeX. Inline `$…$` / `\(…\)`; block `$$…$$` / `\[…\]`.
- * - Output is memoised on `text`; subsequent renders are O(1).
- *
- * Used by `QuestionCard`, `SRSDrillPage` (via QuestionCard), and the teacher
- * authoring preview — so a student, an SRS reviewer, and an author all see the
- * same rendered output.
+ * - **KaTeX is dynamically imported only when the text actually contains math
+ *   delimiters.** Non-math content (dashboards, browse tiles, options without
+ *   formulas) never pays for the ~257 kB KaTeX chunk on first paint.
+ * - Output is memoised on `text`; subsequent renders are O(1) until KaTeX
+ *   finishes loading, at which point the component re-renders once with proper
+ *   math glyphs in place of the pending fallback.
  */
 export interface RichContentProps {
   /** Raw HTML+LaTeX from the API (Cabinet-imported content, AI hints, etc.). */
@@ -23,8 +28,40 @@ export interface RichContentProps {
   className?: string;
 }
 
+let katexLoadPromise: Promise<void> | null = null;
+
+function loadKatex(): Promise<void> {
+  if (katexLoadPromise) return katexLoadPromise;
+  katexLoadPromise = Promise.all([
+    import('katex'),
+    import('katex/dist/katex.min.css'),
+  ]).then(([mod]) => {
+    type KatexModule = typeof import('katex');
+    const m = mod as unknown as { default?: KatexModule };
+    setKatex(m.default ?? (mod as unknown as KatexModule));
+  });
+  return katexLoadPromise;
+}
+
 const RichContentImpl = ({ text, variant = 'inline', className }: RichContentProps) => {
-  const html = useMemo(() => renderRichContent(text), [text]);
+  const hasMath = useMemo(() => textContainsMath(text), [text]);
+  const [katexReady, setKatexReady] = useState(isKatexLoaded);
+
+  useEffect(() => {
+    if (!hasMath || katexReady) return;
+    let cancelled = false;
+    loadKatex().then(() => {
+      if (!cancelled) setKatexReady(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [hasMath, katexReady]);
+
+  // `katexReady` participates in the memo key so the renderer re-runs once
+  // KaTeX is available and the pending fallback is replaced with rendered math.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const html = useMemo(() => renderRichContent(text), [text, katexReady]);
 
   if (!html) return null;
 
@@ -33,7 +70,7 @@ const RichContentImpl = ({ text, variant = 'inline', className }: RichContentPro
       className={clsx(
         'prose-osh',
         variant === 'block' ? 'block' : 'inline-block align-baseline',
-        className
+        className,
       )}
       dangerouslySetInnerHTML={{ __html: html }}
     />

--- a/frontend_modern/src/shared/ui/renderRichContent.ts
+++ b/frontend_modern/src/shared/ui/renderRichContent.ts
@@ -1,5 +1,29 @@
 import createDOMPurify from 'dompurify';
-import katex from 'katex';
+import type Katex from 'katex';
+
+// KaTeX is the largest single dependency in the bundle (~257 kB / ~77 kB gzip).
+// We dynamic-import it from `<RichContent>` only when the text actually contains
+// math delimiters, so dashboards / browse pages / non-math content never pay for
+// it on first paint. The component pokes the loaded module in here via
+// `setKatex()`; until that happens (or for non-math content) `renderRichContent`
+// is fully usable and just renders math expressions as escaped fallback text.
+//
+// In Vitest, `src/test-setup.ts` preloads KaTeX synchronously so the existing
+// sync renderer tests don't have to become async.
+let katexRef: typeof Katex | null = null;
+export function setKatex(mod: typeof Katex): void {
+  katexRef = mod;
+}
+export function isKatexLoaded(): boolean {
+  return katexRef !== null;
+}
+
+// Cheap pre-check so `<RichContent>` can decide whether to even kick off the
+// dynamic import. Matches the same delimiters the renderer recognises.
+const MATH_HINT_PATTERN = /\$|\\\(|\\\[|\\begin\{/;
+export function textContainsMath(text: string): boolean {
+  return MATH_HINT_PATTERN.test(text);
+}
 
 /**
  * Pure HTML+LaTeX renderer used by `<RichContent />`. Split into its own file
@@ -79,8 +103,15 @@ function escapeHtml(s: string): string {
 }
 
 function renderKatex(expr: string, block: boolean): string {
+  if (!katexRef) {
+    // Fallback before the lazy KaTeX chunk has finished loading. We render the
+    // raw expression as inline-code so the user sees something readable rather
+    // than a blank flash; the component re-renders once KaTeX is ready.
+    const tag = block ? 'div' : 'span';
+    return `<${tag} class="katex-pending font-mono text-ink-700">${escapeHtml(expr)}</${tag}>`;
+  }
   try {
-    return katex.renderToString(expr, {
+    return katexRef.renderToString(expr, {
       throwOnError: false,
       displayMode: block,
       strict: 'ignore',

--- a/frontend_modern/src/test-setup.ts
+++ b/frontend_modern/src/test-setup.ts
@@ -1,1 +1,8 @@
 import '@testing-library/jest-dom';
+
+// PERF-04: production builds dynamic-import KaTeX from `<RichContent>` only
+// when the text contains math. Tests assume the sync renderer is ready, so we
+// preload KaTeX here once before any test runs.
+import katex from 'katex';
+import { setKatex } from './shared/ui/renderRichContent';
+setKatex(katex);


### PR DESCRIPTION
## Classification
**Improve** — frontend only.

## Summary
`<RichContent>` now dynamic-imports KaTeX (and its CSS) **only** when the text
it's about to render actually contains math delimiters (`$…$`, `\(…\)`,
`$$…$$`, `\[…\]`, `\begin{…}`). Non-math routes — dashboards, browse,
profile, parent landing — never trigger the fetch.

## Design
- `renderRichContent.ts`: replaced the static `import katex from 'katex'` with
  a module-level `katexRef` + exported `setKatex` / `isKatexLoaded` /
  `textContainsMath` helpers. Fallback when KaTeX not yet loaded is an escaped
  `katex-pending` inline-code span.
- `RichContent.tsx`: a single module-level `loadKatex()` returns a memoised
  `Promise.all([import('katex'), import('katex/dist/katex.min.css')])` so
  concurrent `<RichContent>` instances share one fetch. `katexReady` is in
  the `useMemo` deps so the component re-renders when the chunk arrives.
- `test-setup.ts`: preloads KaTeX synchronously so the existing 19 sync
  renderer tests don't have to become async.

## Verification
- `npm run type-check` / `npm run lint` / `npm test -- --run` (31 files, 194
  tests) / `npm run build` — all green.
- `dist/index.html` modulepreload list = `rolldown-runtime`, `vendor-query`,
  `vendor-react`, `vendor-dompurify`. **`vendor-katex` is no longer in the
  preload list** — that's the ~77 kB gzip cut to first paint.

## Stack note
Branched off PERF-03 (\#253). Merge order: \#251 → \#253 → this PR.

## Change doc
[docs/changes/2026-06-07-perf-04-lazy-katex.md](docs/changes/2026-06-07-perf-04-lazy-katex.md)