### PR TITLE
polish(ai): parent dashboard — AI-generated badge + stub note

### DIFF
--- a/docs/ai-features/polish-backlog.md
+++ b/docs/ai-features/polish-backlog.md
@@ -64,6 +64,34 @@ shows the Auto-summary badge + note. Trigger a failing generate → red error li
 
 ---
 
+## 2026-06-07 — Parent intelligence dashboard: AI-generated label + stub note
+
+**Surface:** Parent intelligence dashboard (`NarrativeCard`, parent
+`ParentInsightsPage`).
+
+**Gap (checklist #3 copy/tone, #7 provider transparency):**
+The weekly parent summary narrative (`summary_text`) was shown with **no
+indication it was AI-generated**, and when the provider cascade fell back to the
+deterministic, data-derived stub (`model_used === 'stub'`) the stub text was
+presented identically to genuine LLM output — exactly the inconsistency already
+fixed on the teacher `WeeklyReportPanel`.
+
+**Fix:**
+- `NarrativeCard` now shows a `Badge` in the card header: `✨ AI-generated`
+  (brand tone) for a real LLM, or `Auto-summary` (neutral tone) when
+  `model_used === 'stub'`, plus a small "AI was unavailable, so this summary was
+  built directly from your child's practice data" note under the narrative.
+- `model_used` was already on the `ParentProgressSummary` type/serializer — no
+  backend change needed.
+- New test file `NarrativeCard.test.tsx` covers the AI-generated label and the
+  stub auto-summary path (checklist #8).
+
+**Verify:** Open the parent insights page. With a provider key set the weekly
+summary card shows the ✨ AI-generated badge; with no key the stub summary shows
+the Auto-summary badge + note.
+
+---
+
 ## Remaining gaps (audit notes — not yet addressed)
 
 - **Natural language explanations** — backend `SubpartExplanationViewSet` is
@@ -71,11 +99,10 @@ shows the Auto-summary badge + note. Trigger a failing generate → red error li
   `frontend_modern`**. The post-grading student feedback surface appears to be
   unwired in the V2 app. Needs UX placement work (inline after feedback) — sizeable,
   flag before treating as polish vs. feature.
-- **Parent summaries (`NarrativeCard`) + interventions (`InterventionsPanel`)**
-  still display LLM narrative text with **no AI-generated / stub badge**, unlike
-  the now-fixed `WeeklyReportPanel`. Both already receive `model_used` from their
-  serializers — apply the same `✨ AI-generated` vs `Auto-summary` badge for
-  consistency (one surface per run). `NarrativeCard` has no badge at all;
-  `InterventionsPanel` only has a footer disclaimer line.
+- **Interventions (`InterventionsPanel`)** still displays LLM narrative text
+  with only a footer disclaimer line, unlike the now-fixed `WeeklyReportPanel`
+  and `NarrativeCard`. It already receives `model_used` from its serializer —
+  apply the same `✨ AI-generated` vs `Auto-summary` badge for consistency (next
+  candidate, one surface per run). _(`NarrativeCard` badge done 2026-06-07.)_
 - **Hint system** — solid: loading ("Thinking of a good hint…"), error, and
   exhausted states all present. Low priority.

--- a/frontend_modern/src/features/parent/components/NarrativeCard.test.tsx
+++ b/frontend_modern/src/features/parent/components/NarrativeCard.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { NarrativeCard } from './NarrativeCard';
+import type { ParentProgressSummary } from '../useParentSummary';
+
+const SUMMARY: ParentProgressSummary = {
+  id: 1,
+  parent: 10,
+  child: 20,
+  child_username: 'asha',
+  child_name: 'Asha',
+  week_start: '2026-06-01',
+  week_end: '2026-06-07',
+  summary_text: 'Asha practised on five days this week and is gaining confidence in fractions.',
+  language: 'en',
+  ticks_recorded: 42,
+  active_days: 5,
+  avg_score: 0.78,
+  score_delta: 0.05,
+  weak_chapters: [],
+  strong_chapters: [],
+  home_activities: [],
+  alerts: [],
+  has_urgent_alert: false,
+  model_used: 'claude-sonnet-4-6',
+  generated_at: '2026-06-07T10:00:00Z',
+};
+
+describe('NarrativeCard', () => {
+  it('labels a real LLM summary as AI-generated', () => {
+    render(<NarrativeCard summary={SUMMARY} />);
+
+    expect(screen.getByText(/gaining confidence in fractions/)).toBeDefined();
+    expect(screen.getByText('✨ AI-generated')).toBeDefined();
+    expect(screen.queryByText(/AI was unavailable/)).toBeNull();
+  });
+
+  it('marks a stub fallback as an auto-summary rather than AI output', () => {
+    render(<NarrativeCard summary={{ ...SUMMARY, model_used: 'stub' }} />);
+
+    expect(screen.getByText('Auto-summary')).toBeDefined();
+    expect(screen.getByText(/AI was unavailable/)).toBeDefined();
+    expect(screen.queryByText('✨ AI-generated')).toBeNull();
+  });
+});

--- a/frontend_modern/src/features/parent/components/NarrativeCard.tsx
+++ b/frontend_modern/src/features/parent/components/NarrativeCard.tsx
@@ -1,3 +1,4 @@
+import { Badge } from '@/shared/ui';
 import type { ParentProgressSummary } from '../useParentSummary';
 
 interface Props {
@@ -21,6 +22,10 @@ const StatTile = ({ label, value }: { label: string; value: string }) => (
 
 export const NarrativeCard = ({ summary }: Props) => {
   const weekRange = `${formatDate(summary.week_start)} – ${formatDate(summary.week_end)}`;
+  // The provider cascade falls back to a deterministic, data-derived summary when
+  // no LLM key is configured. That narrative is still useful, but parents must not
+  // see it presented as genuine AI output (provider-cascade transparency).
+  const isStub = summary.model_used === 'stub';
   const deltaPct = Math.round(summary.score_delta * 100);
   const deltaSign = summary.score_delta > 0 ? '+' : '';
   const deltaColor =
@@ -39,11 +44,20 @@ export const NarrativeCard = ({ summary }: Props) => {
           </p>
           <p className="text-sm text-ink-500 mt-1">{weekRange}</p>
         </div>
+        <Badge tone={isStub ? 'neutral' : 'brand'}>
+          {isStub ? 'Auto-summary' : '✨ AI-generated'}
+        </Badge>
       </div>
 
       <p className="mt-4 text-ink-800 leading-relaxed whitespace-pre-line">
         {summary.summary_text}
       </p>
+      {isStub && (
+        <p className="mt-2 text-xs text-ink-400">
+          AI was unavailable, so this summary was built directly from your child's
+          practice data.
+        </p>
+      )}
 
       <div className="mt-5 grid grid-cols-2 sm:grid-cols-4 gap-2">
         <StatTile label="Questions" value={String(summary.ticks_recorded)} />


### PR DESCRIPTION
## Surface
Parent intelligence dashboard — `NarrativeCard` (parent `ParentInsightsPage`).

## Gap fixed (polished checklist #3 copy/tone, #7 provider transparency)
The weekly parent summary narrative was displayed with **no indication it was AI-generated**, and when the provider cascade fell back to the deterministic, data-derived stub (`model_used === 'stub'`), the stub text was shown identically to genuine LLM output. This is the same inconsistency already fixed on the teacher `WeeklyReportPanel` and called out as a remaining gap in `docs/ai-features/polish-backlog.md`.

## Before / after
- **Before:** Parent sees the weekly summary paragraph with no badge — no signal whether it's AI-written or a fallback.
- **After:** Card header shows a `✨ AI-generated` badge (brand tone) for a real LLM, or `Auto-summary` (neutral tone) when the stub ran, plus a small note: "AI was unavailable, so this summary was built directly from your child's practice data."

## Changes
- `NarrativeCard.tsx`: added the `Badge` + stub note. `model_used` was already on the `ParentProgressSummary` type/serializer — no backend change.
- New `NarrativeCard.test.tsx`: covers the AI-generated label and the stub auto-summary path (checklist #8).
- `docs/ai-features/polish-backlog.md`: logged this run; remaining badge gap is now just `InterventionsPanel`.

## How to verify
Open the parent insights page. With a provider key set the weekly summary card shows the ✨ AI-generated badge; with no key the stub summary shows the Auto-summary badge + note. `npx vitest run NarrativeCard` and `npx tsc --noEmit` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)