### PR TITLE
TW-7: mobile sticky action bars on authoring forms

### DIFF
--- a/docs/changes/2026-06-07-tw7-mobile-teacher.md
+++ b/docs/changes/2026-06-07-tw7-mobile-teacher.md
@@ -1,0 +1,52 @@
+# TW-7 — Mobile teacher pass
+
+**Classification:** Improve (frontend-only).
+**Initiative:** Teacher Workspace.
+**Branch:** `feat/2026-06-07-tw7-mobile-teacher`.
+
+## Summary
+
+The two long teacher authoring forms — `CreateAssignmentPage` and
+`CreateProblemSetPage` — buried their primary CTA at the bottom of a multi-card
+form. On a phone that meant scrolling past the whole preview / picker to hit
+"Publish" or "Create". This change adds a `lg:hidden` sticky bottom action bar
+on both pages that keeps the primary action one tap away on mobile, while
+desktop keeps its inline button (no duplication on big screens). Date-preset
+chips on the assignment form bump up to a 44 px touch target on mobile.
+
+## Why
+
+Initiative principle #6 ("no dead-ends"): on a phone the existing form was a
+de-facto dead-end if you couldn't scroll patiently to the submit button. The
+mobile bar surfaces the action without changing desktop behaviour.
+
+## Changes
+
+- `frontend_modern/src/features/teacher/CreateAssignmentPage.tsx`
+  - Add a `lg:hidden` fixed bottom bar containing a full-width submit button
+    that triggers the existing form `onSubmit`.
+  - Bump page bottom padding (`pb-28 lg:pb-8`) so the last form card doesn't
+    sit under the bar.
+  - Date-preset chips: `px-4 py-2 text-sm sm:px-3 sm:py-1 sm:text-xs` so the
+    touch target hits ~44 px on mobile and stays compact on desktop.
+- `frontend_modern/src/features/teacher/CreateProblemSetPage.tsx`
+  - Hide the inline submit on mobile (`hidden … lg:flex`); add a `lg:hidden`
+    sticky Create bar with the same disabled-state hints and a selected-count
+    pill on the button itself (`Create (3)`).
+  - Same bottom-padding bump.
+- `frontend_modern/src/features/teacher/CreateAssignmentPage.test.tsx` — new
+  test: mobile bar exists, is `lg:hidden`, holds a `type="submit"` button.
+- `frontend_modern/src/features/teacher/CreateProblemSetPage.test.tsx` — new,
+  one test for the mobile bar's presence + disabled hint copy.
+
+## Verify
+
+- `npm run lint`, `npm run type-check` clean.
+- Vitest 223/223. New tests pass.
+- `npm run build` + `npm run check:budget` — entry 93.05 kB / 160 kB.
+- Manual: resize to ≤ 1024 px width → bar appears; ≥ 1024 px → desktop layout.
+
+## Next
+
+This closes the last unblocked Teacher Workspace increment. TW-2 (editable
+preview) is still blocked on Authoring Integrity Phase 1.

--- a/frontend_modern/src/features/teacher/CreateAssignmentPage.test.tsx
+++ b/frontend_modern/src/features/teacher/CreateAssignmentPage.test.tsx
@@ -86,3 +86,16 @@ describe('CreateAssignmentPage deep-link preselection', () => {
     );
   });
 });
+
+describe('CreateAssignmentPage — mobile sticky action bar (TW-7)', () => {
+  it('renders a sticky Publish button on mobile, hidden on desktop via lg:hidden', async () => {
+    renderAt('/teacher/assignments/new');
+    const bar = await screen.findByTestId('mobile-publish-bar');
+    // The sticky bar should be lg-hidden so desktop keeps the inline preview button.
+    expect(bar.className).toMatch(/lg:hidden/);
+    // It must hold a submit-type button (so it triggers the form's onSubmit).
+    const submit = bar.querySelector('button[type="submit"]');
+    expect(submit).not.toBeNull();
+    expect((submit as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/frontend_modern/src/features/teacher/CreateAssignmentPage.tsx
+++ b/frontend_modern/src/features/teacher/CreateAssignmentPage.tsx
@@ -189,8 +189,10 @@ export const CreateAssignmentPage = () => {
   const daysOut = daysFromToday(dueDate);
 
   // ── Main UI ──────────────────────────────────────────────────────────────
+  // Extra bottom padding on small screens leaves room for the sticky mobile
+  // action bar so the last form field doesn't sit underneath it.
   return (
-    <div className="mx-auto max-w-6xl space-y-6 px-4 py-8 lg:px-6">
+    <div className="mx-auto max-w-6xl space-y-6 px-4 py-8 pb-28 lg:px-6 lg:pb-8">
       {/* Header */}
       <SectionHeading
         as="h1"
@@ -208,7 +210,7 @@ export const CreateAssignmentPage = () => {
         }
       />
 
-      <form onSubmit={handleSubmit} className="grid gap-4 lg:grid-cols-12">
+      <form onSubmit={handleSubmit} className="grid gap-4 lg:grid-cols-12" data-testid="create-assignment-form">
         {/* Form column */}
         <div className="space-y-4 lg:col-span-5 xl:col-span-4">
           {/* Step 1: Class */}
@@ -300,7 +302,7 @@ export const CreateAssignmentPage = () => {
               min={minDate}
               onChange={(e) => setDueDate(e.target.value)}
             />
-            <div className="mt-3 flex flex-wrap items-center gap-1.5">
+            <div className="mt-3 flex flex-wrap items-center gap-2">
               <span className="mr-1 text-xs font-medium text-ink-500">Quick set:</span>
               {datePresets.map((p) => (
                 <button
@@ -308,7 +310,8 @@ export const CreateAssignmentPage = () => {
                   type="button"
                   onClick={() => setDueDate(p.iso)}
                   className={[
-                    'inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
+                    // ~44px tall on mobile (touch-target spec); slimmer on desktop.
+                    'inline-flex items-center rounded-full px-4 py-2 text-sm font-medium transition-colors sm:px-3 sm:py-1 sm:text-xs',
                     dueDate === p.iso
                       ? 'bg-brand-600 text-white shadow-soft'
                       : 'bg-ink-50 text-ink-700 hover:bg-ink-100',
@@ -341,6 +344,29 @@ export const CreateAssignmentPage = () => {
             submitting={createAssignment.isPending}
             error={createAssignment.isError}
           />
+        </div>
+
+        {/* Sticky mobile action bar — desktop has the publish button inside
+            the preview Card; on phones the preview is too long to scroll to,
+            so we surface the same action above the system nav. */}
+        <div
+          className="fixed inset-x-0 bottom-0 z-30 border-t border-ink-100 bg-paper/95 px-4 py-3 shadow-lift backdrop-blur lg:hidden"
+          data-testid="mobile-publish-bar"
+        >
+          <Button
+            type="submit"
+            size="lg"
+            disabled={!isFormValid || createAssignment.isPending}
+            className="w-full"
+          >
+            {createAssignment.isPending && <LoadingSpinner size="sm" />}
+            {createAssignment.isPending ? 'Publishing…' : 'Publish Assignment'}
+          </Button>
+          {!isFormValid && (
+            <p className="mt-1.5 text-center text-xs text-ink-500">
+              Complete all three steps to publish.
+            </p>
+          )}
         </div>
       </form>
     </div>

--- a/frontend_modern/src/features/teacher/CreateProblemSetPage.test.tsx
+++ b/frontend_modern/src/features/teacher/CreateProblemSetPage.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { CreateProblemSetPage } from './CreateProblemSetPage';
+
+const { mockGet, mockPost } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPost: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  apiClient: { get: mockGet, post: mockPost },
+}));
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockGet.mockImplementation((url: string) => {
+    if (url.startsWith('/subject-rooms')) return Promise.resolve({ data: { results: [] } });
+    if (url.startsWith('/chapters')) return Promise.resolve({ data: [] });
+    if (url.startsWith('/questions')) return Promise.resolve({ data: { results: [] } });
+    return Promise.resolve({ data: [] });
+  });
+});
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/teacher/problem-sets/new']}>
+        <CreateProblemSetPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('CreateProblemSetPage — mobile sticky action bar (TW-7)', () => {
+  it('renders a mobile-only Create bar that is disabled until the form is valid', async () => {
+    renderPage();
+    const bar = await screen.findByTestId('mobile-create-bar');
+    expect(bar.className).toMatch(/lg:hidden/);
+    const btn = bar.querySelector('button');
+    await waitFor(() => expect(btn).not.toBeNull());
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+    // Hint copy should guide the teacher.
+    expect(bar.textContent).toMatch(/pick a subject, chapter, title/i);
+  });
+});

--- a/frontend_modern/src/features/teacher/CreateProblemSetPage.tsx
+++ b/frontend_modern/src/features/teacher/CreateProblemSetPage.tsx
@@ -286,8 +286,9 @@ export const CreateProblemSetPage = () => {
   }
 
   // ── Main UI ──────────────────────────────────────────────────────────────
+  // Mobile: extra bottom padding leaves room for the sticky mobile action bar.
   return (
-    <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 lg:px-6">
+    <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 pb-28 lg:px-6 lg:pb-8">
       {/* Header */}
       <SectionHeading
         as="h1"
@@ -507,8 +508,8 @@ export const CreateProblemSetPage = () => {
       {/* Selected questions strip */}
       <SelectedStrip selectedQuestions={selectedQuestions} onRemove={removeQuestion} />
 
-      {/* Submit */}
-      <div className="flex flex-wrap items-center justify-end gap-3 border-t border-ink-100 pt-5">
+      {/* Submit — desktop layout (inline action row). */}
+      <div className="hidden flex-wrap items-center justify-end gap-3 border-t border-ink-100 pt-5 lg:flex">
         {!canSubmit && (
           <p className="text-xs text-ink-400">
             Fill in title, subject, chapter, and select at least one question.
@@ -525,6 +526,34 @@ export const CreateProblemSetPage = () => {
           {createProblemSet.isPending && <LoadingSpinner size="sm" />}
           Create Problem Set
         </Button>
+      </div>
+
+      {/* Sticky mobile action bar — the inline submit lives at the bottom of
+          a long page, requiring a lot of scrolling on phones. Surface the
+          same action above the system nav so it's always one tap away. */}
+      <div
+        className="fixed inset-x-0 bottom-0 z-30 border-t border-ink-100 bg-paper/95 px-4 py-3 shadow-lift backdrop-blur lg:hidden"
+        data-testid="mobile-create-bar"
+      >
+        {createProblemSet.isError && (
+          <p className="mb-1.5 text-center text-xs font-medium text-rose-600">
+            Failed to create. Please try again.
+          </p>
+        )}
+        <Button
+          size="lg"
+          onClick={handleSubmit}
+          disabled={!canSubmit || createProblemSet.isPending}
+          className="w-full"
+        >
+          {createProblemSet.isPending && <LoadingSpinner size="sm" />}
+          {createProblemSet.isPending ? 'Creating…' : `Create${selectedQuestionIds.size > 0 ? ` (${selectedQuestionIds.size})` : ''}`}
+        </Button>
+        {!canSubmit && (
+          <p className="mt-1.5 text-center text-xs text-ink-500">
+            Pick a subject, chapter, title, and at least one question.
+          </p>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- `CreateAssignmentPage`: `lg:hidden` sticky **Publish Assignment** bar above the system nav so the primary action is one tap away on phones; desktop keeps the inline button in the preview Card.
- `CreateProblemSetPage`: same treatment with **Create (N)** that shows the selected count on the button.
- Date-preset chips bump to a ~44 px touch target on mobile (`px-4 py-2 text-sm sm:px-3 sm:py-1 sm:text-xs`).
- Extra bottom padding on each page so the last card doesn't sit under the bar.

## Classification
Improve (frontend-only). No new API calls.

## Tests
- `CreateAssignmentPage.test.tsx` — new test for the mobile bar (presence, `lg:hidden`, holds a submit button).
- `CreateProblemSetPage.test.tsx` (new file) — mobile-bar test with disabled-state hint copy.
- Full vitest suite 223/223 green; `npm run lint`, `npm run type-check`, `npm run build` + `npm run check:budget` (entry 93.05 kB / 160 kB) green.

## Verify
- Open `/teacher/assignments/new` at ≤ 1024 px → sticky **Publish Assignment** bar at the bottom; ≥ 1024 px → bar disappears, inline button in the preview Card.
- Same for `/teacher/problem-sets/new`.
- The mobile bar's submit triggers the form's `onSubmit` — picking class + set + due date enables the button.

Initiative doc: `docs/initiatives/teacher-workspace.md` (TW-7).