### PR TITLE
TW-5: join-code UX — expiry, share link, regenerate confirm

### DIFF
--- a/docs/changes/2026-06-07-tw5-join-code-ux.md
+++ b/docs/changes/2026-06-07-tw5-join-code-ux.md
@@ -1,0 +1,38 @@
+# TW-5 — Join-code UX
+
+**Classification:** Improve (frontend-only).
+**Initiative:** Teacher Workspace.
+**Branch:** `feat/2026-06-07-tw5-join-code-ux`.
+
+## Summary
+
+`ClassroomCodeWidget` now surfaces the join code's expiry, a copyable shareable
+link (`/register/school?code=…`), and a confirmation step before regenerating
+(regenerate invalidates the existing code, so this prevents a slip from cutting
+off students who already have it). `RegisterSchoolPage` reads `?code=` from the
+query string and prefills the join-code field.
+
+## Why
+
+The backend already serializes `expires_at` and supports regeneration, but the
+UI hid both. Per the initiative's "no dead-ends" principle, the share path now
+ends in a link a teacher can paste into chat / WhatsApp.
+
+## Changes
+
+- `frontend_modern/src/features/teacher/ClassroomCodeWidget.tsx` — expiry chip
+  (urgent < 48 h), share-link row with copy, two-step regenerate confirm.
+- `frontend_modern/src/features/auth/RegisterSchoolPage.tsx` — read `?code=`
+  from `useSearchParams`, uppercase + truncate to 8 chars, prefill state.
+- `frontend_modern/src/features/teacher/ClassroomCodeWidget.test.tsx` — 7 tests.
+
+## Verify
+
+- `npx vitest run src/features/teacher/ClassroomCodeWidget.test.tsx` — 7/7 green.
+- `npm run type-check` clean. `npm run build` + `npm run check:budget` —
+  entry chunk 93.05 kB (160 kB budget).
+
+## Next
+
+TW-4 (dashboard needs-attention) and TW-3 (assignment lifecycle) follow in this
+batch.

--- a/frontend_modern/src/features/auth/RegisterSchoolPage.tsx
+++ b/frontend_modern/src/features/auth/RegisterSchoolPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { Button, Input } from '@/shared/ui';
 import { AuthLayout } from './AuthLayout';
 import { useRegisterSchoolMutation } from './useRegisterMutation';
@@ -16,13 +16,15 @@ function extractError(err: unknown): string {
 
 export const RegisterSchoolPage = () => {
   const mutation = useRegisterSchoolMutation();
+  const [searchParams] = useSearchParams();
+  const prefillCode = (searchParams.get('code') ?? '').toUpperCase().slice(0, 8);
   const [form, setForm] = useState({
     first_name: '',
     last_name: '',
     username: '',
     password: '',
     email: '',
-    join_code: '',
+    join_code: prefillCode,
   });
 
   const set = (field: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement>) =>

--- a/frontend_modern/src/features/teacher/ClassroomCodeWidget.test.tsx
+++ b/frontend_modern/src/features/teacher/ClassroomCodeWidget.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ClassroomCodeWidget } from './ClassroomCodeWidget';
+import type { ClassroomInviteCode } from '@/types/index';
+
+const { mockGet, mockPost } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPost: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  apiClient: { get: mockGet, post: mockPost },
+}));
+
+function makeCode(overrides: Partial<ClassroomInviteCode> = {}): ClassroomInviteCode {
+  return {
+    id: 1,
+    code: 'ABC123',
+    classroom_id: 5,
+    classroom_name: 'Std 8 A',
+    is_active: true,
+    expires_at: null,
+    created_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderWidget() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <ClassroomCodeWidget classroomId={5} classroomName="Std 8 A" />
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockPost.mockReset();
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    configurable: true,
+  });
+  // jsdom defaults to http://localhost/
+});
+
+describe('ClassroomCodeWidget', () => {
+  it('renders "No expiry" when expires_at is null', async () => {
+    mockGet.mockResolvedValue({ data: [makeCode({ expires_at: null })] });
+    renderWidget();
+    expect(await screen.findByTestId('join-code-expiry')).toHaveTextContent('No expiry');
+  });
+
+  it('renders relative expiry for a dated code', async () => {
+    const future = new Date(Date.now() + 6 * 24 * 60 * 60 * 1000).toISOString();
+    mockGet.mockResolvedValue({ data: [makeCode({ expires_at: future })] });
+    renderWidget();
+    const expiry = await screen.findByTestId('join-code-expiry');
+    expect(expiry.textContent).toMatch(/Expires in \d+ days/);
+  });
+
+  it('marks expiry urgent when less than 48 hours away', async () => {
+    const soon = new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString();
+    mockGet.mockResolvedValue({ data: [makeCode({ expires_at: soon })] });
+    renderWidget();
+    const expiry = await screen.findByTestId('join-code-expiry');
+    expect(expiry.textContent).toMatch(/Expires in \d+ hour/);
+    expect(expiry.className).toMatch(/rose/);
+  });
+
+  it('builds a shareable link with the code in the query string', async () => {
+    mockGet.mockResolvedValue({ data: [makeCode()] });
+    renderWidget();
+    const link = await screen.findByTestId('join-code-link');
+    expect((link as HTMLInputElement).value).toContain('/register/school?code=ABC123');
+  });
+
+  it('copies the shareable link via the Copy link button', async () => {
+    mockGet.mockResolvedValue({ data: [makeCode()] });
+    renderWidget();
+    const copyLinkBtn = await screen.findByRole('button', { name: /copy link/i });
+    fireEvent.click(copyLinkBtn);
+    await waitFor(() => {
+      expect((navigator.clipboard.writeText as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(
+        expect.stringContaining('/register/school?code=ABC123'),
+      );
+    });
+  });
+
+  it('asks for confirmation before regenerating', async () => {
+    mockGet.mockResolvedValue({ data: [makeCode()] });
+    mockPost.mockResolvedValue({ data: makeCode({ code: 'XYZ789' }) });
+    renderWidget();
+    const regenBtn = await screen.findByRole('button', { name: /^regenerate$/i });
+    fireEvent.click(regenBtn);
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    expect(mockPost).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: /yes, regenerate/i }));
+    await waitFor(() => expect(mockPost).toHaveBeenCalledWith(
+      '/users/me/classroom-code/',
+      { classroom_id: 5 },
+    ));
+  });
+
+  it('cancels the regenerate confirmation without calling the API', async () => {
+    mockGet.mockResolvedValue({ data: [makeCode()] });
+    renderWidget();
+    fireEvent.click(await screen.findByRole('button', { name: /^regenerate$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+});

--- a/frontend_modern/src/features/teacher/ClassroomCodeWidget.tsx
+++ b/frontend_modern/src/features/teacher/ClassroomCodeWidget.tsx
@@ -21,9 +21,24 @@ interface Props {
   classroomName: string;
 }
 
+const formatExpiry = (expiresAt: string | null): { text: string; urgent: boolean } => {
+  if (!expiresAt) return { text: 'No expiry', urgent: false };
+  const expires = new Date(expiresAt).getTime();
+  const now = Date.now();
+  const diffMs = expires - now;
+  if (diffMs <= 0) return { text: 'Expired', urgent: true };
+  const hours = Math.floor(diffMs / (1000 * 60 * 60));
+  if (hours < 48) {
+    return { text: hours <= 1 ? 'Expires in <1 hour' : `Expires in ${hours} hours`, urgent: true };
+  }
+  const days = Math.floor(hours / 24);
+  return { text: `Expires in ${days} days`, urgent: false };
+};
+
 export const ClassroomCodeWidget = ({ classroomId, classroomName }: Props) => {
   const queryClient = useQueryClient();
-  const [copied, setCopied] = useState(false);
+  const [copied, setCopied] = useState<'code' | 'link' | null>(null);
+  const [confirmRegenerate, setConfirmRegenerate] = useState(false);
 
   const { data: codes } = useQuery<ClassroomInviteCode[]>({
     queryKey: ['classroom-codes'],
@@ -32,18 +47,26 @@ export const ClassroomCodeWidget = ({ classroomId, classroomName }: Props) => {
 
   const generateMutation = useMutation({
     mutationFn: () => generateCode(classroomId),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['classroom-codes'] }),
+    onSuccess: () => {
+      setConfirmRegenerate(false);
+      queryClient.invalidateQueries({ queryKey: ['classroom-codes'] });
+    },
   });
 
   const myCode = codes?.find((c) => c.classroom_id === classroomId);
 
-  const handleCopy = () => {
-    if (!myCode) return;
-    navigator.clipboard.writeText(myCode.code).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+  const shareLink = myCode
+    ? `${window.location.origin}/register/school?code=${encodeURIComponent(myCode.code)}`
+    : '';
+
+  const handleCopy = (value: string, which: 'code' | 'link') => {
+    navigator.clipboard.writeText(value).then(() => {
+      setCopied(which);
+      setTimeout(() => setCopied(null), 2000);
     });
   };
+
+  const expiry = myCode ? formatExpiry(myCode.expires_at) : null;
 
   return (
     <div className="mt-3 border-t border-ink-100 pt-3">
@@ -51,22 +74,77 @@ export const ClassroomCodeWidget = ({ classroomId, classroomName }: Props) => {
         Classroom Join Code
       </p>
       {myCode ? (
-        <div className="flex flex-wrap items-center gap-2">
-          <code className="rounded-lg bg-brand-50 px-3 py-1.5 font-mono text-sm font-bold tracking-widest text-brand-800 ring-1 ring-brand-100">
-            {myCode.code}
-          </code>
-          <Button variant="ghost" size="sm" onClick={handleCopy}>
-            {copied ? 'Copied!' : 'Copy'}
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => generateMutation.mutate()}
-            disabled={generateMutation.isPending}
-            title={`Regenerate join code for ${classroomName}`}
-          >
-            {generateMutation.isPending ? '…' : 'Regenerate'}
-          </Button>
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <code
+              className="rounded-lg bg-brand-50 px-3 py-1.5 font-mono text-sm font-bold tracking-widest text-brand-800 ring-1 ring-brand-100"
+              data-testid="join-code"
+            >
+              {myCode.code}
+            </code>
+            <Button variant="ghost" size="sm" onClick={() => handleCopy(myCode.code, 'code')}>
+              {copied === 'code' ? 'Copied!' : 'Copy code'}
+            </Button>
+            {expiry && (
+              <span
+                className={`text-xs ${expiry.urgent ? 'font-semibold text-rose-600' : 'text-ink-500'}`}
+                data-testid="join-code-expiry"
+              >
+                {expiry.text}
+              </span>
+            )}
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <input
+              readOnly
+              value={shareLink}
+              data-testid="join-code-link"
+              className="min-w-0 flex-1 rounded-lg border border-ink-200 bg-paper px-2 py-1 font-mono text-xs text-ink-700"
+              onFocus={(e) => e.currentTarget.select()}
+            />
+            <Button variant="ghost" size="sm" onClick={() => handleCopy(shareLink, 'link')}>
+              {copied === 'link' ? 'Copied!' : 'Copy link'}
+            </Button>
+          </div>
+          {confirmRegenerate ? (
+            <div
+              className="rounded-lg border border-amber-200 bg-amber-50 p-2 text-xs text-amber-900"
+              role="alertdialog"
+              aria-label="Confirm regenerate join code"
+            >
+              <p className="mb-2">
+                Regenerating invalidates the current code. Students who haven't joined yet
+                will need the new one.
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  variant="brand"
+                  size="sm"
+                  onClick={() => generateMutation.mutate()}
+                  disabled={generateMutation.isPending}
+                >
+                  {generateMutation.isPending ? '…' : 'Yes, regenerate'}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setConfirmRegenerate(false)}
+                  disabled={generateMutation.isPending}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setConfirmRegenerate(true)}
+              title={`Regenerate join code for ${classroomName}`}
+            >
+              Regenerate
+            </Button>
+          )}
         </div>
       ) : (
         <Button


### PR DESCRIPTION
## Summary
- Show `expires_at` as relative text (urgent < 48 h) on the join-code widget.
- Add a copyable shareable link (`/register/school?code=…`); `RegisterSchoolPage` now prefills from the `?code=` param.
- Wrap **Regenerate** in an inline confirmation so a slip can't invalidate a code students already have.

## Classification
Improve (frontend-only). Backend already serializes `expires_at` and supports regenerate.

## Tests
- `ClassroomCodeWidget.test.tsx` — 7 tests: expiry rendering (null/dated/urgent), share-link build + copy, regenerate confirm + cancel.
- `npm run type-check`, `npm run build`, `npm run check:budget` (entry 93.05 kB / 160 kB budget) all green.

## Verify
- Open teacher dashboard, expand a classroom card → join-code widget shows expiry + share link.
- Click **Regenerate** → confirmation dialog appears before the POST fires.
- Open the share link in a private window → `RegisterSchoolPage` join-code field is prefilled.

Initiative doc: `docs/initiatives/teacher-workspace.md` (TW-5).