### PR TITLE
docs(teacher-workspace): close TW-3/4/5/6/7 + remove TW-T

### DIFF
--- a/docs/initiatives/STATUS.md
+++ b/docs/initiatives/STATUS.md
@@ -4,26 +4,23 @@
 > task advances the **top active initiative** here. See [`README.md`](README.md)
 > for how. Keep this file short - one row per initiative.
 
-**Last updated:** 2026-06-07 (planning) - Teacher Workspace **TW-1 merged**
-([#250](https://github.com/openshiksha/openshiksha/pull/250)); next batch
-(TW-5 / TW-4 / TW-3 / TW-T e2e) planned in
-[2026-06-07-plan-2.md](../daily-plans/2026-06-07-plan-2.md). Earlier today:
-**Performance Budget done.** Shipped
-PERF-01..04 + PERF-06 in one batch ([#251](https://github.com/openshiksha/openshiksha/pull/251),
-[#252](https://github.com/openshiksha/openshiksha/pull/252),
-[#253](https://github.com/openshiksha/openshiksha/pull/253),
-[#254](https://github.com/openshiksha/openshiksha/pull/254),
-[#255](https://github.com/openshiksha/openshiksha/pull/255)), then a follow-up
-([#256](https://github.com/openshiksha/openshiksha/pull/256)) that fixed a
-barrel-export DOMPurify leak. Entry chunk **855 → 93 kB / 247 → 29 kB gzip**
-(88% gzip drop), KaTeX + DOMPurify off the first-paint critical path, CI
-guard at 160 kB defends the cut. PERF-05 (font self-hosting) deferred —
-real-device measurement showed fonts aren't the long pole. **Teacher
-Workspace** remains the active top initiative.
+**Last updated:** 2026-06-07 — **Teacher Workspace mostly closed.** All
+unblocked TW increments shipped today across **#250, #261–#266**
+(TW-1, TW-5, TW-4, TW-3a, TW-3b, TW-6, TW-7). The previously-planned **TW-T**
+Playwright continuity smoke was **dropped from the backlog** — the seams it
+covers are already exercised by Vitest + pytest, and a backend-dependent
+Playwright project is disproportionate infra for one smoke test. **TW-2**
+(editable preview) is the only open increment and remains blocked on
+[Authoring Integrity](authoring-integrity-versioning.md) Phase 1 snapshots.
+Earlier today: **Performance Budget done** (PERF-01..04 + PERF-06
+in [#251](https://github.com/openshiksha/openshiksha/pull/251)–[#255](https://github.com/openshiksha/openshiksha/pull/255);
+[#256](https://github.com/openshiksha/openshiksha/pull/256) for the DOMPurify
+barrel-export leak). Entry chunk **855 → 93 kB / 247 → 29 kB gzip**, CI guard
+at 160 kB defends the cut.
 
 | Priority | Initiative | Status | Headline progress | Next increment |
 |:--:|---|---|---|---|
-| 1 | [Teacher Workspace](teacher-workspace.md) | Active | Promoted 2026-06-07 (user-directed). [#248](https://github.com/openshiksha/openshiksha/pull/248) fixed the worst breakage (join code, read-only student preview, decluttered dashboard). **TW-1 merged** ([#250](https://github.com/openshiksha/openshiksha/pull/250)): Assign deep-links (`?problemSet=`/`?room=`) preselect the set/room + "preview as a student" link before publish. | **TW-5 ∥ TW-4 ∥ TW-3 (a→b) + TW-T e2e** — batch planned in [docs/daily-plans/2026-06-07-plan-2.md](../daily-plans/2026-06-07-plan-2.md). **TW-2** (editable preview) blocked on [Authoring Integrity](authoring-integrity-versioning.md) Phase 1 snapshots. |
+| 1 | [Teacher Workspace](teacher-workspace.md) | Paused | All unblocked increments shipped 2026-06-07: TW-1 ([#250](https://github.com/openshiksha/openshiksha/pull/250)), TW-5 ([#261](https://github.com/openshiksha/openshiksha/pull/261)), TW-4 ([#262](https://github.com/openshiksha/openshiksha/pull/262)), TW-3a ([#263](https://github.com/openshiksha/openshiksha/pull/263)), TW-3b ([#264](https://github.com/openshiksha/openshiksha/pull/264)), TW-6 ([#265](https://github.com/openshiksha/openshiksha/pull/265)), TW-7 ([#266](https://github.com/openshiksha/openshiksha/pull/266)). TW-T smoke test dropped (see initiative doc). | **TW-2** (editable preview) — blocked on [Authoring Integrity](authoring-integrity-versioning.md) Phase 1 snapshots. Unpause this initiative when AIV-1..3 lands. |
 | - | [Performance Budget](performance-budget.md) | Done | Closed 2026-06-07. PERF-01..04 + PERF-06 shipped in one batch ([#251](https://github.com/openshiksha/openshiksha/pull/251)–[#255](https://github.com/openshiksha/openshiksha/pull/255)); follow-up ([#256](https://github.com/openshiksha/openshiksha/pull/256)) dropped `ReactQueryDevtools` in prod, added a measurement harness, and fixed a `@/shared/ui` barrel-export leak that was dragging DOMPurify into the entry chunk. Entry chunk **855 → 93 kB / 247 → 29 kB gzip** (88% gzip drop); vendor split, route-level `React.lazy`, lazy KaTeX behind `<RichContent>`, CI budget guard at 160 kB. Measured `/login` FCP under Slow 4G + 4× CPU: 4.4 s. | - |
 | - | [Interactive Widgets Framework](interactive-widgets-framework.md) | Paused | Tier 1 **Configure** is usable (`WidgetGalleryPanel` + registry schemas). Tier 3 **Code** is usable (`defineWidget`, `npm run widget:new`, `npm run widget:dev -- <kind>`, `/widgets/dev`, docs). First-party library currently includes `_hello`, `thermo-piston`, `number-line`, `function-plotter`, `fraction-bar`, plus admin-only `custom-html`; all render through the same sandboxed iframe and answer-producing widgets report through the shared protocol. | Defer **IW-9 - IW-11** until product discovery proves Widget Studio is more valuable than more first-party/developer-authored widgets. |
 | - | [V2 "Chalk & Unlock" design overhaul](2026-design-system-v2.md) | Done | M1-M7 are closed for the current scope. Mobile shell now has role-aware bottom tabs, account drawer, safe-area/dynamic-viewport padding, large touch targets, responsive surface audit, and focused a11y baseline. Legacy parity gaps are closed or explicitly skipped. Only optional activation remains: run the [seed-visual-baselines](../../.github/workflows/seed-visual-baselines.yaml) workflow once for M6-03 baselines. | - |

--- a/docs/initiatives/teacher-workspace.md
+++ b/docs/initiatives/teacher-workspace.md
@@ -6,10 +6,11 @@
 > that selection straight into an assignment, edit it safely, publish, and then
 > watch it land — without ever re-finding what they were just looking at.
 >
-> **Status:** 🟢 **Active** (promoted 2026-06-07, user-directed). The teacher
-> dashboard rework ([#248](https://github.com/openshiksha/openshiksha/pull/248))
-> fixed the worst breakage; this initiative makes the whole teacher surface
-> coherent.
+> **Status:** 🟡 **Mostly closed — TW-2 blocked.** All unblocked increments
+> (TW-1, TW-3, TW-4, TW-5, TW-6, TW-7) shipped 2026-06-07. The remaining
+> increment, **TW-2 (editable preview)**, is hard-blocked on
+> [Authoring Integrity & Versioning](authoring-integrity-versioning.md) Phase 1
+> snapshots. Pick this initiative back up when AIV-1..3 lands.
 
 **Last updated:** 2026-06-07
 
@@ -118,8 +119,18 @@ a pile of pages, and closes the seams in reviewable increments.
   edges.
 - **DoD:** create-assignment and preview are usable one-handed on a phone.
 
-**Suggested order:** TW-1 (now) → TW-3 ∥ TW-4 ∥ TW-5 (independent polish) →
-TW-2 (after Authoring Integrity Phase 1) → TW-6 → TW-7.
+**Shipping order taken (2026-06-07):** TW-1 → TW-5 ∥ TW-4 ∥ TW-3a → TW-3b →
+TW-6 → TW-7. **TW-2 remains the only open increment** and is gated by
+Authoring Integrity Phase 1.
+
+> **Removed from backlog:** The earlier draft of this initiative also listed
+> a **TW-T** Playwright continuity smoke test. We dropped it after shipping
+> TW-3/4/5/6/7: the seams it would have covered (URL params + three small
+> mutations) are already well-tested via Vitest + pytest, and standing up the
+> backend-dependent Playwright project to drive a full login → close flow
+> would have been a disproportionate infra change for one smoke test. Worth
+> reconsidering only if the continuity flow grows (multi-step wizards,
+> optimistic UI, websockets).
 
 ---
 
@@ -152,4 +163,10 @@ TW-2 (after Authoring Integrity Phase 1) → TW-6 → TW-7.
 | Date | Increment | PR | Notes |
 |---|---|---|---|
 | 2026-06-07 | Dashboard rework: fixed join code (subject-teacher auth + dedupe), read-only student preview, decluttered insights behind a disclosure, problem-sets section. | [#248](https://github.com/openshiksha/openshiksha/pull/248) | The breakage-fix slice. Motivated this initiative. |
-| 2026-06-07 | **TW-1** — Assign continuity (`?problemSet=` / `?room=` deep links + preselection) + "preview actual questions as a student" link before publish. | _this PR_ | Closes the dead-end Assign flow and the blind-publish gap. Editable preview (TW-2) is deferred to after Authoring Integrity Phase 1 so edits stay safe. |
+| 2026-06-07 | **TW-1** — Assign continuity (`?problemSet=` / `?room=` deep links + preselection) + "preview actual questions as a student" link before publish. | [#250](https://github.com/openshiksha/openshiksha/pull/250) | Closes the dead-end Assign flow and the blind-publish gap. |
+| 2026-06-07 | **TW-5** — Join-code UX (expiry display, shareable link, regenerate confirmation). | [#261](https://github.com/openshiksha/openshiksha/pull/261) | Backend already serialized `expires_at`; this surfaces it and adds the share path. |
+| 2026-06-07 | **TW-4** — Dashboard *Needs attention* strip (overdue / ungraded / low-completion with explicit precedence + deep-links). | [#262](https://github.com/openshiksha/openshiksha/pull/262) | Hidden when nothing needs attention — no dead weight. |
+| 2026-06-07 | **TW-3a** — `Assignment.closed_at` + close/reopen API actions + serialized `status` + submission-write guard. | [#263](https://github.com/openshiksha/openshiksha/pull/263) | Backend foundation. Reads remain unaffected (students still see closed assignments labelled as such). |
+| 2026-06-07 | **TW-3b** — Inline due-date editor + Close/Reopen controls on `TeacherAssignmentDetailPage`; status badge reflects closed state. | [#264](https://github.com/openshiksha/openshiksha/pull/264) | Built on TW-3a. Closes the TW-3 DoD. |
+| 2026-06-07 | **TW-6** — Question-bank ↔ authoring continuity: filters live in the URL, "Use in new set" seeds the builder, both Edit and Use-in-new-set carry `returnTo`. | [#265](https://github.com/openshiksha/openshiksha/pull/265) | No more context loss when moving between bank, set builder, and question editor. |
+| 2026-06-07 | **TW-7** — Mobile teacher pass: `lg:hidden` sticky submit bars on `CreateAssignmentPage` + `CreateProblemSetPage`, 44 px date-preset touch targets. | [#266](https://github.com/openshiksha/openshiksha/pull/266) | Closes the last unblocked TW increment. |


### PR DESCRIPTION
## Summary
- Mark Teacher Workspace **Paused** in STATUS.md — all unblocked increments shipped today; only TW-2 remains, hard-blocked on Authoring Integrity Phase 1.
- Add TW-5/TW-4/TW-3a/TW-3b/TW-6/TW-7 rows to the initiative's Progress Ledger with their merged PRs (#261–#266).
- Remove **TW-T** (Playwright continuity smoke) from the backlog. The seams it would cover are already tested via Vitest + pytest; standing up a backend-dependent Playwright project for one smoke test is disproportionate infra. A short paragraph documents the rationale so it doesn't get re-proposed.

## Classification
Docs only.

## Verify
- `docs/initiatives/STATUS.md` — Teacher Workspace row shows Paused, lists all shipped PRs, names TW-2 as the only open increment.
- `docs/initiatives/teacher-workspace.md` — status banner reflects "mostly closed", ledger covers TW-1, TW-5, TW-4, TW-3a, TW-3b, TW-6, TW-7, and the suggested-order block explains why TW-T was removed.