### PR TITLE
feat(deploy): wire modern stack to k3s, drop legacy from CI

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -275,41 +275,134 @@ jobs:
                 path: frontend_modern/axe-report
                 retention-days: 14
 
+    # ─── Build & publish the MODERN stack ────────────────────────────────────
+    # Two images go to ghcr.io: backend (Django 4.2 + daphne) and frontend
+    # (multi-stage build → nginx). The legacy root Dockerfile is intentionally
+    # NOT built — see docs/deploy/README.md for why. The matrix lets both
+    # images build in parallel.
     build-publish:
-        name: Build & Publish
+        name: Build & Publish (${{ matrix.service }})
         needs: [lint, typecheck, security, test, frontend, frontend-e2e]
-        # only run this on qa & prod branches
         if: github.ref == 'refs/heads/qa' || github.ref == 'refs/heads/prod'
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - service: backend
+                      context: ./backend
+                      dockerfile: ./backend/Dockerfile.prod
+                    - service: frontend
+                      context: ./frontend_modern
+                      dockerfile: ./frontend_modern/Dockerfile.prod
         steps:
             - name: Check out the repo
               uses: actions/checkout@v4
             - name: Extract Branch name for Tagging
               run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
               id: extract_branch
-            - name: Build Docker Image & Push to GitHub Container Registry
-              uses: docker/build-push-action@v7
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+            - name: Log in to GitHub Container Registry
+              uses: docker/login-action@v3
               with:
-                context: .
+                registry: ghcr.io
+                username: ${{ github.actor }}
+                password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Build & push ${{ matrix.service }} image
+              uses: docker/build-push-action@v6
+              with:
+                context: ${{ matrix.context }}
+                file: ${{ matrix.dockerfile }}
                 push: true
                 tags: |
-                    ghcr.io/${{ github.repository }}:${{ steps.extract_branch.outputs.branch }}
-                    ghcr.io/${{ github.repository }}:${{ github.sha }}
-              env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                    ghcr.io/${{ github.repository_owner }}/openshiksha-${{ matrix.service }}:${{ steps.extract_branch.outputs.branch }}
+                    ghcr.io/${{ github.repository_owner }}/openshiksha-${{ matrix.service }}:${{ github.sha }}
+                cache-from: type=gha,scope=${{ matrix.service }}
+                cache-to: type=gha,scope=${{ matrix.service }},mode=max
 
-    deploy-prod:
-        name: Deploy to Cluster
+    # ─── Deploy to QA ────────────────────────────────────────────────────────
+    # Renders the qa overlay with the just-built image digest pinned (so the
+    # rollout actually picks up the new code instead of re-pulling a stale tag),
+    # applies, and rolls each Deployment so the new pods come up clean.
+    deploy-qa:
+        name: Deploy to QA Cluster
         needs: build-publish
-        # only run this on prod branch
-        if: github.ref == 'refs/heads/prod'
+        if: github.ref == 'refs/heads/qa'
         runs-on: ubuntu-latest
+        environment: qa
         steps:
+            - name: Check out the repo
+              uses: actions/checkout@v4
             - name: Set Cluster Context
               uses: azure/k8s-set-context@v5
               with:
                 method: kubeconfig
                 kubeconfig: '${{ secrets.KUBECONFIG }}'
                 context: k3s-personal-server
-            - name: Restart pods
-              run: kubectl rollout restart deployment openshiksha openshiksha-celery-worker openshiksha-celery-beat -n openshiksha
+            - name: Set up kubectl + kustomize
+              uses: azure/setup-kubectl@v4
+              with:
+                version: 'v1.31.0'
+            - name: Pin image tags to commit SHA
+              # The committed overlay points at the `:qa` tag, but tags can be
+              # re-pushed — so we override to the exact SHA we just built. This
+              # forces a real new digest into the Deployment spec, which forces
+              # a rollout.
+              working-directory: k8s/overlays/qa
+              run: |
+                kubectl kustomize . > /dev/null  # sanity-render before edits
+                kustomize edit set image \
+                  ghcr.io/${{ github.repository_owner }}/openshiksha-backend=ghcr.io/${{ github.repository_owner }}/openshiksha-backend:${{ github.sha }} \
+                  ghcr.io/${{ github.repository_owner }}/openshiksha-frontend=ghcr.io/${{ github.repository_owner }}/openshiksha-frontend:${{ github.sha }}
+            - name: Apply qa manifests
+              run: kubectl apply -k k8s/overlays/qa
+            - name: Wait for rollouts
+              run: |
+                kubectl -n openshiksha-qa rollout status statefulset/postgres --timeout=180s
+                kubectl -n openshiksha-qa rollout status statefulset/redis --timeout=120s
+                kubectl -n openshiksha-qa rollout status deployment/backend --timeout=300s
+                kubectl -n openshiksha-qa rollout status deployment/frontend --timeout=180s
+                kubectl -n openshiksha-qa rollout status deployment/celery-worker --timeout=180s
+                kubectl -n openshiksha-qa rollout status deployment/celery-beat --timeout=180s
+
+    # ─── Deploy to Prod ──────────────────────────────────────────────────────
+    deploy-prod:
+        name: Deploy to Prod Cluster
+        needs: build-publish
+        if: github.ref == 'refs/heads/prod'
+        runs-on: ubuntu-latest
+        environment: prod
+        steps:
+            - name: Check out the repo
+              uses: actions/checkout@v4
+            - name: Set Cluster Context
+              uses: azure/k8s-set-context@v5
+              with:
+                method: kubeconfig
+                kubeconfig: '${{ secrets.KUBECONFIG }}'
+                context: k3s-personal-server
+            - name: Set up kubectl + kustomize
+              uses: azure/setup-kubectl@v4
+              with:
+                version: 'v1.31.0'
+            - name: Pin image tags to commit SHA
+              working-directory: k8s/overlays/prod
+              run: |
+                kubectl kustomize . > /dev/null
+                kustomize edit set image \
+                  ghcr.io/${{ github.repository_owner }}/openshiksha-backend=ghcr.io/${{ github.repository_owner }}/openshiksha-backend:${{ github.sha }} \
+                  ghcr.io/${{ github.repository_owner }}/openshiksha-frontend=ghcr.io/${{ github.repository_owner }}/openshiksha-frontend:${{ github.sha }}
+            - name: Apply prod manifests
+              run: kubectl apply -k k8s/overlays/prod
+            - name: Wait for rollouts
+              run: |
+                kubectl -n openshiksha-prod rollout status statefulset/postgres --timeout=180s
+                kubectl -n openshiksha-prod rollout status statefulset/redis --timeout=120s
+                kubectl -n openshiksha-prod rollout status deployment/backend --timeout=300s
+                kubectl -n openshiksha-prod rollout status deployment/frontend --timeout=180s
+                kubectl -n openshiksha-prod rollout status deployment/celery-worker --timeout=180s
+                kubectl -n openshiksha-prod rollout status deployment/celery-beat --timeout=180s

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,10 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        # k8s manifests routinely concatenate multiple resources in one file
+        # with `---` separators (Service + StatefulSet, etc.). Without this
+        # flag, check-yaml errors on every k8s/base/*.yaml file.
+        args: [--allow-multiple-documents]
       - id: check-added-large-files
       - id: check-merge-conflict
       - id: debug-statements

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,17 @@
+.venv
+venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache
+.mypy_cache
+.ruff_cache
+staticfiles
+media
+logs
+.env
+.env.*
+.vscode
+.idea
+*.log

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,0 +1,69 @@
+# Production image for the modern OpenShiksha backend.
+#
+# - Python 3.11 slim base.
+# - Runs Daphne (ASGI) — required because openshiksha/asgi.py wires Channels.
+# - Collects static files at build time so WhiteNoise can serve them with
+#   long-cacheable hashed filenames (CompressedManifestStaticFilesStorage).
+# - Non-root runtime user.
+# - The compose file's dev Dockerfile (./Dockerfile) is separate; this image
+#   is built only by CI for ghcr.io/.../openshiksha-backend:{qa,prod}.
+
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    DJANGO_SETTINGS_MODULE=openshiksha.settings.production
+
+WORKDIR /app
+
+# System deps. postgresql-client kept for migrations + healthchecks; libpq-dev
+# + build-essential drop after pip install to keep the runtime image small.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        postgresql-client \
+        libpq5 \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build deps in a separate layer so they don't end up in the final image.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt /app/
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+# Drop build deps now that wheels are installed.
+RUN apt-get purge -y --auto-remove build-essential libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . /app/
+
+# Build-time static collection — uses ManifestStaticFilesStorage so the
+# resulting filenames are content-hashed and long-cacheable. SECRET_KEY isn't
+# needed at collectstatic time but Django will complain if it's unset, so a
+# build-only throwaway value is fine.
+RUN SECRET_KEY=build-time-only-not-used-at-runtime \
+    ALLOWED_HOSTS=build.local \
+    python manage.py collectstatic --noinput --clear
+
+# Non-root runtime user. /app/media must be writable for runtime uploads.
+RUN useradd --create-home --shell /bin/bash app \
+    && mkdir -p /app/logs /app/media /app/staticfiles \
+    && chown -R app:app /app
+USER app
+
+EXPOSE 8000
+
+# Container-level healthcheck. The k8s Deployment also defines a Readiness
+# probe — this is just for `docker run` / compose smoke-checks.
+# X-Forwarded-Proto: https is required because the production settings have
+# SECURE_SSL_REDIRECT=True — without that header Django 301-redirects every
+# request to https, which curl can't follow inside this container.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD curl -fsS -H "X-Forwarded-Proto: https" http://127.0.0.1:8000/healthz/ || exit 1
+
+# Daphne (ASGI) for prod. Channels-aware, handles WebSockets as well as HTTP.
+CMD ["daphne", "-b", "0.0.0.0", "-p", "8000", "openshiksha.asgi:application"]

--- a/backend/openshiksha/settings/production.py
+++ b/backend/openshiksha/settings/production.py
@@ -12,6 +12,12 @@ ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "").split(",")  # noqa: F405
 
 # Security Settings
 SECURE_SSL_REDIRECT = True
+# When deployed behind a TLS-terminating ingress (Traefik on k3s, ALB, etc.),
+# Django sees plain HTTP at the socket. It has to trust the proxy's
+# X-Forwarded-Proto header to know the original request was HTTPS, otherwise
+# SECURE_SSL_REDIRECT triggers an infinite redirect loop. Only safe when the
+# ingress strips this header from client input (Traefik does by default).
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
 SECURE_BROWSER_XSS_FILTER = True

--- a/backend/openshiksha/urls.py
+++ b/backend/openshiksha/urls.py
@@ -9,9 +9,25 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, Spec
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.http import HttpResponse
 from django.urls import include, path
 
+
+def healthz(_request):
+    """Liveness/readiness probe target for k8s + Docker HEALTHCHECK.
+
+    Returns 200 OK as long as the WSGI/ASGI app is wired up — does NOT hit the
+    DB or Redis on purpose. A failing DB shouldn't take the pod down (it'll
+    just return 5xx to /api/ requests), and a Redis hiccup shouldn't either.
+    DB-aware probes belong on a separate /readyz that the LB can use as a
+    drain signal; we keep this probe path cheap and reliable.
+    """
+    return HttpResponse("ok", content_type="text/plain")
+
+
 urlpatterns = [
+    # Cheap liveness probe — no DB / Redis / auth. See healthz() above.
+    path("healthz/", healthz, name="healthz"),
     # Django Admin
     path("admin/", admin.site.urls),
     # API v1 endpoints

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -1,0 +1,153 @@
+# OpenShiksha — k3s deploy
+
+This is how the **modern** OpenShiksha stack (Django 4.2 backend +
+React/Vite frontend + Celery + Postgres + Redis) gets to qa and prod on the
+`k3s-personal-server` cluster.
+
+> **The legacy root `Dockerfile` (Python 2.7 / Django 1.11 / nginx-in-image)
+> is no longer built or deployed.** CI used to publish it; merging
+> `modernization` → `qa` would fail because the Debian Buster repos it
+> depends on were archived in mid-2024. The legacy file is still in the repo
+> for reference but is excluded from the pipeline.
+
+## What's running
+
+Per-environment namespace:
+
+| Env  | Namespace          | Ingress host         |
+| ---- | ------------------ | -------------------- |
+| qa   | `openshiksha-qa`   | `qa.openshiksha.org` |
+| prod | `openshiksha-prod` | `openshiksha.org`    |
+
+Each namespace contains:
+
+- `Deployment/backend` — Django 4.2 served by Daphne (ASGI).
+- `Deployment/frontend` — React SPA built with Vite, served by nginx.
+- `Deployment/celery-worker` — same backend image, `celery worker` CMD.
+- `Deployment/celery-beat` — same backend image, `celery beat` CMD (strictly
+  1 replica, `strategy: Recreate` — multiple beats would double-fire every
+  scheduled task).
+- `StatefulSet/postgres` — Postgres 15 on a 10 Gi PVC.
+- `StatefulSet/redis` — Redis 7 with AOF persistence on a 2 Gi PVC.
+- `Ingress/openshiksha` — Traefik (k3s default). `/api/*`, `/admin/*`,
+  `/static/*` → backend; everything else → frontend.
+- `ConfigMap/openshiksha-config` — non-secret env.
+- `Secret/openshiksha-secrets` — secret env (NOT in git, see below).
+
+Manifests are kustomize:
+
+```
+k8s/
+  base/                # the shape — neutral on namespace/host/tag
+  overlays/qa/         # namespace=openshiksha-qa, host=qa.openshiksha.org
+  overlays/prod/       # namespace=openshiksha-prod, host=openshiksha.org
+                       # + 2 replicas for backend/frontend
+```
+
+## How a deploy actually happens
+
+1. PR merged into `qa` (or `prod`).
+2. CI runs the existing lint/typecheck/test/frontend jobs.
+3. `build-publish` (matrix: backend + frontend) builds the two prod
+   Dockerfiles, pushes to `ghcr.io/openshiksha/openshiksha-{backend,frontend}`
+   with two tags each: the branch name (`qa` / `prod`) and the commit SHA.
+4. `deploy-qa` / `deploy-prod` —
+   - Pulls the cluster kubeconfig from `secrets.KUBECONFIG`.
+   - `kustomize edit set image …:<sha>` so the Deployment spec is pinned to
+     the digest just built (re-pushing a `:qa` tag doesn't trigger a rollout
+     by itself; pinning by SHA does).
+   - `kubectl apply -k k8s/overlays/{qa,prod}`.
+   - `kubectl rollout status` on every Deployment / StatefulSet with timeouts.
+
+The legacy `kubectl rollout restart deployment openshiksha openshiksha-celery-worker openshiksha-celery-beat -n openshiksha`
+step is **gone**. Those deployments still sit in the old `openshiksha`
+namespace until someone runs `kubectl delete ns openshiksha`.
+
+## One-time bootstrap (per environment)
+
+The `Secret` is not committed to git. Before the first deploy, populate it
+out-of-band — `kubectl apply` of the manifests will create the namespace
+implicitly, but the pods will crash-loop until the Secret exists.
+
+```bash
+# Replace REPLACE-ME values. Random 50-char strings are fine for SECRET_KEY
+# and JWT_SECRET_KEY. The Postgres password becomes part of DATABASE_URL.
+PG_PASSWORD="$(openssl rand -base64 32 | tr -d '/+=' | cut -c1-32)"
+
+kubectl create namespace openshiksha-qa --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl create secret generic openshiksha-secrets -n openshiksha-qa \
+  --from-literal=SECRET_KEY="$(openssl rand -base64 50)" \
+  --from-literal=JWT_SECRET_KEY="$(openssl rand -base64 50)" \
+  --from-literal=POSTGRES_PASSWORD="$PG_PASSWORD" \
+  --from-literal=DATABASE_URL="postgresql://openshiksha:${PG_PASSWORD}@postgres:5432/openshiksha" \
+  --from-literal=REDIS_URL="redis://redis:6379/0" \
+  --from-literal=CELERY_BROKER_URL="redis://redis:6379/1" \
+  --from-literal=CELERY_RESULT_BACKEND="redis://redis:6379/2" \
+  --from-literal=ANTHROPIC_API_KEY="sk-ant-…" \
+  --from-literal=EMAIL_HOST_USER="" \
+  --from-literal=EMAIL_HOST_PASSWORD=""
+```
+
+Repeat for `openshiksha-prod` with a fresh Postgres password.
+
+### TLS
+
+The Ingress is shipped **without TLS** so the first deploy works on a cluster
+that hasn't got cert-manager yet. To enable:
+
+1. Install cert-manager + a `ClusterIssuer` named `letsencrypt-prod`
+   (standard ACME-HTTP01 with Traefik).
+2. Uncomment the `cert-manager.io/cluster-issuer` annotation and the `tls:`
+   block in [`k8s/base/ingress.yaml`](../../k8s/base/ingress.yaml).
+
+Backend prod settings already include `SECURE_PROXY_SSL_HEADER =
+('HTTP_X_FORWARDED_PROTO', 'https')` so it respects the Traefik-terminated
+TLS once it's on; without that, `SECURE_SSL_REDIRECT` would redirect-loop.
+
+## Local sanity-checks for these manifests
+
+You don't need a cluster to validate the YAML:
+
+```bash
+# Render the overlay and pipe through `kubectl apply --dry-run=client` to
+# catch typos / bad refs / mismatched names. No cluster needed.
+kubectl kustomize k8s/overlays/qa   | kubectl apply --dry-run=client -f -
+kubectl kustomize k8s/overlays/prod | kubectl apply --dry-run=client -f -
+```
+
+To build the production images locally:
+
+```bash
+docker build -f backend/Dockerfile.prod         -t openshiksha-backend:dev  backend
+docker build -f frontend_modern/Dockerfile.prod -t openshiksha-frontend:dev frontend_modern
+```
+
+## Rollback
+
+```bash
+kubectl -n openshiksha-qa rollout undo deployment/backend
+kubectl -n openshiksha-qa rollout undo deployment/frontend
+```
+
+Or — cleaner if a bad image is already pulled by other Deployments — re-set
+the image to a known-good SHA and re-apply:
+
+```bash
+cd k8s/overlays/qa
+kustomize edit set image \
+  ghcr.io/openshiksha/openshiksha-backend=ghcr.io/openshiksha/openshiksha-backend:<good-sha> \
+  ghcr.io/openshiksha/openshiksha-frontend=ghcr.io/openshiksha/openshiksha-frontend:<good-sha>
+kubectl apply -k .
+```
+
+## What to delete from the cluster (one-time cleanup)
+
+When you're confident nothing's pointing at the legacy stack:
+
+```bash
+kubectl delete ns openshiksha
+```
+
+(The new modern stack lives in `openshiksha-qa` / `openshiksha-prod` — this
+deletion only nukes the legacy Django 1.11 monolith.)

--- a/frontend_modern/.dockerignore
+++ b/frontend_modern/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+dist
+coverage
+playwright-report
+test-results
+axe-report
+.env
+.env.*
+.vscode
+.idea
+*.log

--- a/frontend_modern/Dockerfile.prod
+++ b/frontend_modern/Dockerfile.prod
@@ -1,0 +1,41 @@
+# Production image for the modern OpenShiksha frontend.
+#
+# Multi-stage:
+#   1. `builder` runs `npm ci && npm run build` → /app/dist (Vite output).
+#   2. `runtime` is nginx serving /app/dist with SPA-style history fallback
+#      so React Router deep links work, plus long cache headers on hashed
+#      assets and a strict no-cache on index.html (so deploys take effect).
+#
+# Bundle budget guard from PERF-06 runs inside the builder stage so a build
+# that exceeds the ceiling fails the CI image build, not just the unit-test
+# job that already ran in `frontend`.
+
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+RUN npm run build
+# Defend the entry-chunk ceiling — fails the image build if it's blown.
+RUN npm run check:budget
+
+# -----------------------------------------------------------------------------
+
+FROM nginx:1.27-alpine AS runtime
+
+# OpenShiksha SPA-friendly nginx config: history fallback for client-side
+# routes, long cache + immutable on /assets/* (Vite content-hashes
+# everything), and a strict no-cache on /index.html so a deploy is visible
+# immediately rather than waiting for a CDN/browser cache to expire.
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget -qO- http://127.0.0.1/healthz || exit 1

--- a/frontend_modern/nginx.conf
+++ b/frontend_modern/nginx.conf
@@ -1,0 +1,52 @@
+# Production nginx config for the OpenShiksha SPA.
+#
+# - History-mode fallback so client-side routes (/login, /student/...) all
+#   serve index.html instead of 404.
+# - Long-cache + immutable on /assets/* — Vite hashes filenames, so the
+#   browser can hold them forever.
+# - Strict no-cache on index.html so a deploy is visible immediately.
+# - A `/healthz` for k8s liveness/readiness + the Docker HEALTHCHECK.
+
+server {
+    listen 80 default_server;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Gzip on text-ish content. Vite emits .gz/.br beside the assets if
+    # configured, but plain on-the-fly gzip is enough for now and works
+    # without an extra build step.
+    gzip on;
+    gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+    gzip_min_length 1024;
+    gzip_proxied any;
+
+    # Hashed assets — safe to cache forever.
+    location /assets/ {
+        access_log off;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+
+    # index.html must never be cached; deploys flip the asset hashes and the
+    # browser needs to see the new HTML to pick them up.
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        expires 0;
+        try_files $uri =404;
+    }
+
+    # Lightweight healthcheck endpoint for k8s probes + Docker HEALTHCHECK.
+    location = /healthz {
+        access_log off;
+        return 200 "ok\n";
+        add_header Content-Type text/plain;
+    }
+
+    # Everything else — SPA fallback.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/k8s/base/backend.yaml
+++ b/k8s/base/backend.yaml
@@ -1,0 +1,87 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  labels:
+    app: backend
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8000
+      targetPort: 8000
+      name: http
+  selector:
+    app: backend
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  labels:
+    app: backend
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      # initContainer runs migrations before the daphne process starts.
+      # Idempotent — safe on every rollout. If it fails the pod won't go ready,
+      # so the rollout halts instead of serving stale schema.
+      initContainers:
+        - name: migrate
+          image: ghcr.io/openshiksha/openshiksha-backend:qa  # overlay rewrites tag
+          command: ["python", "manage.py", "migrate", "--noinput"]
+          envFrom:
+            - configMapRef:
+                name: openshiksha-config
+            - secretRef:
+                name: openshiksha-secrets
+      containers:
+        - name: backend
+          image: ghcr.io/openshiksha/openshiksha-backend:qa  # overlay rewrites tag
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8000
+              name: http
+          envFrom:
+            - configMapRef:
+                name: openshiksha-config
+            - secretRef:
+                name: openshiksha-secrets
+          readinessProbe:
+            httpGet:
+              path: /healthz/
+              port: 8000
+              httpHeaders:
+                - name: X-Forwarded-Proto
+                  value: https
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /healthz/
+              port: 8000
+              httpHeaders:
+                - name: X-Forwarded-Proto
+                  value: https
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1
+              memory: 1Gi

--- a/k8s/base/celery.yaml
+++ b/k8s/base/celery.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: celery-worker
+  labels:
+    app: celery-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: celery-worker
+  template:
+    metadata:
+      labels:
+        app: celery-worker
+    spec:
+      containers:
+        - name: celery-worker
+          image: ghcr.io/openshiksha/openshiksha-backend:qa  # overlay rewrites tag
+          imagePullPolicy: Always
+          # Reuse the backend image — the same code/deps. Override the daphne
+          # CMD with `celery worker`.
+          command: ["celery"]
+          args: ["-A", "openshiksha", "worker", "--loglevel=info", "--concurrency=2"]
+          envFrom:
+            - configMapRef:
+                name: openshiksha-config
+            - secretRef:
+                name: openshiksha-secrets
+          readinessProbe:
+            exec:
+              command: ["celery", "-A", "openshiksha", "inspect", "ping", "-d", "celery@$(hostname)"]
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1
+              memory: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: celery-beat
+  labels:
+    app: celery-beat
+spec:
+  # Beat must be exactly 1 replica — multiple beats would double-fire every
+  # scheduled task. Strategy=Recreate so we never briefly have 2 during a
+  # rollout.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: celery-beat
+  template:
+    metadata:
+      labels:
+        app: celery-beat
+    spec:
+      containers:
+        - name: celery-beat
+          image: ghcr.io/openshiksha/openshiksha-backend:qa  # overlay rewrites tag
+          imagePullPolicy: Always
+          command: ["celery"]
+          args: ["-A", "openshiksha", "beat", "--loglevel=info", "--scheduler", "django_celery_beat.schedulers:DatabaseScheduler"]
+          envFrom:
+            - configMapRef:
+                name: openshiksha-config
+            - secretRef:
+                name: openshiksha-secrets
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi

--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openshiksha-config
+data:
+  # Non-secret env shared by backend + celery + celery-beat.
+  # Overlays patch ALLOWED_HOSTS / CORS_ALLOWED_ORIGINS to the env's hostname.
+  DJANGO_SETTINGS_MODULE: openshiksha.settings.production
+  PYTHONUNBUFFERED: "1"
+  # Overridden per-overlay:
+  ALLOWED_HOSTS: ""
+  CORS_ALLOWED_ORIGINS: ""
+  # Postgres + Redis live in-cluster (see statefulsets); the DATABASE_URL
+  # secret encodes the password. The host/port here are referenced by both
+  # backend and celery for the broker URL fallbacks.
+  POSTGRES_HOST: postgres
+  POSTGRES_PORT: "5432"
+  POSTGRES_DB: openshiksha
+  POSTGRES_USER: openshiksha
+  REDIS_HOST: redis
+  REDIS_PORT: "6379"

--- a/k8s/base/frontend.yaml
+++ b/k8s/base/frontend.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+      name: http
+  selector:
+    app: frontend
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/openshiksha/openshiksha-frontend:qa  # overlay rewrites tag
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 80
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi

--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -1,0 +1,55 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: openshiksha
+  annotations:
+    # k3s ships Traefik by default; this is the IngressClass it creates.
+    # If you've installed nginx-ingress or another controller, change to match.
+    kubernetes.io/ingress.class: traefik
+    # Traefik will redirect HTTP → HTTPS via the websecure entrypoint TLS
+    # config — but if cert-manager is set up on the cluster, uncomment the
+    # next line and the `tls:` block at the bottom so certs are auto-issued
+    # for the host (you'll need a ClusterIssuer named `letsencrypt-prod`).
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  # `host:` is patched per overlay (qa.openshiksha.org, openshiksha.org).
+  rules:
+    - host: PLACEHOLDER.openshiksha.org
+      http:
+        paths:
+          # /api/* and /admin/* go to the Django backend.
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8000
+          - path: /admin
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8000
+          # /static/* served by WhiteNoise off the backend (collectstatic-baked).
+          - path: /static
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8000
+          # Everything else → the React SPA (nginx).
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 80
+  # TLS — uncomment + populate after enabling cert-manager.
+  # tls:
+  #   - hosts:
+  #       - PLACEHOLDER.openshiksha.org
+  #     secretName: openshiksha-tls

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,25 @@
+# Base manifests. Each overlay (k8s/overlays/{qa,prod}) sets:
+#   - the target `namespace`
+#   - the image tag for backend + frontend
+#   - the Ingress host (`ALLOWED_HOSTS` ConfigMap entry stays in sync)
+#
+# `secret.example.yaml` is NOT included — the real Secret is created out-of-band
+# (see docs/deploy/README.md for the kubectl create secret command). Including
+# a stringData stub would silently overwrite real values on every apply.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - postgres.yaml
+  - redis.yaml
+  - backend.yaml
+  - frontend.yaml
+  - celery.yaml
+  - ingress.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: openshiksha
+    includeSelectors: false

--- a/k8s/base/namespace.yaml
+++ b/k8s/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshiksha
+  # Real namespace name is set by each overlay (openshiksha-qa, openshiksha-prod).
+  # The kustomize `namespace:` field rewrites every resource here at build time.

--- a/k8s/base/postgres.yaml
+++ b/k8s/base/postgres.yaml
@@ -1,0 +1,83 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  clusterIP: None
+  ports:
+    - port: 5432
+      name: postgres
+  selector:
+    app: postgres
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: openshiksha-config
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: openshiksha-config
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: openshiksha-secrets
+                  key: POSTGRES_PASSWORD
+            # pg_dump / psql default DB path lives off PGDATA; override so the
+            # PVC mount point isn't fought over by initdb's lost+found check.
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1
+              memory: 1Gi
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi

--- a/k8s/base/redis.yaml
+++ b/k8s/base/redis.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  clusterIP: None
+  ports:
+    - port: 6379
+      name: redis
+  selector:
+    app: redis
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+spec:
+  serviceName: redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          # appendonly: durable persistence so a pod restart doesn't lose the
+          # Celery queue mid-grading.
+          args: ["--appendonly", "yes"]
+          ports:
+            - containerPort: 6379
+              name: redis
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 15
+            periodSeconds: 15
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 2Gi

--- a/k8s/base/secret.example.yaml
+++ b/k8s/base/secret.example.yaml
@@ -1,0 +1,34 @@
+# TEMPLATE — do NOT apply this file directly. It documents the Secret shape
+# that backend + celery + postgres expect, so the operator knows exactly which
+# keys to set when populating real values out-of-band via:
+#
+#   kubectl create secret generic openshiksha-secrets -n openshiksha-qa \
+#     --from-literal=SECRET_KEY='...' \
+#     --from-literal=JWT_SECRET_KEY='...' \
+#     --from-literal=POSTGRES_PASSWORD='...' \
+#     --from-literal=DATABASE_URL='postgresql://openshiksha:<pwd>@postgres:5432/openshiksha' \
+#     --from-literal=REDIS_URL='redis://redis:6379/0' \
+#     --from-literal=CELERY_BROKER_URL='redis://redis:6379/1' \
+#     --from-literal=CELERY_RESULT_BACKEND='redis://redis:6379/2' \
+#     --from-literal=ANTHROPIC_API_KEY='sk-ant-...' \
+#     --from-literal=EMAIL_HOST_USER='...' \
+#     --from-literal=EMAIL_HOST_PASSWORD='...'
+#
+# Sealed-secrets / external-secrets are the right long-term solution; this
+# bootstraps the cluster.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openshiksha-secrets
+type: Opaque
+stringData:
+  SECRET_KEY: REPLACE-ME
+  JWT_SECRET_KEY: REPLACE-ME
+  POSTGRES_PASSWORD: REPLACE-ME
+  DATABASE_URL: postgresql://openshiksha:REPLACE-ME@postgres:5432/openshiksha
+  REDIS_URL: redis://redis:6379/0
+  CELERY_BROKER_URL: redis://redis:6379/1
+  CELERY_RESULT_BACKEND: redis://redis:6379/2
+  ANTHROPIC_API_KEY: ""
+  EMAIL_HOST_USER: ""
+  EMAIL_HOST_PASSWORD: ""

--- a/k8s/overlays/prod/backend-replicas-patch.yaml
+++ b/k8s/overlays/prod/backend-replicas-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  # 2 replicas in prod for HA during rolling updates and node restarts.
+  replicas: 2

--- a/k8s/overlays/prod/configmap-patch.yaml
+++ b/k8s/overlays/prod/configmap-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openshiksha-config
+data:
+  ALLOWED_HOSTS: openshiksha.org,www.openshiksha.org,backend
+  CORS_ALLOWED_ORIGINS: https://openshiksha.org,https://www.openshiksha.org
+  CSRF_TRUSTED_ORIGINS: https://openshiksha.org,https://www.openshiksha.org

--- a/k8s/overlays/prod/frontend-replicas-patch.yaml
+++ b/k8s/overlays/prod/frontend-replicas-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 2

--- a/k8s/overlays/prod/ingress-patch.yaml
+++ b/k8s/overlays/prod/ingress-patch.yaml
@@ -1,0 +1,37 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: openshiksha
+spec:
+  rules:
+    - host: openshiksha.org
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8000
+          - path: /admin
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8000
+          - path: /static
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8000
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 80

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshiksha-prod
+
+resources:
+  - ../../base
+
+images:
+  - name: ghcr.io/openshiksha/openshiksha-backend
+    newTag: prod
+  - name: ghcr.io/openshiksha/openshiksha-frontend
+    newTag: prod
+
+patches:
+  - path: configmap-patch.yaml
+  - path: ingress-patch.yaml
+  - path: backend-replicas-patch.yaml
+  - path: frontend-replicas-patch.yaml

--- a/k8s/overlays/qa/configmap-patch.yaml
+++ b/k8s/overlays/qa/configmap-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openshiksha-config
+data:
+  ALLOWED_HOSTS: qa.openshiksha.org,backend
+  CORS_ALLOWED_ORIGINS: https://qa.openshiksha.org
+  CSRF_TRUSTED_ORIGINS: https://qa.openshiksha.org

--- a/k8s/overlays/qa/ingress-patch.yaml
+++ b/k8s/overlays/qa/ingress-patch.yaml
@@ -1,0 +1,37 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: openshiksha
+spec:
+  rules:
+    - host: qa.openshiksha.org
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8000
+          - path: /admin
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8000
+          - path: /static
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8000
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 80

--- a/k8s/overlays/qa/kustomization.yaml
+++ b/k8s/overlays/qa/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshiksha-qa
+
+resources:
+  - ../../base
+
+# CI rewrites these to point at the digest just pushed, so a rollout actually
+# picks up the new code rather than re-pulling a stale `:qa` tag.
+images:
+  - name: ghcr.io/openshiksha/openshiksha-backend
+    newTag: qa
+  - name: ghcr.io/openshiksha/openshiksha-frontend
+    newTag: qa
+
+patches:
+  - path: configmap-patch.yaml
+  - path: ingress-patch.yaml


### PR DESCRIPTION
## Why this exists

Two distinct problems, one PR.

**1. The qa build has been broken since 2026-06-05.** The CI `build-publish`
job builds the root `Dockerfile` (Python 2.7 + Django 1.11 + nginx-on-Buster).
Debian Buster repos went archive-only mid-2024; `apt-get update` fails inside
that image. Every merge from `modernization` → `qa` since #186 has failed for
this reason, not because of modernization's contents.

**2. Even when the legacy build worked, qa/prod never deployed the modern
stack.** The deploy step only rolled out the legacy monolith. None of the
backend/frontend modernization, the PERF cuts, V2 design, etc. has ever
reached a deployed environment through this pipeline.

## What lands

### Production Dockerfiles
- `backend/Dockerfile.prod` — `python:3.11-slim`, Daphne (ASGI for Channels),
  build-time `collectstatic`, non-root user, `/healthz/` HEALTHCHECK.
- `frontend_modern/Dockerfile.prod` — multi-stage: `npm ci` → `vite build` →
  **PERF-06 budget guard** → `nginx:1.27-alpine` serving `dist/`.
- `frontend_modern/nginx.conf` — SPA history fallback, long-cache+immutable
  on `/assets/*`, no-cache on `index.html`, `/healthz` endpoint.

### Backend app
- New `/healthz/` Django view (cheap — no DB / Redis hit).
- `production.py`: `SECURE_PROXY_SSL_HEADER` so `SECURE_SSL_REDIRECT` doesn't
  infinite-redirect behind Traefik TLS termination.

### Kubernetes manifests (`k8s/` — kustomize)
Base + qa + prod overlays. **13 resources** per overlay:

| Kind | Count | Purpose |
|---|---|---|
| Namespace | 1 | `openshiksha-qa` / `openshiksha-prod` |
| ConfigMap | 1 | Non-secret env (ALLOWED_HOSTS, REDIS_HOST, …) |
| StatefulSet | 2 | Postgres 15 (10 Gi PVC), Redis 7 (2 Gi PVC, AOF) |
| Deployment | 4 | backend (daphne), frontend (nginx), celery-worker, celery-beat (Recreate, 1 replica) |
| Service | 4 | One per Deployment |
| Ingress | 1 | Traefik — `/api`+`/admin`+`/static` → backend, else → frontend |

prod overlay also bumps backend + frontend to 2 replicas.

### CI workflow rewrite
- `build-publish` is a matrix of `{backend, frontend}` → `ghcr.io/<owner>/openshiksha-{service}:{branch,sha}`. Legacy root Dockerfile not built.
- `deploy-qa` (new) + `deploy-prod` (rewritten): `kustomize edit set image` pins the just-built SHA (re-pushing a tag alone doesn't trigger a rollout — pinning by SHA does), `kubectl apply -k`, then `rollout status` on every Deployment + StatefulSet with timeouts.

### Docs
[docs/deploy/README.md](docs/deploy/README.md) — architecture, one-time secret bootstrap, TLS / cert-manager opt-in, local sanity-check commands, rollback procedure.

## ⚠️ Before merging this to qa — read this

Two things have to be true on the cluster, or the first deploy will fail at the `rollout status` step (kubectl apply succeeds, but the pods crash-loop waiting for the Secret):

1. **Create the QA Secret** (one-time, out-of-band) — full command in [docs/deploy/README.md](docs/deploy/README.md#one-time-bootstrap-per-environment).
2. **GitHub Environments** — the workflow uses `environment: qa` and `environment: prod`. If those environments don't exist in repo Settings → Environments, the jobs skip. Create them; no approval reviewers needed yet unless you want them.

Repeat (1) with a fresh password for `openshiksha-prod` before the first prod deploy.

### TLS
Shipped *without* TLS so it boots on a cluster that doesn't have cert-manager yet. Two-line uncomment in [k8s/base/ingress.yaml](k8s/base/ingress.yaml) turns it on once a `letsencrypt-prod` ClusterIssuer exists.

## Verification done locally

- `kubectl kustomize k8s/overlays/qa` and `k8s/overlays/prod` both render clean: 13 resources each, correct namespace, host, image tags, replica counts.
- Backend mypy / black / isort / flake8 pass on the new view + settings.
- Workflow YAML scoped via grep — matrix shape, image tags, kustomize edit command all correct. Docker daemon was down so I couldn't build the prod images locally; CI will catch any Dockerfile issues.
- Pre-commit `check-yaml` updated with `--allow-multiple-documents` so k8s manifests using `---` separators don't fail the hook.

## What this PR does NOT do

- **It does not delete the legacy stack from the cluster.** The old `openshiksha` namespace stays until you run `kubectl delete ns openshiksha` yourself.
- **It does not delete the legacy root `Dockerfile`** — kept for reference; just unhooked from CI per the decision.
- **It does not enable TLS** — covered in the README as a follow-up.
