### PR TITLE
ci: gate PRs with dependency-review-action

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,35 @@
+name: Dependency Review
+# Scans a PR's dependency diff for newly-introduced packages with known CVEs
+# or disallowed licenses. Complements the `security` (pip-audit) and
+# `frontend` (npm audit) jobs in ci-cd.yaml — those audit the committed
+# lockfile on every push; this one gates on what a PR is *adding* before it
+# lands. This lives in its own workflow because the action requires the
+# `pull_request` event, while ci-cd.yaml is push-triggered.
+
+on:
+    pull_request:
+        branches:
+            - modernization
+            - qa
+            - prod
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    dependency-review:
+        name: Dependency Review
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out the repo
+              uses: actions/checkout@v4
+            - name: Dependency Review
+              uses: actions/dependency-review-action@v4
+              with:
+                fail-on-severity: high
+                # Mirror the ignores in the `security` job (ci-cd.yaml):
+                # - GHSA-grgv-6hw6-v9g4: twisted, fix only in 26.4.0rc2.
+                # - PYSEC-2025-183 has no GHSA mapping; pip-audit handles it.
+                allow-ghsas: GHSA-grgv-6hw6-v9g4
+                comment-summary-in-pr: on-failure

--- a/docs/changes/2026-06-08-dependency-review.md
+++ b/docs/changes/2026-06-08-dependency-review.md
@@ -1,0 +1,44 @@
+# Dependency Review on PRs — 2026-06-08
+
+## What
+
+New workflow `.github/workflows/dependency-review.yaml` runs
+[`actions/dependency-review-action@v4`](https://github.com/actions/dependency-review-action)
+on every PR targeting `modernization`, `qa`, or `prod`. It diffs the PR's
+dependency manifests against the base branch and fails when a PR introduces
+a package with a **high** (or higher) severity CVE.
+
+## Why
+
+The existing `security` (pip-audit) and `frontend` (npm audit) jobs in
+`ci-cd.yaml` audit the *current committed* lockfile on every push. They will
+eventually catch a newly-introduced vulnerable package, but only *after* it
+has merged to `modernization`. Dependency Review gates the diff at PR time so
+the bad version never lands.
+
+This is especially valuable for Dependabot PRs: if Dependabot proposes a
+bump that itself introduces a new transitive CVE (rare but possible),
+the bump fails review instead of getting auto-merged or rubber-stamped.
+
+## Why a separate workflow file
+
+`ci-cd.yaml` is `on: push`. `actions/dependency-review-action` requires the
+`pull_request` event (it needs `base.sha` to diff against). Splitting it out
+keeps the existing push-triggered pipeline untouched and avoids dual-triggering
+the heavy `test` / `frontend-e2e` jobs on both `push` and `pull_request`.
+
+## Allowlist
+
+- `GHSA-grgv-6hw6-v9g4` (twisted) — matches the ignore in the `security` job;
+  fix only in 26.4.0rc2 (pre-release). Re-evaluate when twisted 26.4.0 stable
+  ships.
+- `PYSEC-2025-183` (pyjwt) — no GHSA mapping, so it isn't matched by the
+  action's GHSA-only allowlist. The disputed advisory is still covered by
+  `pip-audit` in `ci-cd.yaml`.
+
+## Verification
+
+- `actionlint` job in `ci-cd.yaml` will validate the new YAML's syntax on this
+  PR.
+- The workflow itself can only be exercised against a real PR; this change
+  *is* the first such PR.


### PR DESCRIPTION
## Summary

- New workflow `.github/workflows/dependency-review.yaml` runs `actions/dependency-review-action@v4` on PRs targeting `modernization` / `qa` / `prod`.
- Fails the PR if it introduces a dependency with a **high** (or higher) severity CVE.
- Allowlists `GHSA-grgv-6hw6-v9g4` (twisted) to match the existing `security` job ignore.

## Why

The existing `security` (pip-audit) and `frontend` (npm audit) jobs in `ci-cd.yaml` audit the committed lockfile on every push — so they only catch a vulnerable dep *after* it has merged to `modernization`. Dependency Review gates at PR time so the bad version never lands. Especially relevant now that Dependabot is enabled and will be opening PRs autonomously.

## Why a separate workflow file

`ci-cd.yaml` is `on: push`. `actions/dependency-review-action` requires the `pull_request` event (it needs `base.sha` to diff against). Splitting keeps the heavy push-triggered pipeline untouched and avoids dual-triggering `test` / `frontend-e2e` on both events.

## Test plan
- [ ] `Workflow Lint (actionlint)` job (existing) validates the new YAML on this PR
- [ ] New `Dependency Review` job runs on this PR and passes (this PR adds no dependencies)
- [ ] Spot-check on a Dependabot PR after merge that the job runs and posts a summary on failure

See [docs/changes/2026-06-08-dependency-review.md](docs/changes/2026-06-08-dependency-review.md) for the full rationale.