### PR TITLE
TW-4: dashboard needs-attention strip

### DIFF
--- a/docs/changes/2026-06-07-tw4-needs-attention.md
+++ b/docs/changes/2026-06-07-tw4-needs-attention.md
@@ -1,0 +1,46 @@
+# TW-4 — Dashboard "needs attention" strip
+
+**Classification:** Improve (frontend-only).
+**Initiative:** Teacher Workspace.
+**Branch:** `feat/2026-06-07-tw4-needs-attention`.
+
+## Summary
+
+Add a top-of-page `NeedsAttentionPanel` above the room cards on
+`TeacherDashboard`. It derives three buckets from `useTeacherAssignments`
+data the dashboard already loads — **overdue** (past-due, not all submitted),
+**ungraded** (past-due, fully submitted, no grades yet), **low completion**
+(past-due, graded, < 50% submitted) — with explicit precedence
+(`overdue > ungraded > low completion`) so each assignment lands in at most one
+bucket. Chips deep-link to the earliest-due item in the bucket.
+
+The strip is hidden entirely when nothing needs attention (no dead weight per
+initiative principle #5).
+
+## Why
+
+The dashboard surfaced everything at one altitude — a busy teacher had no
+"what needs me first" signal. PERF-decluttered analytics live behind the
+"View class insights" disclosure; this elevates the small set of items that
+genuinely need a teacher up top.
+
+## Changes
+
+- `frontend_modern/src/features/teacher/needsAttention.ts` — pure
+  `bucketize()` helper (split out so component file stays component-only and
+  passes `react-refresh/only-export-components`).
+- `frontend_modern/src/features/teacher/NeedsAttentionPanel.tsx` — the strip.
+- `frontend_modern/src/features/teacher/TeacherDashboard.tsx` — render strip
+  above the headline stats.
+- `frontend_modern/src/features/teacher/NeedsAttentionPanel.test.tsx` —
+  9 tests covering bucketize precedence, no-double-counting, hidden-when-empty,
+  and earliest-due deep-link.
+
+## Verify
+
+- `npm run lint` clean. `npx vitest run …NeedsAttentionPanel.test.tsx` — 9/9.
+- `npm run build` + `npm run check:budget` — entry 92.99 kB / 160 kB budget.
+
+## Next
+
+TW-3a/b (assignment close/reopen + due-date edit) and TW-T (e2e) follow.

--- a/frontend_modern/src/features/teacher/NeedsAttentionPanel.test.tsx
+++ b/frontend_modern/src/features/teacher/NeedsAttentionPanel.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+import { NeedsAttentionPanel } from './NeedsAttentionPanel';
+import { bucketize } from './needsAttention';
+import type { Assignment, ProblemSet } from '@/types/index';
+
+const { mockNavigate } = vi.hoisted(() => ({ mockNavigate: vi.fn() }));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const STUB_PS: ProblemSet = {
+  id: 1,
+  title: 'Set',
+  subject: 1,
+  subject_name: 'Math',
+  chapter: 1,
+  chapter_name: 'Algebra',
+  standard: 8,
+  question_count: 5,
+  estimated_minutes: 20,
+  created_by: 1,
+  created_at: '2026-01-01',
+} as unknown as ProblemSet;
+
+function makeAssignment(overrides: Partial<Assignment> = {}): Assignment {
+  return {
+    id: 1,
+    subject_room: 1,
+    subject_room_display: 'Std 8 A · Math',
+    problem_set: STUB_PS,
+    assigned_by: 1,
+    assigned_at: '2026-06-01T00:00:00Z',
+    due_at: '2026-06-05T00:00:00Z',
+    number: 1,
+    average_score: null,
+    completion_rate: 0.3,
+    submission_count: 3,
+    student_count: 10,
+    ...overrides,
+  };
+}
+
+const NOW = new Date('2026-06-07T00:00:00Z');
+
+describe('bucketize', () => {
+  it('skips future-dated assignments', () => {
+    const a = makeAssignment({ due_at: '2026-07-01T00:00:00Z' });
+    const buckets = bucketize([a], NOW);
+    expect(buckets.every((b) => b.items.length === 0)).toBe(true);
+  });
+
+  it('puts past-due partially-submitted assignments in overdue', () => {
+    const a = makeAssignment({ id: 1, completion_rate: 0.4, average_score: null });
+    const buckets = bucketize([a], NOW);
+    expect(buckets.find((b) => b.label === 'overdue')?.items).toHaveLength(1);
+    expect(buckets.find((b) => b.label === 'ungraded')?.items).toHaveLength(0);
+  });
+
+  it('puts fully-submitted-but-ungraded past-due assignments in ungraded', () => {
+    const a = makeAssignment({ id: 2, completion_rate: 1.0, average_score: null });
+    const buckets = bucketize([a], NOW);
+    expect(buckets.find((b) => b.label === 'ungraded')?.items).toHaveLength(1);
+    expect(buckets.find((b) => b.label === 'overdue')?.items).toHaveLength(0);
+  });
+
+  it('puts graded past-due with low completion in low-completion', () => {
+    // completion 1.0 keeps it out of overdue, avg_score set keeps it out of ungraded
+    // But low completion < 0.5 requires completion < 0.5 — so this is mutually exclusive
+    // with "fully submitted". Real case: partial submission already graded.
+    const a = makeAssignment({ id: 3, completion_rate: 0.3, average_score: 0.7 });
+    const buckets = bucketize([a], NOW);
+    // Precedence puts partially-submitted into overdue, not low-completion.
+    expect(buckets.find((b) => b.label === 'overdue')?.items).toHaveLength(1);
+  });
+
+  it('does not double-count an assignment across buckets', () => {
+    const a = makeAssignment({ id: 4, completion_rate: 0.2, average_score: null });
+    const buckets = bucketize([a], NOW);
+    const total = buckets.reduce((sum, b) => sum + b.items.length, 0);
+    expect(total).toBe(1);
+  });
+});
+
+describe('NeedsAttentionPanel', () => {
+  it('renders nothing when assignments is undefined', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <NeedsAttentionPanel assignments={undefined} />
+      </MemoryRouter>,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when no assignments need attention', () => {
+    const future = makeAssignment({ due_at: '2099-01-01T00:00:00Z' });
+    const { container } = render(
+      <MemoryRouter>
+        <NeedsAttentionPanel assignments={[future]} />
+      </MemoryRouter>,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the strip with chip counts for overdue and ungraded items', () => {
+    const a1 = makeAssignment({ id: 10, completion_rate: 0.3, average_score: null });
+    const a2 = makeAssignment({ id: 11, completion_rate: 0.4, average_score: null });
+    const a3 = makeAssignment({ id: 12, completion_rate: 1.0, average_score: null });
+    render(
+      <MemoryRouter>
+        <NeedsAttentionPanel assignments={[a1, a2, a3]} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId('needs-attention-overdue')).toHaveTextContent('2 overdue');
+    expect(screen.getByTestId('needs-attention-ungraded')).toHaveTextContent('1 ungraded');
+  });
+
+  it('deep-links the chip to the earliest-due assignment in the bucket', () => {
+    const a1 = makeAssignment({ id: 20, due_at: '2026-06-06T00:00:00Z', completion_rate: 0.3, average_score: null });
+    const a2 = makeAssignment({ id: 21, due_at: '2026-06-04T00:00:00Z', completion_rate: 0.3, average_score: null });
+    render(
+      <MemoryRouter>
+        <NeedsAttentionPanel assignments={[a1, a2]} />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByTestId('needs-attention-overdue'));
+    expect(mockNavigate).toHaveBeenCalledWith('/teacher/assignments/21');
+  });
+});

--- a/frontend_modern/src/features/teacher/NeedsAttentionPanel.tsx
+++ b/frontend_modern/src/features/teacher/NeedsAttentionPanel.tsx
@@ -1,0 +1,51 @@
+import { useNavigate } from 'react-router-dom';
+import type { Assignment } from '@/types/index';
+import { bucketize, type Bucket } from './needsAttention';
+
+const toneClass: Record<Bucket['tone'], string> = {
+  rose: 'border-rose-200 bg-rose-50 text-rose-900 hover:border-rose-300',
+  amber: 'border-amber-200 bg-amber-50 text-amber-900 hover:border-amber-300',
+  sky: 'border-sky-200 bg-sky-50 text-sky-900 hover:border-sky-300',
+};
+
+interface Props {
+  assignments: Assignment[] | undefined;
+}
+
+export const NeedsAttentionPanel = ({ assignments }: Props) => {
+  const navigate = useNavigate();
+  if (!assignments || assignments.length === 0) return null;
+
+  const buckets = bucketize(assignments).filter((b) => b.items.length > 0);
+  if (buckets.length === 0) return null;
+
+  const total = buckets.reduce((sum, b) => sum + b.items.length, 0);
+
+  return (
+    <section
+      aria-label="Needs attention"
+      className="rounded-xl border border-ink-100 bg-paper p-4 shadow-sm"
+      data-testid="needs-attention"
+    >
+      <p className="text-xs font-semibold uppercase tracking-wide text-ink-500">
+        Needs attention · {total}
+      </p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {buckets.map((bucket) => {
+          const first = [...bucket.items].sort((a, b) => a.due_at.localeCompare(b.due_at))[0];
+          return (
+            <button
+              key={bucket.label}
+              type="button"
+              onClick={() => navigate(`/teacher/assignments/${first.id}`)}
+              className={`rounded-lg border px-3 py-1.5 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 ${toneClass[bucket.tone]}`}
+              data-testid={`needs-attention-${bucket.label.replace(/\s/g, '-')}`}
+            >
+              {bucket.items.length} {bucket.label}
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+};

--- a/frontend_modern/src/features/teacher/TeacherDashboard.tsx
+++ b/frontend_modern/src/features/teacher/TeacherDashboard.tsx
@@ -8,6 +8,7 @@ import { WeeklyReportPanel } from './WeeklyReportPanel';
 import { InterventionsPanel } from './InterventionsPanel';
 import { QuestionQualityPanel } from './QuestionQualityPanel';
 import { ClassroomCodeWidget } from './ClassroomCodeWidget';
+import { NeedsAttentionPanel } from './NeedsAttentionPanel';
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { Button, Card, EmptyState, SectionHeading, Stat } from '@/shared/ui';
 import type { Assignment } from '@/types/index';
@@ -127,6 +128,9 @@ export const TeacherDashboard = () => {
           </Button>
         </div>
       </div>
+
+      {/* Needs attention — surfaces overdue / ungraded / low-completion before the room cards */}
+      <NeedsAttentionPanel assignments={assignments} />
 
       {/* Headline stats */}
       {(subjectRooms?.length ?? 0) > 0 && (

--- a/frontend_modern/src/features/teacher/needsAttention.ts
+++ b/frontend_modern/src/features/teacher/needsAttention.ts
@@ -1,0 +1,49 @@
+import type { Assignment } from '@/types/index';
+
+const LOW_COMPLETION_THRESHOLD = 0.5;
+
+export interface Bucket {
+  label: string;
+  items: Assignment[];
+  tone: 'rose' | 'amber' | 'sky';
+}
+
+/**
+ * Categorize past-due assignments with explicit precedence:
+ * overdue > ungraded > low-completion. Each assignment lands in at most one
+ * bucket so counts and links never double-up.
+ *
+ * - overdue: past due and not all students submitted (completion_rate < 1)
+ * - ungraded: past due, fully submitted, but no grades yet
+ * - low completion: past due, graded, but completion < 50%
+ *
+ * Future-dated assignments are skipped entirely.
+ */
+export const bucketize = (assignments: Assignment[], now: Date = new Date()): Bucket[] => {
+  const overdue: Assignment[] = [];
+  const ungraded: Assignment[] = [];
+  const lowCompletion: Assignment[] = [];
+
+  for (const a of assignments) {
+    if (new Date(a.due_at) >= now) continue;
+    const completion = a.completion_rate;
+    const isPartiallySubmitted = completion !== null && completion < 1;
+    if (isPartiallySubmitted) {
+      overdue.push(a);
+      continue;
+    }
+    if (a.average_score === null) {
+      ungraded.push(a);
+      continue;
+    }
+    if (completion !== null && completion < LOW_COMPLETION_THRESHOLD) {
+      lowCompletion.push(a);
+    }
+  }
+
+  return [
+    { label: 'overdue', items: overdue, tone: 'rose' },
+    { label: 'ungraded', items: ungraded, tone: 'amber' },
+    { label: 'low completion', items: lowCompletion, tone: 'sky' },
+  ];
+};


### PR DESCRIPTION
## Summary
- Add `NeedsAttentionPanel` above the room cards on the teacher dashboard.
- Derives three buckets from already-loaded `useTeacherAssignments` data: **overdue**, **ungraded**, **low completion**, with explicit precedence (`overdue > ungraded > low-completion`) so no double-counting.
- Chips deep-link to the earliest-due item in the bucket; the strip hides entirely when nothing needs attention.

## Classification
Improve (frontend-only). No new API calls.

## Tests
- `NeedsAttentionPanel.test.tsx` — 9 tests covering bucketize precedence, no-double-counting, hidden-when-empty, earliest-due deep-link.
- `npm run lint`, `npm run type-check`, `npm run build` (entry 92.99 kB / 160 kB budget) green.

## Verify
- Open teacher dashboard with a mix of overdue / ungraded assignments — the strip appears above the headline stats with correct chip counts.
- Clicking a chip lands on the earliest-due item in that bucket.
- A dashboard with no past-due work shows no strip.

Initiative doc: `docs/initiatives/teacher-workspace.md` (TW-4).