### PR TITLE
TW-6: question-bank ↔ authoring continuity (URL state + returnTo)

### DIFF
--- a/docs/changes/2026-06-07-tw6-bank-authoring-continuity.md
+++ b/docs/changes/2026-06-07-tw6-bank-authoring-continuity.md
@@ -1,0 +1,53 @@
+# TW-6 — Question-bank ↔ authoring continuity
+
+**Classification:** Improve (frontend-only).
+**Initiative:** Teacher Workspace.
+**Branch:** `feat/2026-06-07-tw6-bank-authoring-continuity`.
+
+## Summary
+
+Closes the last "context loss" seam in the teacher workspace: filter state on
+`QuestionBankPage` now lives in the URL, so back-button after a detour
+through the editor or set builder restores the exact same search. New
+"Use in new set" action seeds a freshly-built problem set with the focused
+question. Both Edit and Use-in-new-set carry a `returnTo` query param so the
+destination page can offer "Back to question bank" that lands on the same
+filtered view.
+
+## Why
+
+The bank already had healthy reuse paths (preview, add-to-existing-set via
+side sheet) but the moment a teacher jumped out — to fix a typo, or build a
+new set around a question — they lost everything. `useState` for filters and
+`navigate('/teacher/questions')` for "back" both erased context. URL-state +
+`returnTo` makes the round-trip free.
+
+## Changes
+
+- `frontend_modern/src/features/teacher/QuestionBankPage.tsx`
+  - Filters (`q`, `subject`, `chapter`, `diff`, `focus`) read/write via
+    `useSearchParams`; `useDeferredValue(search)` replaces the manual debounce.
+  - Edit button (row + preview footer) and new **Use in new set** button
+    encode the current URL as `returnTo=…`.
+- `frontend_modern/src/features/teacher/CreateProblemSetPage.tsx`
+  - Reads `?seedQuestion=<id>` → fetches via `useQuestion`, pre-fills subject /
+    chapter / selection on first load.
+  - Reads `?returnTo=…` → success state swaps "Back to dashboard" for
+    "Back to question bank" when returning makes sense.
+- `frontend_modern/src/features/teacher/CreateQuestionPage.tsx`
+  - Reads `?returnTo=…` (defaults to `/teacher/questions`) so the Back link
+    and post-save "Back to question bank" button respect the originating
+    search.
+- `frontend_modern/src/features/teacher/QuestionBankPage.test.tsx` — new,
+  5 tests covering URL hydration, filter push, clear, Use-in-new-set
+  navigation, and Edit returnTo.
+
+## Verify
+
+- `npm run lint`, `npm run type-check` clean.
+- `npx vitest run …QuestionBankPage.test.tsx` — 5/5. Full suite 226/226.
+- `npm run build` + `npm run check:budget` — entry 93.09 kB / 160 kB budget.
+
+## Next
+
+TW-7 (mobile teacher pass) — the last unblocked initiative item.

--- a/frontend_modern/src/features/teacher/CreateProblemSetPage.tsx
+++ b/frontend_modern/src/features/teacher/CreateProblemSetPage.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useSubjectRooms } from './useSubjectRooms';
 import { useChapters } from './useChapters';
+import { useQuestion } from './useQuestion';
 import { useQuestionList } from './useQuestionList';
 import { useCreateProblemSet } from './useCreateProblemSet';
 import { previewFromQuestionText } from './previewFromQuestionText';
@@ -157,7 +158,20 @@ const SelectedStrip = ({
 
 export const CreateProblemSetPage = () => {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { data: subjectRooms } = useSubjectRooms();
+
+  // TW-6: a teacher can land here with ?seedQuestion=<id> from the question
+  // bank's "Use in new set" action. Pre-fetch that question so we can seed
+  // the subject / chapter / selection before the picker renders.
+  const seedQuestionId = (() => {
+    const raw = searchParams.get('seedQuestion');
+    if (!raw) return undefined;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : undefined;
+  })();
+  const returnTo = searchParams.get('returnTo');
+  const { data: seedQuestion } = useQuestion(seedQuestionId);
 
   const [title, setTitle] = useState('');
   const [selectedSubjectId, setSelectedSubjectId] = useState<number | ''>('');
@@ -166,6 +180,18 @@ export const CreateProblemSetPage = () => {
   const [selectedQuestionIds, setSelectedQuestionIds] = useState<Set<number>>(new Set());
   const [focusedQuestionId, setFocusedQuestionId] = useState<number | null>(null);
   const [successId, setSuccessId] = useState<number | null>(null);
+
+  // One-shot seed: when the question loads, pre-fill subject/chapter and
+  // mark it as selected. Tracked via a ref-style state guard so a later user
+  // edit (e.g. changing subject) doesn't get clobbered on the next render.
+  const [seededFromId, setSeededFromId] = useState<number | undefined>(undefined);
+  if (seedQuestion && seededFromId !== seedQuestion.id) {
+    setSeededFromId(seedQuestion.id);
+    setSelectedSubjectId(seedQuestion.subject);
+    setSelectedChapterId(seedQuestion.chapter);
+    setSelectedQuestionIds(new Set([seedQuestion.id]));
+    setFocusedQuestionId(seedQuestion.id);
+  }
 
   // Filters within the picker
   const [searchQuery, setSearchQuery] = useState('');
@@ -275,9 +301,15 @@ export const CreateProblemSetPage = () => {
           action={
             <div className="flex flex-wrap justify-center gap-3">
               <Button onClick={() => navigate('/teacher/assignments/new')}>Assign it now</Button>
-              <Button variant="ghost" onClick={() => navigate('/teacher')}>
-                Back to dashboard
-              </Button>
+              {returnTo ? (
+                <Button variant="ghost" onClick={() => navigate(returnTo)}>
+                  Back to question bank
+                </Button>
+              ) : (
+                <Button variant="ghost" onClick={() => navigate('/teacher')}>
+                  Back to dashboard
+                </Button>
+              )}
             </div>
           }
         />

--- a/frontend_modern/src/features/teacher/CreateQuestionPage.tsx
+++ b/frontend_modern/src/features/teacher/CreateQuestionPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { LoadingSpinner } from '@/shared/ui';
 import { RichContent } from '@/shared/ui/RichContent';
 import { WidgetGalleryPanel } from './WidgetGalleryPanel';
@@ -457,6 +457,11 @@ export const CreateQuestionPage = ({ editMode = false }: { editMode?: boolean })
   const { id } = useParams<{ id: string }>();
   const editId = editMode && id ? Number(id) : undefined;
 
+  // TW-6: when launched from the question bank we receive `?returnTo=` so the
+  // Back / "Back to question bank" actions land on the exact same search.
+  const [searchParams] = useSearchParams();
+  const returnTo = searchParams.get('returnTo') ?? '/teacher/questions';
+
   const { data: subjectRooms } = useSubjectRooms();
   const [selectedSubjectId, setSelectedSubjectId] = useState<number | ''>('');
   const [selectedChapterId, setSelectedChapterId] = useState<number | ''>('');
@@ -686,7 +691,7 @@ export const CreateQuestionPage = ({ editMode = false }: { editMode?: boolean })
               </button>
             )}
             <button
-              onClick={() => navigate('/teacher/questions')}
+              onClick={() => navigate(returnTo)}
               className="px-4 py-2 rounded-lg border border-ink-200 text-ink-700 text-sm font-medium hover:bg-ink-50"
             >
               Back to question bank
@@ -717,7 +722,7 @@ export const CreateQuestionPage = ({ editMode = false }: { editMode?: boolean })
           </p>
         </div>
         <button
-          onClick={() => navigate('/teacher/questions')}
+          onClick={() => navigate(returnTo)}
           className="text-sm text-ink-500 hover:text-ink-700"
         >
           ← Back

--- a/frontend_modern/src/features/teacher/QuestionBankPage.test.tsx
+++ b/frontend_modern/src/features/teacher/QuestionBankPage.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { QuestionBankPage } from './QuestionBankPage';
+import type { Question, Subject, ChapterItem } from '@/types/index';
+
+const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
+vi.mock('@/api/client', () => ({ apiClient: { get: mockGet, post: vi.fn() } }));
+
+const SUBJECTS: Subject[] = [
+  { id: 1, name: 'Mathematics', description: '' },
+  { id: 2, name: 'Physics', description: '' },
+];
+
+const CHAPTERS: ChapterItem[] = [
+  { id: 10, name: 'Algebra', standard_number: 8 } as ChapterItem,
+  { id: 11, name: 'Geometry', standard_number: 8 } as ChapterItem,
+];
+
+function makeQuestion(overrides: Partial<Question> = {}): Question {
+  return {
+    id: 100,
+    question_type: 'mcq',
+    difficulty: 3,
+    subject: 1,
+    subject_name: 'Mathematics',
+    chapter: 10,
+    chapter_name: 'Algebra',
+    standard: 8,
+    tags: [],
+    subparts: [{ id: 1, question_text: 'What is 2 + 2?', options: [], image_url: null }],
+    created_by: 1,
+    created_at: '2026-01-01',
+    ...overrides,
+  } as unknown as Question;
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  return (
+    <span data-testid="location">{location.pathname}{location.search}</span>
+  );
+}
+
+function renderBank(initialEntry = '/teacher/questions') {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route
+            path="/teacher/questions"
+            element={
+              <>
+                <QuestionBankPage />
+                <LocationProbe />
+              </>
+            }
+          />
+          <Route path="*" element={<LocationProbe />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockGet.mockImplementation((url: string) => {
+    if (url.startsWith('/subjects')) return Promise.resolve({ data: SUBJECTS });
+    if (url.startsWith('/chapters')) return Promise.resolve({ data: CHAPTERS });
+    if (url.startsWith('/questions')) {
+      return Promise.resolve({ data: { results: [makeQuestion()], count: 1 } });
+    }
+    return Promise.resolve({ data: [] });
+  });
+});
+
+describe('QuestionBankPage — URL-driven filters & continuity', () => {
+  it('reads filters from the URL on first render', async () => {
+    renderBank('/teacher/questions?q=2+2&subject=1&diff=3');
+    await waitFor(() => {
+      const searchInput = screen.getByPlaceholderText(/search question text/i) as HTMLInputElement;
+      expect(searchInput.value).toBe('2 2');
+    });
+    // The questions API call should carry the filters
+    await waitFor(() => {
+      const calls = mockGet.mock.calls.map((c) => c[0] as string);
+      expect(calls.some((u) => u.includes('/questions/') && u.includes('subject=1') && u.includes('difficulty=3'))).toBe(true);
+    });
+  });
+
+  it('pushes search edits into the URL', async () => {
+    renderBank('/teacher/questions');
+    await screen.findByPlaceholderText(/search question text/i);
+    const searchInput = screen.getByPlaceholderText(/search question text/i);
+    fireEvent.change(searchInput, { target: { value: 'algebra' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('location').textContent).toContain('q=algebra');
+    });
+  });
+
+  it('clears all filters via Clear filters', async () => {
+    renderBank('/teacher/questions?q=hi&subject=1');
+    const clear = await screen.findByRole('button', { name: /clear filters/i });
+    fireEvent.click(clear);
+    await waitFor(() => {
+      const loc = screen.getByTestId('location').textContent ?? '';
+      expect(loc).toBe('/teacher/questions');
+    });
+  });
+
+  it('navigates "Use in new set" with the question + returnTo encoded', async () => {
+    renderBank('/teacher/questions?q=alg&subject=1');
+    const useBtn = await screen.findByRole('button', { name: /use in new set/i });
+    fireEvent.click(useBtn);
+    await waitFor(() => {
+      const loc = screen.getByTestId('location').textContent ?? '';
+      expect(loc).toContain('/teacher/problem-sets/new');
+      expect(loc).toContain('seedQuestion=100');
+      expect(loc).toContain('returnTo=');
+      // returnTo should preserve the current filters
+      expect(decodeURIComponent(loc)).toContain('q=alg');
+    });
+  });
+
+  it('navigates Edit with returnTo so the editor can come back', async () => {
+    renderBank('/teacher/questions?q=alg');
+    // Both the row hover-action and the preview footer have an "Edit" button.
+    // Click the row's so we don't depend on the focus-driven footer rendering.
+    const editBtns = await screen.findAllByRole('button', { name: /^edit$/i });
+    fireEvent.click(editBtns[0]);
+    await waitFor(() => {
+      const loc = screen.getByTestId('location').textContent ?? '';
+      expect(loc).toContain('/teacher/questions/100/edit');
+      expect(loc).toContain('returnTo=');
+      expect(decodeURIComponent(loc)).toContain('q=alg');
+    });
+  });
+});

--- a/frontend_modern/src/features/teacher/QuestionBankPage.tsx
+++ b/frontend_modern/src/features/teacher/QuestionBankPage.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useQuestionList } from './useQuestionList';
 import { useSubjects } from './useSubjects';
 import { useChapters } from './useChapters';
@@ -271,16 +271,60 @@ const AddToProblemSetSheet = ({
 
 // ── Page ────────────────────────────────────────────────────────────────────
 
+/**
+ * TW-6: filter state lives in the URL so the back-button restores the same
+ * search after the teacher visits the editor or set builder. Keys are short
+ * (`q`, `subject`, `chapter`, `diff`, `focus`) to keep the URL tidy.
+ */
+const numberOrEmpty = (raw: string | null): number | '' => {
+  if (!raw) return '';
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : '';
+};
+
 export const QuestionBankPage = () => {
   const navigate = useNavigate();
-  const [search, setSearch] = useState('');
-  const [debouncedSearch, setDebouncedSearch] = useState('');
-  const [selectedSubject, setSelectedSubject] = useState<number | ''>('');
-  const [selectedChapter, setSelectedChapter] = useState<number | ''>('');
-  const [selectedDifficulty, setSelectedDifficulty] = useState<number | ''>('');
-  const [focusedQuestionId, setFocusedQuestionId] = useState<number | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const search = searchParams.get('q') ?? '';
+  const selectedSubject = numberOrEmpty(searchParams.get('subject'));
+  const selectedChapter = numberOrEmpty(searchParams.get('chapter'));
+  const selectedDifficulty = numberOrEmpty(searchParams.get('diff'));
+  const focusedQuestionId = (() => {
+    const raw = searchParams.get('focus');
+    if (!raw) return null;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+  })();
+
+  // useDeferredValue gives us "debounce-ish" behaviour without an effect:
+  // search updates the URL immediately for back/forward to round-trip,
+  // and the heavy filtered query reads `deferredSearch` which lags behind
+  // until rendering catches up.
+  const deferredSearch = useDeferredValue(search);
   const [modalQuestion, setModalQuestion] = useState<Question | null>(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Merge-style URL updater — pass `null` to remove a key.
+  const updateParams = (patch: Record<string, string | number | null | ''>) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        for (const [key, value] of Object.entries(patch)) {
+          if (value === null || value === '') next.delete(key);
+          else next.set(key, String(value));
+        }
+        return next;
+      },
+      { replace: true },
+    );
+  };
+
+  const setSearch = (value: string) => updateParams({ q: value });
+  const setSelectedSubject = (value: number | '') =>
+    updateParams({ subject: value, chapter: null });
+  const setSelectedChapter = (value: number | '') => updateParams({ chapter: value });
+  const setSelectedDifficulty = (value: number | '') => updateParams({ diff: value });
+  const setFocusedQuestionId = (value: number | null) => updateParams({ focus: value });
 
   const { data: subjects } = useSubjects();
   // Chapter list is scoped to the selected subject; disabled until a subject
@@ -290,17 +334,16 @@ export const QuestionBankPage = () => {
     selectedSubject !== '' ? (selectedSubject as number) : undefined,
   );
   const { data: questions, isLoading } = useQuestionList({
-    search: debouncedSearch || undefined,
+    search: deferredSearch || undefined,
     subject: selectedSubject !== '' ? (selectedSubject as number) : undefined,
     chapter: selectedChapter !== '' ? (selectedChapter as number) : undefined,
     difficulty: selectedDifficulty !== '' ? (selectedDifficulty as number) : undefined,
   });
 
-  const handleSearchChange = (value: string) => {
-    setSearch(value);
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => setDebouncedSearch(value), 300);
-  };
+  const handleSearchChange = (value: string) => setSearch(value);
+
+  // Pass current URL state forward so the editor / set builder can return here.
+  const currentReturnTo = `/teacher/questions?${searchParams.toString()}`;
 
   const hasFilters =
     !!search ||
@@ -309,11 +352,7 @@ export const QuestionBankPage = () => {
     selectedDifficulty !== '';
 
   const clearFilters = () => {
-    setSearch('');
-    setDebouncedSearch('');
-    setSelectedSubject('');
-    setSelectedChapter('');
-    setSelectedDifficulty('');
+    setSearchParams(new URLSearchParams(), { replace: true });
   };
 
   const focusedQuestion = useMemo(
@@ -458,7 +497,11 @@ export const QuestionBankPage = () => {
                       question={q}
                       focused={focusedQuestionId === q.id}
                       onFocus={() => setFocusedQuestionId(q.id)}
-                      onEdit={() => navigate(`/teacher/questions/${q.id}/edit`)}
+                      onEdit={() =>
+                        navigate(
+                          `/teacher/questions/${q.id}/edit?returnTo=${encodeURIComponent(currentReturnTo)}`,
+                        )
+                      }
                     />
                   ))}
                 </div>
@@ -479,13 +522,28 @@ export const QuestionBankPage = () => {
                   <p className="text-xs text-ink-500">
                     Reuse this question in any of your problem sets.
                   </p>
-                  <div className="flex items-center gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
                     <Button
                       variant="ghost"
                       size="sm"
-                      onClick={() => navigate(`/teacher/questions/${focusedQuestion.id}/edit`)}
+                      onClick={() =>
+                        navigate(
+                          `/teacher/questions/${focusedQuestion.id}/edit?returnTo=${encodeURIComponent(currentReturnTo)}`,
+                        )
+                      }
                     >
                       Edit
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() =>
+                        navigate(
+                          `/teacher/problem-sets/new?seedQuestion=${focusedQuestion.id}&returnTo=${encodeURIComponent(currentReturnTo)}`,
+                        )
+                      }
+                    >
+                      Use in new set
                     </Button>
                     <Button size="sm" onClick={() => setModalQuestion(focusedQuestion)}>
                       + Add to problem set


### PR DESCRIPTION
## Summary
- `QuestionBankPage` filters (`q`, `subject`, `chapter`, `diff`, `focus`) live in the URL — back-button after editing a question or building a set restores the exact same search. `useDeferredValue(search)` replaces the manual debounce.
- New **Use in new set** action on the focused preview seeds `CreateProblemSetPage?seedQuestion=…` with the subject, chapter, and selection pre-filled.
- Edit and Use-in-new-set both encode the bank's current URL as `?returnTo=…` so the destination page's Back / "Back to question bank" lands on the same filtered view.

## Classification
Improve (frontend-only). Closes the "context loss" seam called out in TW-6.

## Tests
- `QuestionBankPage.test.tsx` (new) — 5 tests: URL → state hydration, search → URL push, Clear filters, Use-in-new-set navigation + returnTo, Edit returnTo.
- Full vitest suite 226/226 still green.
- `npm run lint`, `npm run type-check`, `npm run build` + `npm run check:budget` (entry 93.09 kB / 160 kB) all green.

## Verify
- Open `/teacher/questions`, filter by subject, click Edit on a question → editor's Back / "Back to question bank" returns to the same filter.
- From the focused preview footer, click **Use in new set** → set builder loads with the question's subject + chapter selected and the question already in the selection.
- Use the browser back button after navigating away → bank still shows your filters.

Initiative doc: `docs/initiatives/teacher-workspace.md` (TW-6).