### PR TITLE
fix: make rollup-plugin-visualizer import optional in vite.config

### DIFF
--- a/frontend_modern/vite.config.ts
+++ b/frontend_modern/vite.config.ts
@@ -1,10 +1,30 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type PluginOption } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
-import { visualizer } from 'rollup-plugin-visualizer';
+
+// `rollup-plugin-visualizer` is only used in `--mode analyze`. We dynamic-
+// import it inside the factory so missing it never breaks a normal `dev` /
+// `build` — Docker images that omit dev deps, fresh clones before
+// `npm install`, etc. still boot cleanly.
+async function loadVisualizer(): Promise<PluginOption | null> {
+  try {
+    const mod = await import('rollup-plugin-visualizer');
+    return mod.visualizer({
+      filename: 'dist/stats.html',
+      template: 'treemap',
+      gzipSize: true,
+      brotliSize: true,
+    });
+  } catch {
+    console.warn(
+      '[vite.config] --mode analyze requested but rollup-plugin-visualizer is not installed; skipping.',
+    );
+    return null;
+  }
+}
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
+export default defineConfig(async ({ mode }) => ({
   test: {
     globals: true,
     environment: 'happy-dom',
@@ -51,16 +71,7 @@ export default defineConfig(({ mode }) => ({
   },
   plugins: [
     react(),
-    ...(mode === 'analyze'
-      ? [
-          visualizer({
-            filename: 'dist/stats.html',
-            template: 'treemap',
-            gzipSize: true,
-            brotliSize: true,
-          }),
-        ]
-      : []),
+    ...(mode === 'analyze' ? [await loadVisualizer()].filter(Boolean) : []),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
## What broke
After PERF-01 ([#251](https://github.com/openshiksha/openshiksha/pull/251))
added `rollup-plugin-visualizer` as a devDependency, Docker users hit:

```
failed to load config from /app/vite.config.ts
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'rollup-plugin-visualizer'
```

The cause is the **top-level static import** in `vite.config.ts` — it's
evaluated at config-load time regardless of mode, so any environment where
the dep isn't installed (Docker images with cached node_modules layers from
before PERF-01, builds running `npm ci --omit=dev`, fresh clones before
`npm install`) crashes before `mode === 'analyze'` even gets a chance to
short-circuit.

## Fix
Switch to a dynamic import inside the `defineConfig` factory, guarded by a
try/catch. Normal `dev` and `build` never touch the package. `build:analyze`
still emits `dist/stats.html` when the dep is present, and prints a warning
and skips the visualizer plugin when it isn't.

## Verification
- `npm run build` / `npm run build:analyze` both green with the dep installed.
- Temporarily renamed `node_modules/rollup-plugin-visualizer` → both still
  succeed; analyze prints a warning and skips.
- `tsc --noEmit` / ESLint green.

## For Docker users hitting this now
Pull this fix and rebuild the image:
```bash
docker compose build --no-cache frontend
```
(or whatever the project's image-name is — the `--no-cache` is what matters
so the node_modules layer regenerates against the post-PERF-01 lockfile.)