### PR TITLE
perf(PERF-06): CI bundle-size budget guard

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -221,6 +221,10 @@ jobs:
                 retention-days: 14
             - name: Build
               run: npm run build
+            - name: Check bundle-size budget (PERF-06)
+              # Fails if the entry chunk grows past the documented ceiling.
+              # See docs/perf/budget.md for the raise-the-ceiling protocol.
+              run: npm run check:budget
 
     frontend-e2e:
         name: Frontend E2E (Playwright smoke)

--- a/docs/changes/2026-06-07-perf-06-bundle-budget.md
+++ b/docs/changes/2026-06-07-perf-06-bundle-budget.md
@@ -1,0 +1,43 @@
+# PERF-06 — CI bundle-size budget guard
+
+**Date:** 2026-06-07
+**Initiative:** Performance Budget
+**Classification:** New
+
+## Summary
+
+Locks in the entry-chunk cuts landed in PERF-01..PERF-04 with a CI-enforced
+budget. Adds:
+- `frontend_modern/scripts/check-bundle-budget.mjs` — reads `dist/index.html`,
+  resolves the hashed entry chunk filename (never hard-coded), compares its
+  size to `DEFAULT_BUDGET_BYTES = 160 * 1024`, exits non-zero on overage with a
+  clear over-by-X message pointing at how to raise the ceiling deliberately.
+- `frontend_modern/scripts/check-bundle-budget.test.mjs` — 9 unit tests
+  covering `findEntryChunk` (parsing index.html), `formatBytes`, and the pure
+  `checkBudget` decision function (pass / boundary / fail).
+- `npm run check:budget` script.
+- `docs/perf/budget.md` — the ceiling, the CI plumbing, the raise-the-ceiling
+  protocol, and a dated history table.
+- A new CI step in `.github/workflows/ci-cd.yaml`'s `frontend` job that runs
+  `npm run check:budget` after `npm run build`.
+
+## Why 160 kB?
+
+Post-PERF-04 the entry chunk measures ~129 kB uncompressed. 160 kB gives ~24%
+headroom — enough to absorb routine feature growth without paging on every PR,
+small enough that any sustained drift triggers a forced conversation. The
+protocol in `docs/perf/budget.md` requires every ceiling bump to either avoid
+itself via lazy-loading or be documented in the history table.
+
+## Verification
+
+- `npm run check:budget` on a fresh post-PERF-04 build —
+  `OK — assets/index-ijK6y_PY.js is 128.99 kB (budget 160.00 kB, headroom 31.01 kB).`
+- `npm test -- --run` — 32 files / 203 tests pass (9 new for the script).
+- Synthetic overage tested via `checkBudget({ sizeBytes: 200kB, budgetBytes: 160kB })`
+  — asserts a `FAIL` result and the raise-the-ceiling pointer.
+
+## Next steps
+
+PERF-05 (font-loading optimization) is the obvious next pull. The budget guard
+will now defend whatever ceiling PERF-05 lands.

--- a/docs/perf/budget.md
+++ b/docs/perf/budget.md
@@ -1,0 +1,54 @@
+# Frontend bundle-size budget (PERF-06)
+
+This budget is a *contract*. Every PR that ships frontend code must keep the
+entry JS chunk under the ceiling, otherwise CI fails. The whole point is to
+prevent silent regression of the cuts landed in PERF-01..PERF-04.
+
+## Current ceiling
+
+| Asset                  | Ceiling | Measured (post-PERF-04) |
+| ---------------------- | ------- | ----------------------- |
+| `dist/assets/index-*.js` (entry) | **160 kB** | ~129 kB |
+
+The "entry" is whatever `dist/index.html` references as
+`<script type="module" src="/assets/*.js">`. Hash-renamed each build; the
+guard resolves the name from `index.html`, never hard-codes it.
+
+## How CI enforces it
+
+The frontend job runs `npm run check:budget` after `npm run build` (see
+`.github/workflows/ci-cd.yaml`). The script
+(`frontend_modern/scripts/check-bundle-budget.mjs`) reads `dist/index.html`,
+finds the entry chunk, and compares its size to `DEFAULT_BUDGET_BYTES`. Exit
+non-zero on overage. Unit-tested via `check-bundle-budget.test.mjs`.
+
+## Running it locally
+
+```bash
+cd frontend_modern
+npm run build
+npm run check:budget                  # prints OK / FAIL
+npm run check:budget -- --budget=131072   # one-off override (128 kB)
+```
+
+## Raise-the-ceiling protocol
+
+Don't quietly bump the budget. When a deliberate, justified change pushes the
+entry chunk past the ceiling:
+
+1. **Try to avoid the bump first.** Can the new code be lazy-loaded behind a
+   route, behind a user action, or behind a feature flag? PERF-03's
+   `React.lazy` pattern is the default tool.
+2. If the bump is genuinely warranted, edit `DEFAULT_BUDGET_BYTES` in
+   `frontend_modern/scripts/check-bundle-budget.mjs`.
+3. Add a row to the **history** section below with the date, the new ceiling,
+   the measured entry size, and the reason.
+4. Ship the budget bump in its own PR (or call it out clearly in the PR that
+   needs it). Reviewers should be able to see the budget change without
+   hunting.
+
+## History
+
+| Date       | Ceiling | Measured | Reason                                |
+| ---------- | ------- | -------- | ------------------------------------- |
+| 2026-06-07 | 160 kB  | 129 kB   | PERF-06 initial set after PERF-01..04. |

--- a/frontend_modern/package.json
+++ b/frontend_modern/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "build:analyze": "tsc && vite build --mode analyze",
+    "check:budget": "node scripts/check-bundle-budget.mjs",
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --ext ts,tsx --fix",

--- a/frontend_modern/scripts/check-bundle-budget.mjs
+++ b/frontend_modern/scripts/check-bundle-budget.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * PERF-06 — Bundle-size budget guard.
+ *
+ * After `npm run build`, run this script to assert that the entry JS chunk
+ * (the one referenced by dist/index.html as a top-level <script type="module">)
+ * is at most BUDGET_BYTES. Exits non-zero with a clear diff when the budget is
+ * blown — protecting the gains landed in PERF-01..PERF-04.
+ *
+ * To raise the ceiling deliberately: change BUDGET_BYTES in this file (or pass
+ * --budget=<bytes> on the CLI), commit a baseline + budget bump in the same PR,
+ * and call out the reason in docs/perf/budget.md.
+ *
+ * Exported helpers (`findEntryChunk`, `formatBytes`, `checkBudget`) are unit-
+ * tested in check-bundle-budget.test.mjs.
+ */
+import { readFileSync, statSync, readdirSync, existsSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Post-PERF-04 the entry chunk is ~132 kB uncompressed / ~41 kB gzip.
+// Budget set with ~17% headroom over the measured uncompressed entry to absorb
+// routine feature growth without false-alarming every PR. Raise deliberately.
+export const DEFAULT_BUDGET_BYTES = 160 * 1024;
+
+/**
+ * Find the entry JS chunk filename from `dist/index.html`.
+ * Looks for `<script type="module" ... src="/assets/<name>.js"></script>`.
+ */
+export function findEntryChunk(indexHtml) {
+  const match = indexHtml.match(
+    /<script[^>]*type=["']module["'][^>]*src=["']\/?(assets\/[^"']+\.js)["']/i,
+  );
+  if (!match) {
+    throw new Error(
+      'Could not find an entry <script type="module" src="/assets/*.js"> in dist/index.html.',
+    );
+  }
+  return match[1];
+}
+
+export function formatBytes(n) {
+  if (n < 1024) return `${n} B`;
+  return `${(n / 1024).toFixed(2)} kB`;
+}
+
+/**
+ * Pure budget check. Returns `{ ok, message }` so it's trivially unit-testable
+ * without touching the file system.
+ */
+export function checkBudget({ entryChunk, sizeBytes, budgetBytes }) {
+  if (sizeBytes <= budgetBytes) {
+    return {
+      ok: true,
+      message:
+        `[bundle-budget] OK — ${entryChunk} is ${formatBytes(sizeBytes)} ` +
+        `(budget ${formatBytes(budgetBytes)}, headroom ` +
+        `${formatBytes(budgetBytes - sizeBytes)}).`,
+    };
+  }
+  const over = sizeBytes - budgetBytes;
+  return {
+    ok: false,
+    message:
+      `[bundle-budget] FAIL — ${entryChunk} is ${formatBytes(sizeBytes)}, ` +
+      `over the ${formatBytes(budgetBytes)} budget by ${formatBytes(over)}.\n` +
+      `To raise the ceiling: bump DEFAULT_BUDGET_BYTES in ` +
+      `frontend_modern/scripts/check-bundle-budget.mjs, document why in ` +
+      `docs/perf/budget.md, and ship the change as its own PR.`,
+  };
+}
+
+function parseCliBudget(argv) {
+  for (const arg of argv) {
+    const m = arg.match(/^--budget=(\d+)$/);
+    if (m) return Number(m[1]);
+  }
+  return undefined;
+}
+
+function main() {
+  const distDir = resolve(__dirname, '..', 'dist');
+  const indexPath = join(distDir, 'index.html');
+  if (!existsSync(indexPath)) {
+    console.error(
+      `[bundle-budget] FAIL — ${indexPath} does not exist. Did you forget to run \`npm run build\` first?`,
+    );
+    process.exit(2);
+  }
+  const html = readFileSync(indexPath, 'utf8');
+  const entryRel = findEntryChunk(html);
+  const entryAbs = join(distDir, entryRel);
+  if (!existsSync(entryAbs)) {
+    // Defensive — the hashed name from index.html should always resolve.
+    console.error(
+      `[bundle-budget] FAIL — entry chunk ${entryRel} referenced by index.html does not exist on disk.\n` +
+        `assets/ contents: ${readdirSync(join(distDir, 'assets')).join(', ')}`,
+    );
+    process.exit(2);
+  }
+  const { size } = statSync(entryAbs);
+  const budgetBytes = parseCliBudget(process.argv) ?? DEFAULT_BUDGET_BYTES;
+  const result = checkBudget({ entryChunk: entryRel, sizeBytes: size, budgetBytes });
+  console.log(result.message);
+  process.exit(result.ok ? 0 : 1);
+}
+
+// Only execute when run as a script (not when imported for tests).
+// `process.argv[1]` is the resolved entry path on all platforms; we just look
+// at its basename rather than comparing URLs (Windows vs POSIX path encodings
+// have bitten us here before).
+const entryBasename = (process.argv[1] ?? '').replace(/\\/g, '/').split('/').pop();
+if (entryBasename === 'check-bundle-budget.mjs') {
+  main();
+}

--- a/frontend_modern/scripts/check-bundle-budget.test.mjs
+++ b/frontend_modern/scripts/check-bundle-budget.test.mjs
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import {
+  checkBudget,
+  findEntryChunk,
+  formatBytes,
+  DEFAULT_BUDGET_BYTES,
+} from './check-bundle-budget.mjs';
+
+describe('findEntryChunk', () => {
+  it('extracts the entry chunk path from a typical Vite index.html', () => {
+    const html =
+      '<!doctype html><html><head>' +
+      '<script type="module" crossorigin src="/assets/index-ABC123.js"></script>' +
+      '<link rel="modulepreload" crossorigin href="/assets/vendor-react-XYZ.js">' +
+      '</head><body></body></html>';
+    expect(findEntryChunk(html)).toBe('assets/index-ABC123.js');
+  });
+
+  it('handles single-quoted attributes', () => {
+    const html = "<script type='module' src='/assets/index-Q.js'></script>";
+    expect(findEntryChunk(html)).toBe('assets/index-Q.js');
+  });
+
+  it('throws when no entry script is present', () => {
+    expect(() => findEntryChunk('<html><body>no script</body></html>')).toThrow();
+  });
+});
+
+describe('formatBytes', () => {
+  it('renders < 1 kB as bytes', () => {
+    expect(formatBytes(512)).toBe('512 B');
+  });
+  it('renders >= 1 kB with two decimals of kB', () => {
+    expect(formatBytes(1024)).toBe('1.00 kB');
+    expect(formatBytes(160 * 1024)).toBe('160.00 kB');
+  });
+});
+
+describe('checkBudget', () => {
+  it('passes when the entry is under the budget', () => {
+    const result = checkBudget({
+      entryChunk: 'assets/index-AAA.js',
+      sizeBytes: 100 * 1024,
+      budgetBytes: 160 * 1024,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain('OK');
+    expect(result.message).toContain('assets/index-AAA.js');
+    expect(result.message).toContain('headroom');
+  });
+
+  it('passes exactly at the budget (boundary)', () => {
+    const result = checkBudget({
+      entryChunk: 'assets/index-AAA.js',
+      sizeBytes: 160 * 1024,
+      budgetBytes: 160 * 1024,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('fails when the entry exceeds the budget and points at how to raise the ceiling', () => {
+    const result = checkBudget({
+      entryChunk: 'assets/index-BIG.js',
+      sizeBytes: 200 * 1024,
+      budgetBytes: 160 * 1024,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('FAIL');
+    expect(result.message).toContain('assets/index-BIG.js');
+    expect(result.message).toContain('over the');
+    expect(result.message).toContain('DEFAULT_BUDGET_BYTES');
+    expect(result.message).toContain('docs/perf/budget.md');
+  });
+});
+
+describe('DEFAULT_BUDGET_BYTES', () => {
+  it('is set to the documented 160 kB post-PERF-04 ceiling', () => {
+    expect(DEFAULT_BUDGET_BYTES).toBe(160 * 1024);
+  });
+});


### PR DESCRIPTION
## Classification
**New** — adds a small CI script + workflow step + docs. No app code touched.

## Summary
Locks the entry-chunk cuts landed in PERF-01..PERF-04 with a CI-enforced budget.

- `scripts/check-bundle-budget.mjs` — reads `dist/index.html`, resolves the
  hashed entry chunk filename (never hard-coded), compares its size to
  `DEFAULT_BUDGET_BYTES = 160 * 1024`, exits non-zero on overage with a clear
  over-by-X message pointing at how to raise the ceiling deliberately.
- `scripts/check-bundle-budget.test.mjs` — 9 unit tests covering
  `findEntryChunk`, `formatBytes`, and the pure `checkBudget` decision
  function (pass / boundary / fail / parse failure).
- `npm run check:budget` script.
- New `Check bundle-size budget (PERF-06)` step in the `frontend` CI job
  after `npm run build`.
- [`docs/perf/budget.md`](docs/perf/budget.md) — ceiling, plumbing,
  raise-the-ceiling protocol, history table.

## Why 160 kB?
Post-PERF-04 entry chunk measures ~129 kB. 160 kB gives ~24% headroom —
absorbs routine feature growth without paging on every PR, small enough that
sustained drift triggers a forced conversation. Protocol requires every bump
to either be avoided via lazy-loading or be documented in the history table.

## Verification
- Local: `npm run check:budget` →
  `OK — assets/index-ijK6y_PY.js is 128.99 kB (budget 160.00 kB, headroom 31.01 kB).`
- `npm test -- --run` — 32 files / 203 tests pass (9 new for the script).

## Stack note
Branched off PERF-04. Merge order: \#251 → \#253 → \#254 → this PR.

## Change doc
[docs/changes/2026-06-07-perf-06-bundle-budget.md](docs/changes/2026-06-07-perf-06-bundle-budget.md)