### PR TITLE
feat(teacher): TW-2 / AIV-4 — editable problem-set preview

### DIFF
--- a/backend/openshiksha/apps/api/serializers/core.py
+++ b/backend/openshiksha/apps/api/serializers/core.py
@@ -553,6 +553,10 @@ class ProblemSetSerializer(serializers.ModelSerializer):
     # response on freshly created rows).
     assigned_count = serializers.SerializerMethodField()
     has_graded_submissions = serializers.SerializerMethodField()
+    # TW-2 / AIV-4: signals whether the current teacher created this set so the
+    # editable preview can show / hide its add+remove affordances without the
+    # frontend having to re-derive the rule (creator == request.user).
+    created_by_me = serializers.SerializerMethodField()
 
     class Meta:
         model = ProblemSet
@@ -573,6 +577,7 @@ class ProblemSetSerializer(serializers.ModelSerializer):
             "source_assignment",
             "assigned_count",
             "has_graded_submissions",
+            "created_by_me",
             "created_at",
         ]
 
@@ -590,6 +595,13 @@ class ProblemSetSerializer(serializers.ModelSerializer):
         if anno is not None:
             return bool(anno)
         return Submission.objects.filter(assignment__problem_set=obj, score__isnull=False).exists()
+
+    def get_created_by_me(self, obj) -> bool:
+        request = self.context.get("request")
+        user = getattr(request, "user", None)
+        if not user or not getattr(user, "is_authenticated", False):
+            return False
+        return obj.created_by_id == user.pk
 
 
 class ProblemSetDetailSerializer(ProblemSetSerializer):

--- a/backend/openshiksha/apps/api/tests/test_problemset_edit_safety.py
+++ b/backend/openshiksha/apps/api/tests/test_problemset_edit_safety.py
@@ -1,0 +1,199 @@
+"""
+TW-2 / AIV-4: editing the live problem set's question list must NOT change any
+existing assignment's snapshot. This is the property that makes the editable
+preview safe to ship.
+
+Mirrors the AIV-1 byte-identical guarantee at the API surface — through the
+``add-question`` and ``remove-question`` endpoints that the editable preview
+calls — so a regression in either path fails the test.
+"""
+
+from __future__ import annotations
+
+import copy
+from datetime import timedelta
+
+import pytest
+
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from openshiksha.apps.core.models import (
+    Assignment,
+    Board,
+    Chapter,
+    ClassRoom,
+    ProblemSet,
+    Question,
+    QuestionSubpart,
+    School,
+    Standard,
+    Subject,
+    SubjectRoom,
+    User,
+    UserRole,
+)
+from openshiksha.apps.core.snapshots import build_assignment_snapshot
+
+
+@pytest.fixture
+def board(db):
+    return Board.objects.create(name="CBSE")
+
+
+@pytest.fixture
+def school(db, board):
+    return School.objects.create(name="S", board=board)
+
+
+@pytest.fixture
+def standard(db):
+    return Standard.objects.create(number=9)
+
+
+@pytest.fixture
+def subject(db):
+    return Subject.objects.create(name="Math")
+
+
+@pytest.fixture
+def chapter(db, subject, standard):
+    return Chapter.objects.create(name="Algebra", subject=subject, standard=standard, order=1)
+
+
+@pytest.fixture
+def classroom(db, school, standard):
+    return ClassRoom.objects.create(school=school, standard=standard, division="A", academic_year="2025-26")
+
+
+@pytest.fixture
+def teacher(db, school):
+    return User.objects.create_user(username="t", password="pw", role=UserRole.TEACHER, school=school)
+
+
+@pytest.fixture
+def other_teacher(db, school):
+    return User.objects.create_user(username="t2", password="pw", role=UserRole.TEACHER, school=school)
+
+
+@pytest.fixture
+def student(db, school):
+    return User.objects.create_user(username="s", password="pw", role=UserRole.STUDENT, school=school)
+
+
+@pytest.fixture
+def subject_room(db, classroom, subject, teacher, student):
+    room = SubjectRoom.objects.create(classroom=classroom, subject=subject, teacher=teacher)
+    room.students.add(student)
+    return room
+
+
+def _make_question(school, standard, subject, chapter, teacher, *, text):
+    q = Question.objects.create(school=school, standard=standard, subject=subject, chapter=chapter, created_by=teacher)
+    QuestionSubpart.objects.create(
+        question=q,
+        index=0,
+        subpart_type="fill_blank",
+        question_text=text,
+        correct_answer={"type": "fill_blank", "answer": "42"},
+    )
+    return q
+
+
+@pytest.fixture
+def problem_set(db, school, standard, subject, chapter, teacher):
+    ps = ProblemSet.objects.create(
+        school=school,
+        standard=standard,
+        subject=subject,
+        chapter=chapter,
+        title="Set",
+        number=1,
+        created_by=teacher,
+    )
+    q1 = _make_question(school, standard, subject, chapter, teacher, text="Q1")
+    q2 = _make_question(school, standard, subject, chapter, teacher, text="Q2")
+    ps.questions.add(q1, q2)
+    return ps
+
+
+@pytest.fixture
+def assignment(db, problem_set, subject_room, teacher):
+    return Assignment.objects.create(
+        problem_set=problem_set,
+        subject_room=subject_room,
+        assigned_by=teacher,
+        due_at=timezone.now() + timedelta(days=3),
+        assigned_content=build_assignment_snapshot(problem_set),
+    )
+
+
+@pytest.fixture
+def teacher_api(teacher):
+    c = APIClient()
+    c.force_authenticate(user=teacher)
+    return c
+
+
+class TestProblemSetEditableLiveAPIs:
+    def test_remove_question_does_not_change_existing_assignment_snapshot(self, teacher_api, problem_set, assignment):
+        """AIV-4 / TW-2 golden test: removing a question from the live set must
+        not change any pre-existing assignment's snapshot. AIV-1 stored the
+        snapshot at assign time; AIV-2 reads from it. This proves the cycle."""
+        original_snapshot = copy.deepcopy(assignment.assigned_content)
+        live_question = problem_set.questions.first()
+
+        resp = teacher_api.post(
+            f"/api/v1/problem-sets/{problem_set.pk}/remove-question/",
+            {"question_id": live_question.pk},
+            format="json",
+        )
+        assert resp.status_code == 200
+
+        # Live set lost the question.
+        problem_set.refresh_from_db()
+        assert not problem_set.questions.filter(pk=live_question.pk).exists()
+
+        # But the existing assignment's snapshot is byte-identical.
+        assignment.refresh_from_db()
+        assert assignment.assigned_content == original_snapshot
+
+    def test_add_question_does_not_change_existing_assignment_snapshot(
+        self, teacher_api, problem_set, assignment, school, standard, subject, chapter, teacher
+    ):
+        original_snapshot = copy.deepcopy(assignment.assigned_content)
+        new_question = _make_question(school, standard, subject, chapter, teacher, text="Q3-new")
+
+        resp = teacher_api.post(
+            f"/api/v1/problem-sets/{problem_set.pk}/add-question/",
+            {"question_id": new_question.pk},
+            format="json",
+        )
+        assert resp.status_code == 200
+
+        # Live set gained the question.
+        problem_set.refresh_from_db()
+        assert problem_set.questions.filter(pk=new_question.pk).exists()
+
+        # Existing assignment's snapshot is untouched.
+        assignment.refresh_from_db()
+        assert assignment.assigned_content == original_snapshot
+
+    def test_remove_question_requires_creator(self, problem_set, other_teacher):
+        c = APIClient()
+        c.force_authenticate(user=other_teacher)
+        live_question = problem_set.questions.first()
+        resp = c.post(
+            f"/api/v1/problem-sets/{problem_set.pk}/remove-question/",
+            {"question_id": live_question.pk},
+            format="json",
+        )
+        assert resp.status_code == 403
+
+    def test_remove_question_requires_question_id(self, teacher_api, problem_set):
+        resp = teacher_api.post(
+            f"/api/v1/problem-sets/{problem_set.pk}/remove-question/",
+            {},
+            format="json",
+        )
+        assert resp.status_code == 400

--- a/backend/openshiksha/apps/api/views/core.py
+++ b/backend/openshiksha/apps/api/views/core.py
@@ -750,6 +750,35 @@ class ProblemSetViewSet(viewsets.ModelViewSet):
         problem_set.questions.add(question)
         return Response({"detail": "Question added.", "question_id": question.id, "problem_set_id": problem_set.id})
 
+    @action(detail=True, methods=["post"], url_path="remove-question")
+    def remove_question(self, request, pk=None):
+        """
+        POST /api/v1/problem-sets/<id>/remove-question/
+        Body: {"question_id": <int>}
+
+        Removes a question from this problem set. Teacher must have created the
+        set. Per AIV-1/2, this **only** affects the live set + future assignments
+        — every existing ``Assignment.assigned_content`` snapshot keeps the
+        question and students/teachers viewing past assignments are unaffected.
+        That's the property that makes TW-2 editable preview safe to ship.
+        """
+        if request.user.role != UserRole.TEACHER:
+            return Response({"detail": "Only teachers can modify problem sets."}, status=status.HTTP_403_FORBIDDEN)
+
+        problem_set = get_object_or_404(ProblemSet, pk=pk, is_active=True)
+        if problem_set.created_by_id != request.user.pk:
+            return Response(
+                {"detail": "You can only modify problem sets you created."}, status=status.HTTP_403_FORBIDDEN
+            )
+
+        question_id = request.data.get("question_id")
+        if not question_id:
+            return Response({"detail": "question_id is required."}, status=status.HTTP_400_BAD_REQUEST)
+
+        question = get_object_or_404(Question, pk=question_id)
+        problem_set.questions.remove(question)
+        return Response({"detail": "Question removed.", "question_id": question.id, "problem_set_id": problem_set.id})
+
 
 class AssignmentViewSet(viewsets.ModelViewSet):
     """

--- a/docs/changes/2026-06-08-tw2-aiv4-editable-preview.md
+++ b/docs/changes/2026-06-08-tw2-aiv4-editable-preview.md
@@ -1,0 +1,36 @@
+# TW-2 / AIV-4 — Editable problem-set preview
+
+**Date:** 2026-06-08
+**Initiatives:** Teacher Workspace (TW-2) + Authoring Integrity & Versioning — Phase 2 (AIV-4)
+**Classification:** Improve
+
+## Summary
+
+`ProblemSetPreviewPage` gains an **edit mode**: the set's creator toggles "Edit set" and gets per-question Remove + Edit-question affordances and an Add-question entry to the question bank (which already has the Add-to-set sheet). The mode banner switches from brand to amber and surfaces the AIV-3b `EditSafetyBanner` when the set is already in use.
+
+Backend ships the missing `remove-question` endpoint that mirrors `add-question`, plus a regression test pinning the property that makes TW-2 safe: **mutating the live set's question list must not change any pre-existing assignment's `assigned_content` snapshot**. Without AIV-1/2 this would silently rewrite already-assigned work; with them it doesn't, and the test proves it through the API.
+
+## Files
+
+- `backend/openshiksha/apps/api/views/core.py` — `remove-question` action on `ProblemSetViewSet`
+- `backend/openshiksha/apps/api/serializers/core.py` — `created_by_me` flag on `ProblemSetSerializer`
+- `backend/openshiksha/apps/api/tests/test_problemset_edit_safety.py` (new) — 4 tests
+- `frontend_modern/src/features/teacher/useRemoveQuestionFromProblemSet.ts` (new) — mutation hook
+- `frontend_modern/src/features/teacher/useProblemSetPreview.ts` — preview type gains `assigned_count`, `has_graded_submissions`, `created_by_me`
+- `frontend_modern/src/features/teacher/ProblemSetPreviewPage.tsx` — edit-mode toggle, per-question Remove + Edit, Add-question link, reuses `EditSafetyBanner`
+- `frontend_modern/src/features/teacher/ProblemSetPreviewPage.test.tsx` (new) — 5 tests
+
+## Verify
+
+- Backend pytest: 24 passed (`test_problemset_edit_safety.py` + `test_problemset_api.py`).
+- Vitest: 9 passed (`ProblemSetPreviewPage.test.tsx` + `EditSafetyBanner.test.tsx`).
+- `npm run type-check` clean; `npm run lint` clean (max-warnings 0); `npm run build` clean.
+
+## Notes
+
+- Reorder is deliberately out of scope: `ProblemSet.questions` is an unordered M2M, so reorder would need a through-table or `position` field — a bigger model change that doesn't belong in this atomic PR.
+- The "Add question" button sends teachers to the question bank with a `returnTo` query param, reusing the existing `AddToProblemSetSheet` flow that QuestionBankPage already drives.
+
+## Next
+
+- AIV-5 — assignment-level preview rendering from the snapshot + a drift banner when the live set has moved past it.

--- a/frontend_modern/src/features/teacher/ProblemSetPreviewPage.test.tsx
+++ b/frontend_modern/src/features/teacher/ProblemSetPreviewPage.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ProblemSetPreviewPage } from './ProblemSetPreviewPage';
+
+const mockPreview = vi.fn();
+const mockRemove = vi.fn();
+const mockMutate = vi.fn();
+
+vi.mock('./useProblemSetPreview', () => ({
+  useProblemSetPreview: (id: number | null) => mockPreview(id),
+}));
+
+vi.mock('./useRemoveQuestionFromProblemSet', () => ({
+  useRemoveQuestionFromProblemSet: () => mockRemove(),
+}));
+
+vi.mock('../student/QuestionCard', () => ({
+  QuestionCard: ({ question }: { question: { id: number; subparts: { question_text: string }[] } }) => (
+    <div data-testid={`qcard-${question.id}`}>{question.subparts[0]?.question_text ?? ''}</div>
+  ),
+}));
+
+const renderAt = () => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/teacher/problem-sets/7/preview']}>
+        <Routes>
+          <Route
+            path="/teacher/problem-sets/:id/preview"
+            element={<ProblemSetPreviewPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
+
+const baseData = {
+  id: 7,
+  title: 'Algebra Set',
+  description: '',
+  number: 1,
+  subject_name: 'Math',
+  chapter_name: 'Algebra',
+  estimated_minutes: null,
+  question_count: 2,
+  questions: [
+    { id: 101, subparts: [{ question_text: 'Q1' }] },
+    { id: 102, subparts: [{ question_text: 'Q2' }] },
+  ],
+};
+
+describe('<ProblemSetPreviewPage />', () => {
+  beforeEach(() => {
+    mockMutate.mockReset();
+    mockRemove.mockReturnValue({ mutate: mockMutate, isPending: false });
+    window.confirm = vi.fn(() => true);
+  });
+
+  it('renders read-only preview by default and hides Edit set when not creator', () => {
+    mockPreview.mockReturnValue({
+      data: { ...baseData, created_by_me: false, assigned_count: 0, has_graded_submissions: false },
+      isLoading: false,
+      isError: false,
+    });
+    renderAt();
+    expect(screen.getByText(/Student preview · read-only/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('toggle-edit')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('remove-101')).not.toBeInTheDocument();
+  });
+
+  it('shows the Edit set toggle when the current teacher is the creator', () => {
+    mockPreview.mockReturnValue({
+      data: { ...baseData, created_by_me: true, assigned_count: 0, has_graded_submissions: false },
+      isLoading: false,
+      isError: false,
+    });
+    renderAt();
+    expect(screen.getByTestId('toggle-edit')).toBeInTheDocument();
+  });
+
+  it('reveals remove buttons in edit mode and calls the mutation', () => {
+    mockPreview.mockReturnValue({
+      data: { ...baseData, created_by_me: true, assigned_count: 0, has_graded_submissions: false },
+      isLoading: false,
+      isError: false,
+    });
+    renderAt();
+
+    fireEvent.click(screen.getByTestId('toggle-edit'));
+    expect(screen.getByText(/Editing set · live changes/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('remove-101'));
+    expect(mockMutate).toHaveBeenCalledWith({ problemSetId: 7, questionId: 101 });
+  });
+
+  it('renders the AIV-3b safety banner in edit mode when the set is already assigned', () => {
+    mockPreview.mockReturnValue({
+      data: { ...baseData, created_by_me: true, assigned_count: 3, has_graded_submissions: true },
+      isLoading: false,
+      isError: false,
+    });
+    renderAt();
+    fireEvent.click(screen.getByTestId('toggle-edit'));
+    expect(screen.getByTestId('edit-safety-banner')).toBeInTheDocument();
+    expect(screen.getByText(/used in 3 assignments\./i)).toBeInTheDocument();
+    expect(screen.getByText(/graded against/i)).toBeInTheDocument();
+  });
+
+  it('does not call the mutation when the confirm dialog is dismissed', () => {
+    mockPreview.mockReturnValue({
+      data: { ...baseData, created_by_me: true, assigned_count: 0, has_graded_submissions: false },
+      isLoading: false,
+      isError: false,
+    });
+    window.confirm = vi.fn(() => false);
+
+    renderAt();
+    fireEvent.click(screen.getByTestId('toggle-edit'));
+    fireEvent.click(screen.getByTestId('remove-101'));
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend_modern/src/features/teacher/ProblemSetPreviewPage.tsx
+++ b/frontend_modern/src/features/teacher/ProblemSetPreviewPage.tsx
@@ -1,22 +1,32 @@
+import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useProblemSetPreview } from './useProblemSetPreview';
+import { useRemoveQuestionFromProblemSet } from './useRemoveQuestionFromProblemSet';
 import { QuestionCard } from '../student/QuestionCard';
 import { Button, EmptyState, LoadingSpinner } from '@/shared/ui';
+import { EditSafetyBanner } from './EditSafetyBanner';
 
 /**
- * Read-only "view as student" preview of a problem set.
+ * Read-only "view as student" preview of a problem set — with an optional
+ * **edit mode** (TW-2 / AIV-4).
  *
  * Renders each question through the **same `<QuestionCard>` students use** on
  * the assignment page — correct answers stripped, `{{var}}` substituted, MCQs
- * shuffled (the backend's student serializer does all of that). Inputs are
- * locked via `isSubmitted` so nothing can be typed or submitted: a teacher is
- * inspecting, not solving.
+ * shuffled. Inputs are locked via `isSubmitted` so nothing can be typed or
+ * submitted: a teacher is inspecting, not solving.
+ *
+ * Edit mode lets the creator remove questions from the live set, jump to the
+ * question editor, or jump to the bank to add more. Editing the live set is
+ * safe by construction: AIV-1/2 snapshot per-assignment content at assign
+ * time, so existing assignments keep exactly what students were given.
  */
 export const ProblemSetPreviewPage = () => {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const setId = id ? Number(id) : null;
   const { data, isLoading, isError } = useProblemSetPreview(setId);
+  const removeQuestion = useRemoveQuestionFromProblemSet();
+  const [isEditing, setIsEditing] = useState(false);
 
   if (isLoading) {
     return (
@@ -38,30 +48,95 @@ export const ProblemSetPreviewPage = () => {
     );
   }
 
+  const canEdit = data.created_by_me === true && setId != null;
+  const assignedCount = data.assigned_count ?? 0;
+  const hasGraded = data.has_graded_submissions ?? false;
+  const returnTo = `/teacher/problem-sets/${setId}/preview`;
+  // Send the teacher to the question bank, scoped to the set's subject so the
+  // first results are relevant; their "Add to set" sheet already drives the
+  // add-question API. ``returnTo`` carries them back here after they confirm.
+  const addPath = `/teacher/questions?returnTo=${encodeURIComponent(returnTo)}`;
+
+  const handleRemove = (questionId: number) => {
+    if (setId == null) return;
+    if (
+      !window.confirm(
+        assignedCount > 0
+          ? 'Remove this question from the live set?\n\nExisting assignments keep it — they grade and render the frozen copy.'
+          : 'Remove this question from the set?',
+      )
+    ) {
+      return;
+    }
+    removeQuestion.mutate({ problemSetId: setId, questionId });
+  };
+
   return (
     <div className="mx-auto max-w-3xl space-y-6 px-4 py-8">
-      {/* Read-only student-preview banner */}
-      <div className="flex flex-wrap items-center gap-3 rounded-xl border border-brand-200 bg-brand-50 px-4 py-3">
-        <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-brand-100 text-brand-700">
+      {/* Mode banner */}
+      <div
+        className={`flex flex-wrap items-center gap-3 rounded-xl border px-4 py-3 ${
+          isEditing
+            ? 'border-amber-200 bg-amber-50'
+            : 'border-brand-200 bg-brand-50'
+        }`}
+      >
+        <span
+          className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full ${
+            isEditing ? 'bg-amber-100 text-amber-700' : 'bg-brand-100 text-brand-700'
+          }`}
+        >
           <svg viewBox="0 0 20 20" className="h-4 w-4" fill="currentColor">
             <path d="M10 4C5.5 4 2 7.5 1 10c1 2.5 4.5 6 9 6s8-3.5 9-6c-1-2.5-4.5-6-9-6zm0 9a3 3 0 110-6 3 3 0 010 6z" />
           </svg>
         </span>
         <div className="min-w-0 flex-1">
-          <p className="text-sm font-semibold text-brand-900">Student preview · read-only</p>
-          <p className="text-xs text-brand-700">
-            This is exactly how students see the set — answers hidden, variables filled in. You
-            can't type or submit here.
+          <p
+            className={`text-sm font-semibold ${
+              isEditing ? 'text-amber-900' : 'text-brand-900'
+            }`}
+          >
+            {isEditing ? 'Editing set · live changes' : 'Student preview · read-only'}
+          </p>
+          <p
+            className={`text-xs ${isEditing ? 'text-amber-800' : 'text-brand-700'}`}
+          >
+            {isEditing
+              ? 'Changes apply to future assignments only — existing ones keep what students were given.'
+              : "This is exactly how students see the set — answers hidden, variables filled in. You can't type or submit here."}
           </p>
         </div>
-        <button
-          type="button"
-          onClick={() => navigate(-1)}
-          className="text-sm font-medium text-brand-700 hover:text-brand-900"
-        >
-          ← Back
-        </button>
+        <div className="flex shrink-0 items-center gap-2">
+          {canEdit && (
+            <button
+              type="button"
+              onClick={() => setIsEditing((v) => !v)}
+              data-testid="toggle-edit"
+              className="rounded-md border border-ink-200 bg-white px-3 py-1.5 text-xs font-medium text-ink-700 hover:bg-ink-50"
+            >
+              {isEditing ? 'Done editing' : 'Edit set'}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className={`text-sm font-medium ${
+              isEditing ? 'text-amber-800 hover:text-amber-900' : 'text-brand-700 hover:text-brand-900'
+            }`}
+          >
+            ← Back
+          </button>
+        </div>
       </div>
+
+      {/* AIV-3b banner reused for problem sets when editing. */}
+      {isEditing && (
+        <EditSafetyBanner
+          assignedCount={assignedCount}
+          hasGradedSubmissions={hasGraded}
+          noun="this problem set"
+        />
+      )}
 
       {/* Set header */}
       <div>
@@ -78,20 +153,63 @@ export const ProblemSetPreviewPage = () => {
       {data.questions.length === 0 ? (
         <EmptyState
           title="This set has no questions yet"
-          description="Add questions to the set, then preview again."
+          description={
+            isEditing
+              ? 'Use the Add question button below to start filling it in.'
+              : 'Add questions to the set, then preview again.'
+          }
         />
       ) : (
         <div className="space-y-4">
           {data.questions.map((q, i) => (
-            <QuestionCard
-              key={q.id}
-              question={q}
-              questionNumber={i + 1}
-              answers={{}}
-              onAnswerChange={() => {}}
-              isSubmitted
-            />
+            <div key={q.id} className="relative">
+              <QuestionCard
+                question={q}
+                questionNumber={i + 1}
+                answers={{}}
+                onAnswerChange={() => {}}
+                isSubmitted
+              />
+              {isEditing && (
+                <div className="mt-2 flex items-center justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={() =>
+                      navigate(
+                        `/teacher/questions/${q.id}/edit?returnTo=${encodeURIComponent(returnTo)}`,
+                      )
+                    }
+                    className="rounded-md border border-ink-200 bg-white px-3 py-1.5 text-xs font-medium text-ink-700 hover:bg-ink-50"
+                  >
+                    Edit question
+                  </button>
+                  <button
+                    type="button"
+                    data-testid={`remove-${q.id}`}
+                    disabled={removeQuestion.isPending}
+                    onClick={() => handleRemove(q.id)}
+                    className="rounded-md border border-red-200 bg-white px-3 py-1.5 text-xs font-medium text-red-700 hover:bg-red-50 disabled:opacity-50"
+                  >
+                    Remove from set
+                  </button>
+                </div>
+              )}
+            </div>
           ))}
+        </div>
+      )}
+
+      {isEditing && (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-dashed border-ink-200 bg-paper px-4 py-3">
+          <div>
+            <p className="text-sm font-semibold text-ink-800">Add more questions</p>
+            <p className="text-xs text-ink-500">
+              Pick from the question bank, or author a new question — you'll come back here when done.
+            </p>
+          </div>
+          <Button onClick={() => navigate(addPath)} variant="brand">
+            Add question
+          </Button>
         </div>
       )}
 

--- a/frontend_modern/src/features/teacher/useProblemSetPreview.ts
+++ b/frontend_modern/src/features/teacher/useProblemSetPreview.ts
@@ -17,6 +17,11 @@ export interface ProblemSetStudentPreview {
   estimated_minutes: number | null;
   question_count: number;
   questions: Question[];
+  /** AIV-3a edit-safety flags (also on the regular detail endpoint). */
+  assigned_count?: number;
+  has_graded_submissions?: boolean;
+  /** Whether the current teacher created this set — determines edit affordances. */
+  created_by_me?: boolean;
 }
 
 const fetchPreview = async (id: number): Promise<ProblemSetStudentPreview> => {

--- a/frontend_modern/src/features/teacher/useRemoveQuestionFromProblemSet.ts
+++ b/frontend_modern/src/features/teacher/useRemoveQuestionFromProblemSet.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+
+interface RemoveQuestionPayload {
+  problemSetId: number;
+  questionId: number;
+}
+
+const removeQuestion = async ({ problemSetId, questionId }: RemoveQuestionPayload) => {
+  const response = await apiClient.post(
+    `/problem-sets/${problemSetId}/remove-question/`,
+    { question_id: questionId },
+  );
+  return response.data;
+};
+
+/**
+ * TW-2 / AIV-4: drop a question from the live problem set.
+ *
+ * Existing assignments using this set are unaffected — they grade and render
+ * from their per-assignment ``assigned_content`` snapshot (AIV-1/2). Verified
+ * by ``apps/api/tests/test_problemset_edit_safety.py``.
+ */
+export const useRemoveQuestionFromProblemSet = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: removeQuestion,
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['problem-sets'] });
+      queryClient.invalidateQueries({
+        queryKey: ['problem-set-preview', variables.problemSetId],
+      });
+    },
+  });
+};


### PR DESCRIPTION
## Summary

Closes the last open Teacher Workspace increment **TW-2** and ships the matching Authoring Integrity Phase 2 increment **AIV-4**.

`ProblemSetPreviewPage` gains an **edit mode** for the set's creator:
- per-question **Remove** + **Edit question** buttons
- an **Add question** entry that sends the teacher to the question bank (the bank already has an Add-to-set sheet driving `add-question`)
- the AIV-3b `EditSafetyBanner` when the set is already in use

Backend ships the missing `remove-question` endpoint (mirror of `add-question`) and a regression test pinning the property that makes TW-2 safe by construction: **mutating the live set's question list must NOT change any pre-existing assignment's `assigned_content` snapshot**. AIV-1/2 already guaranteed this at the model + grader + student-serializer layers; this test proves it through the live API surface the editable preview hits.

Adds `created_by_me` on `ProblemSetSerializer` so the frontend can show/hide edit affordances without re-deriving the creator-only rule the backend already enforces.

## Files

- `api/views/core.py` — `remove-question` action on `ProblemSetViewSet`
- `api/serializers/core.py` — `created_by_me` flag
- `api/tests/test_problemset_edit_safety.py` (new) — 4 tests
- `features/teacher/useRemoveQuestionFromProblemSet.ts` (new)
- `features/teacher/useProblemSetPreview.ts` — preview type gains `assigned_count` / `has_graded_submissions` / `created_by_me`
- `features/teacher/ProblemSetPreviewPage.tsx` — edit toggle, per-question Remove + Edit, Add-question link
- `features/teacher/ProblemSetPreviewPage.test.tsx` (new) — 5 tests

## Test plan

- [x] **Golden API test:** `test_remove_question_does_not_change_existing_assignment_snapshot` — calling `remove-question` after assigning leaves the assignment's snapshot byte-identical
- [x] Companion: `add-question` is also snapshot-safe
- [x] Non-creator gets 403; missing `question_id` gets 400
- [x] Vitest 5 passed (read-only by default; toggle only for creator; remove fires mutation; safety banner shown when assigned; confirm-dismissal cancels)
- [x] `type-check`, `lint --max-warnings 0`, `build` clean

## Out of scope

Reorder — `ProblemSet.questions` is an unordered M2M. Reordering needs a through-table or `position` field, a model change that doesn't belong in this atomic PR.

## Stack

Depends on AIV-1..3 (#270–#274, already merged).