### PR TITLE
docs(initiatives): close Authoring Integrity Phase 1, unpause Teacher Workspace

### DIFF
--- a/docs/initiatives/STATUS.md
+++ b/docs/initiatives/STATUS.md
@@ -4,18 +4,22 @@
 > task advances the **top active initiative** here. See [`README.md`](README.md)
 > for how. Keep this file short - one row per initiative.
 
-**Last updated:** 2026-06-08 — **Authoring Integrity promoted to top
-initiative.** Teacher Workspace's only open increment (**TW-2**, editable
-preview) is hard-blocked on Authoring Integrity **Phase 1** snapshots, and every
-other initiative is Done/Paused — so Phase 1 is the unambiguous next bet. It also
-fixes a verified silent-data-corruption bug: `grade_submission` grades against
-**live** content, so editing a set/answer retroactively re-grades already-assigned
-work. Today's batch ships **AIV-1..3** (per-assignment content snapshots →
-grade/serve from the snapshot → edit-safety UI). Earlier (2026-06-07): all
-unblocked TW increments shipped across **#250, #261–#266** (TW-1, TW-5, TW-4,
-TW-3a, TW-3b, TW-6, TW-7); the planned **TW-T** Playwright smoke was dropped
-(seams already covered by Vitest + pytest).
-Earlier today: **Performance Budget done** (PERF-01..04 + PERF-06
+**Last updated:** 2026-06-08 — **Authoring Integrity Phase 1 done.** AIV-1..3
+shipped across [#270](https://github.com/openshiksha/openshiksha/pull/270)–[#274](https://github.com/openshiksha/openshiksha/pull/274):
+per-assignment content snapshot + backfill ([#270](https://github.com/openshiksha/openshiksha/pull/270)),
+grader reads the snapshot ([#271](https://github.com/openshiksha/openshiksha/pull/271))
+with the golden re-grade-after-edit regression test, student-detail serves the
+snapshot ([#272](https://github.com/openshiksha/openshiksha/pull/272)),
+`assigned_count` + `has_graded_submissions` flags ([#273](https://github.com/openshiksha/openshiksha/pull/273)),
+non-blocking edit-safety banner on `CreateQuestionPage` ([#274](https://github.com/openshiksha/openshiksha/pull/274)).
+The silent-data-corruption hole is closed and **TW-2 (editable preview) is
+unblocked** — Teacher Workspace promoted back to Active. Phase 1 is the unambiguous
+next bet's Done; next-up is **TW-2** under Teacher Workspace, then AIV Phase 2
+(editable + assignment-level preview) → Phase 3 (versioning + guarded re-sync).
+Earlier (2026-06-07): all unblocked TW increments shipped across **#250, #261–#266**
+(TW-1, TW-5, TW-4, TW-3a, TW-3b, TW-6, TW-7); the planned **TW-T** Playwright smoke
+was dropped (seams already covered by Vitest + pytest). Earlier batch:
+**Performance Budget done** (PERF-01..04 + PERF-06
 in [#251](https://github.com/openshiksha/openshiksha/pull/251)–[#255](https://github.com/openshiksha/openshiksha/pull/255);
 [#256](https://github.com/openshiksha/openshiksha/pull/256) for the DOMPurify
 barrel-export leak). Entry chunk **855 → 93 kB / 247 → 29 kB gzip**, CI guard
@@ -23,8 +27,8 @@ at 160 kB defends the cut.
 
 | Priority | Initiative | Status | Headline progress | Next increment |
 |:--:|---|---|---|---|
-| 1 | [Authoring Integrity & Versioning](authoring-integrity-versioning.md) | Active | Promoted 2026-06-08. Root-caused: `grade_submission` reads **live** content, so editing a set/question retroactively re-grades already-assigned work. Phase 1 (Approach A — copy-on-assign snapshot) removes the bug and unblocks TW-2. | **Phase 1: AIV-1** (`Assignment.assigned_content` snapshot + backfill) → **AIV-2a** (grade from snapshot + golden test) ∥ **AIV-2b** (serve snapshot to student) ∥ **AIV-3a** (edit-safety flags) → **AIV-3b** (edit-safety UI notice). |
-| 2 | [Teacher Workspace](teacher-workspace.md) | Paused | All unblocked increments shipped 2026-06-07: TW-1 ([#250](https://github.com/openshiksha/openshiksha/pull/250)), TW-5 ([#261](https://github.com/openshiksha/openshiksha/pull/261)), TW-4 ([#262](https://github.com/openshiksha/openshiksha/pull/262)), TW-3a ([#263](https://github.com/openshiksha/openshiksha/pull/263)), TW-3b ([#264](https://github.com/openshiksha/openshiksha/pull/264)), TW-6 ([#265](https://github.com/openshiksha/openshiksha/pull/265)), TW-7 ([#266](https://github.com/openshiksha/openshiksha/pull/266)). TW-T smoke test dropped (see initiative doc). | **TW-2** (editable preview) — blocked on [Authoring Integrity](authoring-integrity-versioning.md) Phase 1 snapshots. Unpause this initiative when AIV-1..3 lands. |
+| 1 | [Teacher Workspace](teacher-workspace.md) | Active | Unpaused 2026-06-08 after Authoring Integrity Phase 1 shipped. All other increments (TW-1, TW-3a/b, TW-4, TW-5, TW-6, TW-7) closed 2026-06-07 across [#250](https://github.com/openshiksha/openshiksha/pull/250), [#261](https://github.com/openshiksha/openshiksha/pull/261)–[#266](https://github.com/openshiksha/openshiksha/pull/266). | **TW-2** (editable problem-set preview) — now safe by construction (AIV-1/2 snapshots make every edit a future-only change). |
+| 2 | [Authoring Integrity & Versioning](authoring-integrity-versioning.md) | Active | **Phase 1 done 2026-06-08.** AIV-1..3 shipped in [#270](https://github.com/openshiksha/openshiksha/pull/270)–[#274](https://github.com/openshiksha/openshiksha/pull/274): snapshot foundation, grader reads snapshot (golden re-grade-after-edit test), student-detail serves snapshot, `assigned_count` + `has_graded_submissions` flags, edit-safety banner. Silent-data-corruption hole closed; TW-2 unblocked. | **Phase 2: AIV-4** (editable problem-set preview backend hook) + **AIV-5** (assignment-level preview that renders from the snapshot). Then **Phase 3** (AIV-6 guarded re-sync, AIV-7 `ProblemSetVersion`, AIV-8 audit UI). |
 | - | [Performance Budget](performance-budget.md) | Done | Closed 2026-06-07. PERF-01..04 + PERF-06 shipped in one batch ([#251](https://github.com/openshiksha/openshiksha/pull/251)–[#255](https://github.com/openshiksha/openshiksha/pull/255)); follow-up ([#256](https://github.com/openshiksha/openshiksha/pull/256)) dropped `ReactQueryDevtools` in prod, added a measurement harness, and fixed a `@/shared/ui` barrel-export leak that was dragging DOMPurify into the entry chunk. Entry chunk **855 → 93 kB / 247 → 29 kB gzip** (88% gzip drop); vendor split, route-level `React.lazy`, lazy KaTeX behind `<RichContent>`, CI budget guard at 160 kB. Measured `/login` FCP under Slow 4G + 4× CPU: 4.4 s. | - |
 | - | [Interactive Widgets Framework](interactive-widgets-framework.md) | Paused | Tier 1 **Configure** is usable (`WidgetGalleryPanel` + registry schemas). Tier 3 **Code** is usable (`defineWidget`, `npm run widget:new`, `npm run widget:dev -- <kind>`, `/widgets/dev`, docs). First-party library currently includes `_hello`, `thermo-piston`, `number-line`, `function-plotter`, `fraction-bar`, plus admin-only `custom-html`; all render through the same sandboxed iframe and answer-producing widgets report through the shared protocol. | Defer **IW-9 - IW-11** until product discovery proves Widget Studio is more valuable than more first-party/developer-authored widgets. |
 | - | [V2 "Chalk & Unlock" design overhaul](2026-design-system-v2.md) | Done | M1-M7 are closed for the current scope. Mobile shell now has role-aware bottom tabs, account drawer, safe-area/dynamic-viewport padding, large touch targets, responsive surface audit, and focused a11y baseline. Legacy parity gaps are closed or explicitly skipped. Only optional activation remains: run the [seed-visual-baselines](../../.github/workflows/seed-visual-baselines.yaml) workflow once for M6-03 baselines. | - |

--- a/docs/initiatives/authoring-integrity-versioning.md
+++ b/docs/initiatives/authoring-integrity-versioning.md
@@ -7,9 +7,11 @@
 > the assigned, frozen copy are clearly separate, and moving changes from one to
 > the other is an explicit, reviewable act.
 >
-> **Status:** 🟢 **Active** — promoted 2026-06-08 to the top initiative. It is
-> the only unblocked next bet (every other initiative is Done/Paused) and gates
-> Teacher Workspace's last increment, TW-2. Phase 1 (AIV-1..3) is in flight.
+> **Status:** 🟢 **Active** — Phase 1 (AIV-1..3) **done 2026-06-08** across
+> [#270](https://github.com/openshiksha/openshiksha/pull/270)–[#274](https://github.com/openshiksha/openshiksha/pull/274).
+> Silent-data-corruption hole is closed; TW-2 (editable preview) is unblocked.
+> Next bet is **Phase 2** (AIV-4 + AIV-5) — editable + assignment-level preview
+> that renders from the snapshot.
 
 **Last updated:** 2026-06-08
 
@@ -225,3 +227,9 @@ real silent-data-corruption risk even if editable preview never ships.
 |---|---|---|---|
 | 2026-06-07 | Initiative drafted (⚪ Proposed). Root-caused the live-content grading risk; chose snapshot-first (Approach A) → versioning (Approach B). | _(this docs PR)_ | Motivated by the editable-preview ask on [#248](https://github.com/openshiksha/openshiksha/pull/248). Phase 1 (AIV-1..3) is independently shippable and is the priority — it removes a silent data-corruption risk. |
 | 2026-06-08 | **Promoted to top initiative (🟢 Active).** Planned Phase 1 as a 5-PR batch: AIV-1 (snapshot model + capture in both creation paths + backfill) → AIV-2a (grade from snapshot + golden test) ∥ AIV-2b (serve snapshot to student) ∥ AIV-3a (edit-safety flags) → AIV-3b (edit-safety UI notice). | _(plan: [docs/daily-plans/2026-06-08-plan.md](../daily-plans/2026-06-08-plan.md))_ | Only unblocked next bet; gates TW-2. Re-confirmed in code: `grade_submission` reads live content ([tasks.py:52,84](../../backend/openshiksha/apps/core/tasks.py)); two creation paths to instrument — `AssignmentViewSet.perform_create` and `_create_remedial_assignment`. |
+| 2026-06-08 | **AIV-1 done** — `Assignment.assigned_content` JSONField, `apps.core.snapshots.build_assignment_snapshot()`, captured in both creation paths (`AssignmentSerializer.create` + `_create_remedial_assignment`), backfilled every existing assignment from its live set. Byte-identical-after-live-edit regression test pins the integrity invariant. | [#270](https://github.com/openshiksha/openshiksha/pull/270) | Zero behaviour change on its own — readers still hit the live set. Foundation for AIV-2a/2b. |
+| 2026-06-08 | **AIV-2a done** — `grade_submission` reads `subpart_type`, `correct_answer`, `variable_constraints` from the assignment snapshot; falls back to the live set only for legacy rows the backfill couldn't reach. Ships the **golden regression test** (edit live `correct_answer` → re-grade unchanged) + per-assignment corollary (a new assignment after the same edit grades against the new answer). | [#271](https://github.com/openshiksha/openshiksha/pull/271) | The silent-corruption hole is closed at the grader. |
+| 2026-06-08 | **AIV-2b done** — student assignment-detail serializer (`AssignmentDetailSerializer.to_representation`) renders `problem_set.questions` from the snapshot via `render_snapshot_for_student`. Same croupier shuffle + `{{var}}` substitution as the live path; response shape preserved 1:1; no `correct_answer` leak. | [#272](https://github.com/openshiksha/openshiksha/pull/272) | Student sees exactly what they were assigned, even after the live set drifts. |
+| 2026-06-08 | **AIV-3a done** — read-only `assigned_count` + `has_graded_submissions` flags on `ProblemSetSerializer` + `QuestionSerializer`, backed by `Count` + `Exists` annotations so list endpoints stay N+1-free. Falls back to per-row query when annotation absent (POST responses). | [#273](https://github.com/openshiksha/openshiksha/pull/273) | UX-only signal — integrity is guaranteed by AIV-1/2; this just makes "edit is future-only" legible to the editor. |
+| 2026-06-08 | **AIV-3b done** — non-blocking edit-safety banner on `CreateQuestionPage` in edit mode. Says "this question is used in N assignment(s); edits apply to future assignments only" with stronger wording when graded submissions exist. Nothing is disabled. | [#274](https://github.com/openshiksha/openshiksha/pull/274) | Closes Phase 1's Definition of Done. ProblemSet edit surface will reuse the same component when TW-2 ships. |
+| 2026-06-08 | **Phase 1 closed.** Silent-data-corruption hole is gone; TW-2 (editable preview) is unblocked. Teacher Workspace promoted back to Active. Next bet: **Phase 2** (AIV-4 editable + AIV-5 assignment-level preview rendering from the snapshot). | — | All five PRs landed clean. |

--- a/docs/initiatives/teacher-workspace.md
+++ b/docs/initiatives/teacher-workspace.md
@@ -6,13 +6,14 @@
 > that selection straight into an assignment, edit it safely, publish, and then
 > watch it land — without ever re-finding what they were just looking at.
 >
-> **Status:** 🟡 **Mostly closed — TW-2 blocked.** All unblocked increments
-> (TW-1, TW-3, TW-4, TW-5, TW-6, TW-7) shipped 2026-06-07. The remaining
-> increment, **TW-2 (editable preview)**, is hard-blocked on
-> [Authoring Integrity & Versioning](authoring-integrity-versioning.md) Phase 1
-> snapshots. Pick this initiative back up when AIV-1..3 lands.
+> **Status:** 🟢 **Active — TW-2 unblocked.** All other increments (TW-1,
+> TW-3, TW-4, TW-5, TW-6, TW-7) shipped 2026-06-07. Authoring Integrity
+> **Phase 1 landed 2026-06-08**
+> ([#270](https://github.com/openshiksha/openshiksha/pull/270)–[#274](https://github.com/openshiksha/openshiksha/pull/274)),
+> so editing problem-set content is now safe by construction — assigned content
+> is frozen at assign time. **TW-2 (editable preview)** is the next bet.
 
-**Last updated:** 2026-06-07
+**Last updated:** 2026-06-08
 
 ---
 
@@ -120,8 +121,9 @@ a pile of pages, and closes the seams in reviewable increments.
 - **DoD:** create-assignment and preview are usable one-handed on a phone.
 
 **Shipping order taken (2026-06-07):** TW-1 → TW-5 ∥ TW-4 ∥ TW-3a → TW-3b →
-TW-6 → TW-7. **TW-2 remains the only open increment** and is gated by
-Authoring Integrity Phase 1.
+TW-6 → TW-7. **TW-2 is the only open increment**; Authoring Integrity Phase 1
+landed 2026-06-08 ([#270](https://github.com/openshiksha/openshiksha/pull/270)–[#274](https://github.com/openshiksha/openshiksha/pull/274))
+so TW-2 is now unblocked and is this initiative's next bet.
 
 > **Removed from backlog:** The earlier draft of this initiative also listed
 > a **TW-T** Playwright continuity smoke test. We dropped it after shipping
@@ -170,3 +172,4 @@ Authoring Integrity Phase 1.
 | 2026-06-07 | **TW-3b** — Inline due-date editor + Close/Reopen controls on `TeacherAssignmentDetailPage`; status badge reflects closed state. | [#264](https://github.com/openshiksha/openshiksha/pull/264) | Built on TW-3a. Closes the TW-3 DoD. |
 | 2026-06-07 | **TW-6** — Question-bank ↔ authoring continuity: filters live in the URL, "Use in new set" seeds the builder, both Edit and Use-in-new-set carry `returnTo`. | [#265](https://github.com/openshiksha/openshiksha/pull/265) | No more context loss when moving between bank, set builder, and question editor. |
 | 2026-06-07 | **TW-7** — Mobile teacher pass: `lg:hidden` sticky submit bars on `CreateAssignmentPage` + `CreateProblemSetPage`, 44 px date-preset touch targets. | [#266](https://github.com/openshiksha/openshiksha/pull/266) | Closes the last unblocked TW increment. |
+| 2026-06-08 | **TW-2 unblocked.** Authoring Integrity Phase 1 (AIV-1..3) landed across [#270](https://github.com/openshiksha/openshiksha/pull/270)–[#274](https://github.com/openshiksha/openshiksha/pull/274): per-assignment content snapshot + capture in both creation paths + backfill, grader and student-detail serializer both read from the snapshot, `assigned_count`/`has_graded_submissions` flags + non-blocking edit-safety banner. Editing a question or problem set can no longer silently re-grade or re-write what students were given. | — | Initiative re-promoted to 🟢 Active; TW-2 (editable preview) is the next bet. |


### PR DESCRIPTION
## Summary

Ledger update for the AIV-1..3 batch that merged today. No code changes.

- **STATUS.md** — Teacher Workspace promoted back to **Active** (now #1, TW-2 unblocked); Authoring Integrity stays Active for **Phase 2** (AIV-4 + AIV-5). Headline note rewritten with PR links ([#270](https://github.com/openshiksha/openshiksha/pull/270)–[#274](https://github.com/openshiksha/openshiksha/pull/274)) and the next-bet plan.
- **authoring-integrity-versioning.md** — status line flipped to *Phase 1 done*; ledger appended with one row per merged PR (AIV-1, AIV-2a, AIV-2b, AIV-3a, AIV-3b) and a Phase-1-closed summary row pointing at Phase 2.
- **teacher-workspace.md** — status flipped from *Mostly closed — TW-2 blocked* to *Active — TW-2 unblocked*; ledger row added pointing at the AIV merges that unblocked it.

## Test plan

- [x] Markdown renders — links resolve