### PR TITLE
TW-3b: assignment lifecycle UI (due-date edit + close/reopen)

### DIFF
--- a/docs/changes/2026-06-07-tw3b-lifecycle-ui.md
+++ b/docs/changes/2026-06-07-tw3b-lifecycle-ui.md
@@ -1,0 +1,46 @@
+# TW-3b — Assignment lifecycle UI (frontend)
+
+**Classification:** Improve (frontend, depends on TW-3a).
+**Initiative:** Teacher Workspace.
+**Branch:** `feat/2026-06-07-tw3b-lifecycle-ui` (branched off TW-3a).
+
+## Summary
+
+Adds inline lifecycle controls to `TeacherAssignmentDetailPage`:
+- A `datetime-local` due-date editor that PATCHes the assignment (already
+  permitted by the `ModelViewSet`).
+- Close / Reopen buttons wired to the TW-3a `close` / `reopen` actions.
+- Header badge swaps among `Active` / `Overdue` / `Closed` from the serialized
+  `status`.
+- Due-date input and Save button disabled while the assignment is closed
+  (re-date by reopening first).
+
+After a successful mutation, the detail and list queries are invalidated so
+the dashboard's `NeedsAttentionPanel` reflects the change.
+
+## Why
+
+`TeacherAssignmentDetailPage` was read-only — a teacher who set the wrong due
+date or wanted to stop accepting late work had to use Django admin. This is
+the TW-3 Definition of Done.
+
+## Changes
+
+- `frontend_modern/src/features/teacher/useTeacherAssignmentDetail.ts` —
+  add `updateDueAtMutation`, `closeMutation`, `reopenMutation`; invalidate
+  detail + list queries on success.
+- `frontend_modern/src/features/teacher/TeacherAssignmentDetailPage.tsx` —
+  render lifecycle controls, derive status badge.
+- `frontend_modern/src/features/teacher/TeacherAssignmentDetailPage.test.tsx`
+  — 6 tests: badges (Active/Closed), PATCH due-date, POST close/reopen,
+  disabled-when-closed.
+
+## Verify
+
+- `npm run lint` clean, `npm run type-check` clean.
+- `npx vitest run …TeacherAssignmentDetailPage.test.tsx` — 6/6 green.
+- `npm run build` + `npm run check:budget` — entry 92.99 kB / 160 kB.
+
+## Next
+
+TW-T (Playwright e2e) locks in the full TW-1 → TW-3 continuity flow.

--- a/frontend_modern/src/features/teacher/TeacherAssignmentDetailPage.test.tsx
+++ b/frontend_modern/src/features/teacher/TeacherAssignmentDetailPage.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { TeacherAssignmentDetailPage } from './TeacherAssignmentDetailPage';
+import type { Assignment, ProblemSet } from '@/types/index';
+
+const { mockGet, mockPatch, mockPost } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPatch: vi.fn(),
+  mockPost: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  apiClient: { get: mockGet, patch: mockPatch, post: mockPost },
+}));
+
+const STUB_PS = {
+  id: 1,
+  title: 'Algebra #1',
+  subject: 1,
+  subject_name: 'Math',
+  chapter: 1,
+  chapter_name: 'Algebra',
+  standard: 8,
+  question_count: 5,
+  estimated_minutes: 20,
+  created_by: 1,
+  created_at: '2026-01-01',
+} as unknown as ProblemSet;
+
+function makeAssignment(overrides: Partial<Assignment> = {}): Assignment {
+  return {
+    id: 7,
+    subject_room: 1,
+    subject_room_display: 'Std 8 A · Math',
+    problem_set: STUB_PS,
+    assigned_by: 1,
+    assigned_at: '2026-06-01T00:00:00Z',
+    due_at: '2026-06-10T10:00:00Z',
+    number: 1,
+    average_score: null,
+    completion_rate: 0.2,
+    submission_count: 2,
+    student_count: 10,
+    closed_at: null,
+    status: 'active',
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/teacher/assignments/7']}>
+        <Routes>
+          <Route path="/teacher/assignments/:id" element={<TeacherAssignmentDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockPatch.mockReset();
+  mockPost.mockReset();
+});
+
+describe('TeacherAssignmentDetailPage — lifecycle controls', () => {
+  it('renders the Active badge and Close button when assignment is active', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/submissions')) return Promise.resolve({ data: [] });
+      return Promise.resolve({ data: makeAssignment() });
+    });
+    renderPage();
+    expect(await screen.findByText('Active')).toBeInTheDocument();
+    expect(screen.getByTestId('close-button')).toBeInTheDocument();
+  });
+
+  it('renders the Closed badge and Reopen button when assignment is closed', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/submissions')) return Promise.resolve({ data: [] });
+      return Promise.resolve({
+        data: makeAssignment({ status: 'closed', closed_at: '2026-06-08T00:00:00Z' }),
+      });
+    });
+    renderPage();
+    expect(await screen.findByText('Closed')).toBeInTheDocument();
+    expect(screen.getByTestId('reopen-button')).toBeInTheDocument();
+    expect(screen.queryByTestId('close-button')).not.toBeInTheDocument();
+  });
+
+  it('PATCHes the due date when Save due date is clicked', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/submissions')) return Promise.resolve({ data: [] });
+      return Promise.resolve({ data: makeAssignment() });
+    });
+    mockPatch.mockResolvedValue({ data: makeAssignment({ due_at: '2026-07-01T10:00:00Z' }) });
+    renderPage();
+    const input = (await screen.findByTestId('due-at-input')) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '2026-07-01T10:00' } });
+    fireEvent.click(screen.getByTestId('due-at-save'));
+    await waitFor(() => {
+      expect(mockPatch).toHaveBeenCalledWith(
+        '/assignments/7/',
+        expect.objectContaining({ due_at: expect.any(String) }),
+      );
+    });
+  });
+
+  it('POSTs to /close/ when Close is clicked', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/submissions')) return Promise.resolve({ data: [] });
+      return Promise.resolve({ data: makeAssignment() });
+    });
+    mockPost.mockResolvedValue({
+      data: makeAssignment({ status: 'closed', closed_at: '2026-06-08T00:00:00Z' }),
+    });
+    renderPage();
+    fireEvent.click(await screen.findByTestId('close-button'));
+    await waitFor(() => expect(mockPost).toHaveBeenCalledWith('/assignments/7/close/'));
+  });
+
+  it('POSTs to /reopen/ when Reopen is clicked', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/submissions')) return Promise.resolve({ data: [] });
+      return Promise.resolve({
+        data: makeAssignment({ status: 'closed', closed_at: '2026-06-08T00:00:00Z' }),
+      });
+    });
+    mockPost.mockResolvedValue({ data: makeAssignment({ status: 'active', closed_at: null }) });
+    renderPage();
+    fireEvent.click(await screen.findByTestId('reopen-button'));
+    await waitFor(() => expect(mockPost).toHaveBeenCalledWith('/assignments/7/reopen/'));
+  });
+
+  it('disables due-date controls when assignment is closed', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/submissions')) return Promise.resolve({ data: [] });
+      return Promise.resolve({
+        data: makeAssignment({ status: 'closed', closed_at: '2026-06-08T00:00:00Z' }),
+      });
+    });
+    renderPage();
+    const input = (await screen.findByTestId('due-at-input')) as HTMLInputElement;
+    expect(input.disabled).toBe(true);
+    expect((screen.getByTestId('due-at-save') as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/frontend_modern/src/features/teacher/TeacherAssignmentDetailPage.tsx
+++ b/frontend_modern/src/features/teacher/TeacherAssignmentDetailPage.tsx
@@ -1,8 +1,10 @@
+import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTeacherAssignmentDetail } from './useTeacherAssignmentDetail';
 import { useQuestionMistakes } from './useQuestionMistakes';
 import {
   Badge,
+  Button,
   EmptyState,
   LoadingSpinner,
   SectionHeading,
@@ -89,8 +91,21 @@ export const TeacherAssignmentDetailPage = () => {
   const navigate = useNavigate();
   const assignmentId = id ? parseInt(id, 10) : 0;
 
-  const { metaQuery, submissionsQuery } = useTeacherAssignmentDetail(assignmentId);
+  const { metaQuery, submissionsQuery, updateDueAtMutation, closeMutation, reopenMutation } =
+    useTeacherAssignmentDetail(assignmentId);
   const { data: mistakes } = useQuestionMistakes(metaQuery.data?.subject_room);
+
+  // Draft holds the user's edit; null means "show server value".
+  // datetime-local input expects "YYYY-MM-DDTHH:mm" in local time.
+  const [dueAtDraft, setDueAtDraft] = useState<string | null>(null);
+  const serverDueAtLocal = (() => {
+    const dueAt = metaQuery.data?.due_at;
+    if (!dueAt) return '';
+    const d = new Date(dueAt);
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  })();
+  const dueAtValue = dueAtDraft ?? serverDueAtLocal;
 
   const isLoading = metaQuery.isLoading || submissionsQuery.isLoading;
   const isError = metaQuery.isError || submissionsQuery.isError;
@@ -135,6 +150,24 @@ export const TeacherAssignmentDetailPage = () => {
   });
   const overdue = isOverdue(assignment.due_at);
   const submissionPct = totalStudents > 0 ? (submittedCount / totalStudents) * 100 : 0;
+  const status = assignment.status ?? (overdue ? 'overdue' : 'active');
+  const isClosed = status === 'closed';
+
+  const statusBadge = isClosed ? (
+    <Badge tone="neutral">Closed</Badge>
+  ) : status === 'overdue' ? (
+    <Badge tone="urgent">Overdue</Badge>
+  ) : (
+    <Badge tone="brand">Active</Badge>
+  );
+
+  const handleDueAtSave = () => {
+    if (!dueAtValue) return;
+    const iso = new Date(dueAtValue).toISOString();
+    updateDueAtMutation.mutate(iso, {
+      onSuccess: () => setDueAtDraft(null),
+    });
+  };
 
   return (
     <div className="mx-auto max-w-3xl space-y-6 px-4 py-8">
@@ -150,14 +183,58 @@ export const TeacherAssignmentDetailPage = () => {
           as="h1"
           eyebrow={assignment.subject_room_display}
           title={assignment.problem_set.title}
-          action={
-            overdue ? (
-              <Badge tone="urgent">Overdue</Badge>
-            ) : (
-              <Badge tone="brand">Active</Badge>
-            )
-          }
+          action={statusBadge}
         />
+
+        {/* Lifecycle controls — due-date edit + close / reopen */}
+        <div
+          className="mt-5 flex flex-wrap items-end gap-3 rounded-xl border border-ink-100 bg-paper-50 p-4"
+          data-testid="lifecycle-controls"
+        >
+          <label className="flex flex-col text-xs font-semibold uppercase tracking-wide text-ink-500">
+            Due date
+            <input
+              type="datetime-local"
+              value={dueAtValue}
+              onChange={(e) => setDueAtDraft(e.target.value)}
+              disabled={isClosed || updateDueAtMutation.isPending}
+              className="mt-1 rounded-lg border border-ink-200 bg-paper px-3 py-1.5 text-sm font-normal normal-case text-ink-900"
+              data-testid="due-at-input"
+            />
+          </label>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleDueAtSave}
+            disabled={isClosed || updateDueAtMutation.isPending}
+            data-testid="due-at-save"
+          >
+            {updateDueAtMutation.isPending ? 'Saving…' : 'Save due date'}
+          </Button>
+          <div className="ml-auto">
+            {isClosed ? (
+              <Button
+                variant="brand"
+                size="sm"
+                onClick={() => reopenMutation.mutate()}
+                disabled={reopenMutation.isPending}
+                data-testid="reopen-button"
+              >
+                {reopenMutation.isPending ? 'Reopening…' : 'Reopen assignment'}
+              </Button>
+            ) : (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => closeMutation.mutate()}
+                disabled={closeMutation.isPending}
+                data-testid="close-button"
+              >
+                {closeMutation.isPending ? 'Closing…' : 'Close assignment'}
+              </Button>
+            )}
+          </div>
+        </div>
 
         <div className="mt-5 grid grid-cols-1 gap-3 sm:grid-cols-3">
           <Stat

--- a/frontend_modern/src/features/teacher/useTeacherAssignmentDetail.ts
+++ b/frontend_modern/src/features/teacher/useTeacherAssignmentDetail.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '@/api/client';
 import type { Assignment, Submission } from '@/types/index';
 
@@ -20,7 +20,24 @@ const fetchAssignmentSubmissions = async (id: number): Promise<SubmissionWithStu
   return response.data;
 };
 
+const patchAssignmentDueAt = async (id: number, dueAt: string): Promise<Assignment> => {
+  const response = await apiClient.patch<Assignment>(`/assignments/${id}/`, { due_at: dueAt });
+  return response.data;
+};
+
+const closeAssignment = async (id: number): Promise<Assignment> => {
+  const response = await apiClient.post<Assignment>(`/assignments/${id}/close/`);
+  return response.data;
+};
+
+const reopenAssignment = async (id: number): Promise<Assignment> => {
+  const response = await apiClient.post<Assignment>(`/assignments/${id}/reopen/`);
+  return response.data;
+};
+
 export const useTeacherAssignmentDetail = (id: number) => {
+  const queryClient = useQueryClient();
+
   const metaQuery = useQuery<Assignment>({
     queryKey: ['teacher-assignment', id],
     queryFn: () => fetchAssignmentMeta(id),
@@ -35,5 +52,25 @@ export const useTeacherAssignmentDetail = (id: number) => {
     enabled: !!id,
   });
 
-  return { metaQuery, submissionsQuery };
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ['teacher-assignment', id] });
+    queryClient.invalidateQueries({ queryKey: ['teacher-assignments'] });
+  };
+
+  const updateDueAtMutation = useMutation({
+    mutationFn: (dueAt: string) => patchAssignmentDueAt(id, dueAt),
+    onSuccess: invalidate,
+  });
+
+  const closeMutation = useMutation({
+    mutationFn: () => closeAssignment(id),
+    onSuccess: invalidate,
+  });
+
+  const reopenMutation = useMutation({
+    mutationFn: () => reopenAssignment(id),
+    onSuccess: invalidate,
+  });
+
+  return { metaQuery, submissionsQuery, updateDueAtMutation, closeMutation, reopenMutation };
 };


### PR DESCRIPTION
## Summary
- Inline `datetime-local` due-date editor that PATCHes the assignment.
- Close / Reopen buttons wired to the TW-3a `/close/` and `/reopen/` actions.
- Status badge swaps among Active / Overdue / Closed from the serialized `status`.
- Due-date input + Save are disabled while the assignment is closed (re-date by reopening first).
- React Query invalidation on success so the dashboard's needs-attention strip reflects the new state.

## Depends on
- [#263 TW-3a](https://github.com/openshiksha/openshiksha/pull/263) (backend lifecycle actions + serialized `status`). This PR targets the TW-3a branch; rebase onto `modernization` once #263 lands.

## Classification
Improve (frontend).

## Tests
- `TeacherAssignmentDetailPage.test.tsx` — 6 tests: Active/Closed badges, PATCH due-date, POST close, POST reopen, disabled-when-closed.
- `npm run lint`, `npm run type-check`, `npm run build` (entry 92.99 kB / 160 kB) all green.

## Verify
- Open a teacher assignment detail page → due-date editor + Close button render below the header.
- Edit the date, click Save → PATCH fires, page refreshes with the new date.
- Click Close → badge flips to Closed, Reopen button appears; the input is disabled.
- Reopen → controls return to Active state.

Initiative doc: `docs/initiatives/teacher-workspace.md` (TW-3 DoD).