### PR TITLE
polish(ai): interventions — AI-generated badge + generation error state

### DIFF
--- a/docs/ai-features/polish-backlog.md
+++ b/docs/ai-features/polish-backlog.md
@@ -92,6 +92,37 @@ the Auto-summary badge + note.
 
 ---
 
+## 2026-06-08 — Interventions: AI-generated label + generation error state
+
+**Surface:** Intervention suggestions (teacher dashboard `InterventionsPanel`).
+
+**Gaps (checklist #1 error states, #3 copy/tone, #7 provider transparency):**
+1. Each per-student `strategy_text` is LLM-written but was shown with **no
+   indication it was AI-generated** — the same inconsistency already fixed on
+   `WeeklyReportPanel` and `NarrativeCard`. When the cascade fell back to the
+   deterministic stub (`model_used === 'stub'`) the strategy was presented
+   identically to genuine AI output.
+2. `useGenerateInterventions` **silently swallowed errors**: a failing generate
+   POST left the panel in its prior state with no feedback, so a teacher couldn't
+   tell the click had failed.
+
+**Fix:**
+- Each `SuggestionCard` now shows a `Badge` above the strategy: `✨ AI-generated`
+  (brand tone) for a real LLM, or `Auto-strategy` (neutral tone) plus an "AI was
+  unavailable, so this strategy was built directly from <student>'s learning-gap
+  data" note when `model_used === 'stub'`. `model_used` was already on the
+  `InterventionSuggestion` type/serializer — no backend change needed.
+- Added a friendly inline error ("Couldn't generate suggestions just now. Please
+  try again in a moment.") shown when `generate.isError`.
+- Extended `InterventionsPanel.test.tsx` with the AI-generated label, the stub
+  Auto-strategy + note path, and the generation-error path (checklist #8).
+
+**Verify:** Expand "Intervention Suggestions" on the teacher dashboard. With a
+provider key set each card shows the ✨ AI-generated badge; with no key cards show
+the Auto-strategy badge + note. Trigger a failing generate → red error line.
+
+---
+
 ## Remaining gaps (audit notes — not yet addressed)
 
 - **Natural language explanations** — backend `SubpartExplanationViewSet` is
@@ -99,10 +130,8 @@ the Auto-summary badge + note.
   `frontend_modern`**. The post-grading student feedback surface appears to be
   unwired in the V2 app. Needs UX placement work (inline after feedback) — sizeable,
   flag before treating as polish vs. feature.
-- **Interventions (`InterventionsPanel`)** still displays LLM narrative text
-  with only a footer disclaimer line, unlike the now-fixed `WeeklyReportPanel`
-  and `NarrativeCard`. It already receives `model_used` from its serializer —
-  apply the same `✨ AI-generated` vs `Auto-summary` badge for consistency (next
-  candidate, one surface per run). _(`NarrativeCard` badge done 2026-06-07.)_
+- **Interventions (`InterventionsPanel`)** — ✅ done 2026-06-08. Per-card
+  `✨ AI-generated` vs `Auto-strategy` badge + stub note, plus a generation-error
+  state, now consistent with `WeeklyReportPanel` and `NarrativeCard`.
 - **Hint system** — solid: loading ("Thinking of a good hint…"), error, and
   exhausted states all present. Low priority.

--- a/frontend_modern/src/features/teacher/InterventionsPanel.test.tsx
+++ b/frontend_modern/src/features/teacher/InterventionsPanel.test.tsx
@@ -92,6 +92,46 @@ describe('InterventionsPanel', () => {
     );
   });
 
+  it('labels real LLM strategies as AI-generated', async () => {
+    mockGet.mockResolvedValue({ data: { results: [SUGGESTION] } });
+    renderPanel();
+
+    fireEvent.click(screen.getByText('Intervention Suggestions'));
+    await waitFor(() => expect(screen.getByText('Asha Rao')).toBeDefined());
+
+    expect(screen.getByText('✨ AI-generated')).toBeDefined();
+    expect(screen.queryByText('Auto-strategy')).toBeNull();
+  });
+
+  it('labels stub-mode strategies as Auto-strategy with a fallback note', async () => {
+    mockGet.mockResolvedValue({
+      data: { results: [{ ...SUGGESTION, model_used: 'stub' }] },
+    });
+    renderPanel();
+
+    fireEvent.click(screen.getByText('Intervention Suggestions'));
+    await waitFor(() => expect(screen.getByText('Asha Rao')).toBeDefined());
+
+    expect(screen.getByText('Auto-strategy')).toBeDefined();
+    expect(screen.getByText(/AI was unavailable/)).toBeDefined();
+    expect(screen.queryByText('✨ AI-generated')).toBeNull();
+  });
+
+  it('surfaces a friendly error when generation fails', async () => {
+    mockGet.mockResolvedValue({ data: { results: [] } });
+    mockPost.mockRejectedValue(new Error('boom'));
+    renderPanel();
+
+    fireEvent.click(screen.getByText('Intervention Suggestions'));
+    await waitFor(() => expect(screen.getByText(/No struggling students flagged/)).toBeDefined());
+
+    fireEvent.click(screen.getByText('Generate'));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't generate suggestions just now/)).toBeDefined()
+    );
+  });
+
   it('shows an empty state and a Generate action when there are no suggestions', async () => {
     mockGet.mockResolvedValue({ data: { results: [] } });
     mockPost.mockResolvedValue({ data: {} });

--- a/frontend_modern/src/features/teacher/InterventionsPanel.tsx
+++ b/frontend_modern/src/features/teacher/InterventionsPanel.tsx
@@ -27,6 +27,10 @@ interface CardProps {
 const SuggestionCard = ({ item, subjectRoomId }: CardProps) => {
   const setStatus = useSetInterventionStatus(subjectRoomId);
   const busy = setStatus.isPending;
+  // The provider cascade falls back to a deterministic, data-derived strategy when
+  // no LLM key is configured. That guidance is still useful, but teachers must not
+  // see it presented as genuine AI output (provider-cascade transparency).
+  const isStub = item.model_used === 'stub';
 
   return (
     <div className="rounded-xl border border-ink-100 bg-paper p-4">
@@ -40,7 +44,18 @@ const SuggestionCard = ({ item, subjectRoomId }: CardProps) => {
         <Badge tone={SEVERITY_TONE[item.severity]}>Priority {item.priority}</Badge>
       </div>
 
-      <p className="mt-3 text-sm text-ink-700 leading-relaxed">{item.strategy_text}</p>
+      <div className="mt-3">
+        <Badge tone={isStub ? 'neutral' : 'brand'}>
+          {isStub ? 'Auto-strategy' : '✨ AI-generated'}
+        </Badge>
+        <p className="mt-2 text-sm text-ink-700 leading-relaxed">{item.strategy_text}</p>
+        {isStub && (
+          <p className="mt-1 text-xs text-ink-400">
+            AI was unavailable, so this strategy was built directly from {item.student_name}'s
+            learning-gap data.
+          </p>
+        )}
+      </div>
 
       {item.focus_chapters.length > 0 && (
         <div className="mt-3 flex flex-wrap gap-1.5">
@@ -148,6 +163,12 @@ export const InterventionsPanel = ({ subjectRoomId }: Props) => {
             active.map((item) => (
               <SuggestionCard key={item.id} item={item} subjectRoomId={subjectRoomId} />
             ))}
+
+          {generate.isError && (
+            <p className="text-xs text-rose-600 pt-1">
+              Couldn't generate suggestions just now. Please try again in a moment.
+            </p>
+          )}
 
           <div className="flex items-center justify-between pt-1">
             <p className="text-xs text-ink-400">AI strategies guide your follow-up — you stay in control.</p>


### PR DESCRIPTION
## Surface
Intervention suggestions (teacher dashboard `InterventionsPanel`).

## Gaps fixed (against the AI polish checklist)
1. **Provider transparency (#7) / copy (#3):** Each per-student `strategy_text` is LLM-written but was shown with **no indication it was AI-generated**, and stub-mode fallbacks (`model_used === 'stub'`) were indistinguishable from genuine AI output — the same inconsistency already fixed on `WeeklyReportPanel` and `NarrativeCard`.
2. **Error states (#1):** `useGenerateInterventions` **silently swallowed errors** — a failing generate POST left the panel unchanged with no feedback.

## Before / after
- **Before:** strategy text with only a footer disclaimer; failed generation → nothing happens.
- **After:** each card shows a `✨ AI-generated` (brand) badge for a real LLM, or `Auto-strategy` (neutral) badge + "AI was unavailable, so this strategy was built directly from <student>'s learning-gap data" note for stub mode. Failed generation → friendly red inline error.

No backend change — `model_used` was already on the `InterventionSuggestion` serializer/type.

## How to verify
Expand "Intervention Suggestions" on the teacher dashboard. With a provider key set each card shows the ✨ AI-generated badge; with no key cards show the Auto-strategy badge + note. Trigger a failing generate → red error line.

## Tests
Extended `InterventionsPanel.test.tsx` with the AI-generated label, the stub Auto-strategy + note path, and the generation-error path. All 7 tests pass; `tsc --noEmit` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)