### PR TITLE
feat(teacher): AIV-5 — assignment-level snapshot preview + drift banner

### DIFF
--- a/backend/openshiksha/apps/api/serializers/core.py
+++ b/backend/openshiksha/apps/api/serializers/core.py
@@ -742,15 +742,25 @@ class AssignmentDetailSerializer(AssignmentSerializer):
     problem-set's ``questions`` array is built from the snapshot — so a student
     always sees exactly what they were assigned, even after the live set
     drifts. Response shape is preserved 1:1 with the live path.
+
+    AIV-5: also surfaces ``snapshot_drift`` — true when the live set has moved
+    past the frozen snapshot. Lets the teacher UI flag "this assignment's
+    content predates the latest edits" without re-fetching the live set.
     """
 
     # ``my_submission`` is inherited from AssignmentSerializer now — the
     # detail serializer only swaps the problem-set serializer for the
     # student-safe variant that hides ``correct_answer``.
     problem_set = ProblemSetStudentDetailSerializer(read_only=True)
+    snapshot_drift = serializers.SerializerMethodField()
 
     class Meta(AssignmentSerializer.Meta):
-        fields = AssignmentSerializer.Meta.fields
+        fields = AssignmentSerializer.Meta.fields + ["snapshot_drift"]
+
+    def get_snapshot_drift(self, obj) -> bool:
+        from openshiksha.apps.core.snapshots import snapshot_has_drifted
+
+        return snapshot_has_drifted(obj.assigned_content, obj.problem_set)
 
     def to_representation(self, instance):
         data = super().to_representation(instance)

--- a/backend/openshiksha/apps/core/snapshots.py
+++ b/backend/openshiksha/apps/core/snapshots.py
@@ -94,6 +94,23 @@ def build_assignment_snapshot(problem_set: "ProblemSet") -> dict[str, Any]:
     }
 
 
+def snapshot_has_drifted(snapshot: dict[str, Any] | None, problem_set: "ProblemSet") -> bool:
+    """
+    AIV-5: report whether the live ``problem_set`` has drifted from a frozen
+    ``snapshot`` (i.e. anything the renderer or grader cares about has
+    changed since assign time). A no-snapshot assignment is treated as not
+    drifted — there's nothing to drift from.
+
+    Compares the snapshot's ``questions`` block to a freshly-built one,
+    ignoring volatile keys (``captured_at``, ``problem_set_title``) that
+    don't affect what students see or how grading runs.
+    """
+    if not snapshot or not snapshot.get("questions"):
+        return False
+    fresh = build_assignment_snapshot(problem_set)
+    return snapshot.get("questions") != fresh.get("questions")
+
+
 def render_snapshot_for_student(
     snapshot: dict[str, Any],
     *,

--- a/backend/openshiksha/apps/core/tests/test_snapshot_drift.py
+++ b/backend/openshiksha/apps/core/tests/test_snapshot_drift.py
@@ -1,0 +1,171 @@
+"""
+AIV-5: ``snapshot_has_drifted`` and the ``snapshot_drift`` field on
+``AssignmentDetailSerializer`` flag when the live problem-set has moved past
+the frozen snapshot — without changing what's served to the student.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from openshiksha.apps.core.models import (
+    Assignment,
+    Board,
+    Chapter,
+    ClassRoom,
+    ProblemSet,
+    Question,
+    QuestionSubpart,
+    School,
+    Standard,
+    Subject,
+    SubjectRoom,
+    User,
+    UserRole,
+)
+from openshiksha.apps.core.snapshots import build_assignment_snapshot, snapshot_has_drifted
+
+
+@pytest.fixture
+def board(db):
+    return Board.objects.create(name="CBSE")
+
+
+@pytest.fixture
+def school(db, board):
+    return School.objects.create(name="S", board=board)
+
+
+@pytest.fixture
+def standard(db):
+    return Standard.objects.create(number=9)
+
+
+@pytest.fixture
+def subject(db):
+    return Subject.objects.create(name="Math")
+
+
+@pytest.fixture
+def chapter(db, subject, standard):
+    return Chapter.objects.create(name="Algebra", subject=subject, standard=standard, order=1)
+
+
+@pytest.fixture
+def classroom(db, school, standard):
+    return ClassRoom.objects.create(school=school, standard=standard, division="A", academic_year="2025-26")
+
+
+@pytest.fixture
+def teacher(db, school):
+    return User.objects.create_user(username="t", password="pw", role=UserRole.TEACHER, school=school)
+
+
+@pytest.fixture
+def student(db, school):
+    return User.objects.create_user(username="s", password="pw", role=UserRole.STUDENT, school=school)
+
+
+@pytest.fixture
+def subject_room(db, classroom, subject, teacher, student):
+    room = SubjectRoom.objects.create(classroom=classroom, subject=subject, teacher=teacher)
+    room.students.add(student)
+    return room
+
+
+@pytest.fixture
+def problem_set(db, school, standard, subject, chapter, teacher):
+    ps = ProblemSet.objects.create(
+        school=school,
+        standard=standard,
+        subject=subject,
+        chapter=chapter,
+        title="Set",
+        number=1,
+        created_by=teacher,
+    )
+    q = Question.objects.create(school=school, standard=standard, subject=subject, chapter=chapter, created_by=teacher)
+    QuestionSubpart.objects.create(
+        question=q,
+        index=0,
+        subpart_type="fill_blank",
+        question_text="What is 6*7?",
+        correct_answer={"type": "fill_blank", "answer": "42"},
+    )
+    ps.questions.add(q)
+    return ps
+
+
+@pytest.fixture
+def assignment(db, problem_set, subject_room, teacher):
+    return Assignment.objects.create(
+        problem_set=problem_set,
+        subject_room=subject_room,
+        assigned_by=teacher,
+        due_at=timezone.now() + timedelta(days=3),
+        assigned_content=build_assignment_snapshot(problem_set),
+    )
+
+
+class TestSnapshotHasDrifted:
+    def test_no_drift_immediately_after_assign(self, problem_set, assignment):
+        assert snapshot_has_drifted(assignment.assigned_content, problem_set) is False
+
+    def test_no_drift_when_snapshot_is_missing(self, problem_set):
+        # Defensive: legacy rows the backfill missed report no drift, not a crash.
+        assert snapshot_has_drifted(None, problem_set) is False
+        assert snapshot_has_drifted({}, problem_set) is False
+
+    def test_drift_when_subpart_correct_answer_edited(self, problem_set, assignment):
+        sp = problem_set.questions.first().subparts.first()
+        sp.correct_answer = {"type": "fill_blank", "answer": "999"}
+        sp.save(update_fields=["correct_answer"])
+        assert snapshot_has_drifted(assignment.assigned_content, problem_set) is True
+
+    def test_drift_when_question_added(self, problem_set, assignment, school, standard, subject, chapter, teacher):
+        q2 = Question.objects.create(
+            school=school,
+            standard=standard,
+            subject=subject,
+            chapter=chapter,
+            created_by=teacher,
+        )
+        QuestionSubpart.objects.create(question=q2, index=0, subpart_type="fill_blank", correct_answer={"answer": "1"})
+        problem_set.questions.add(q2)
+        assert snapshot_has_drifted(assignment.assigned_content, problem_set) is True
+
+    def test_drift_when_question_removed(self, problem_set, assignment):
+        problem_set.questions.clear()
+        assert snapshot_has_drifted(assignment.assigned_content, problem_set) is True
+
+
+class TestAssignmentDetailDriftField:
+    def test_teacher_assignment_detail_includes_snapshot_drift_false(self, assignment, teacher):
+        c = APIClient()
+        c.force_authenticate(user=teacher)
+        resp = c.get(f"/api/v1/assignments/{assignment.pk}/")
+        assert resp.status_code == 200
+        assert resp.data["snapshot_drift"] is False
+
+    def test_teacher_assignment_detail_drift_flips_after_live_edit(self, assignment, problem_set, teacher):
+        # Edit the live set.
+        sp = problem_set.questions.first().subparts.first()
+        sp.correct_answer = {"type": "fill_blank", "answer": "999"}
+        sp.save(update_fields=["correct_answer"])
+
+        c = APIClient()
+        c.force_authenticate(user=teacher)
+        resp = c.get(f"/api/v1/assignments/{assignment.pk}/")
+        assert resp.data["snapshot_drift"] is True
+
+        # And the rendered questions still match the snapshot, not the live edit.
+        sp_data = resp.data["problem_set"]["questions"][0]["subparts"][0]
+        # correct_answer is stripped (student-safe) — assert question_text is the
+        # snapshot value, not the edit, by checking a stable field that didn't
+        # change. The drift flag carries the signal; the body stays frozen.
+        assert sp_data["question_text"] == "What is 6*7?"

--- a/docs/changes/2026-06-09-aiv5-snapshot-drift.md
+++ b/docs/changes/2026-06-09-aiv5-snapshot-drift.md
@@ -1,0 +1,40 @@
+# AIV-5 — Assignment-level snapshot preview + drift banner
+
+**Date:** 2026-06-09
+**Initiative:** Authoring Integrity & Versioning — Phase 2
+**Classification:** New
+**Depends on:** AIV-1/2 (snapshot capture + readers)
+
+## Summary
+
+Teachers opening an assignment now see a collapsible **"What students see · snapshot"** section that renders the frozen `Assignment.assigned_content` through the same `QuestionCard` students use (locked, no input). When the live `ProblemSet` has moved past the snapshot, an amber drift banner explains the situation and deep-links to the editable live-set preview so the teacher can compare.
+
+Backend ships:
+- `apps.core.snapshots.snapshot_has_drifted(snapshot, problem_set)` — true iff the snapshot's `questions` block differs from a fresh one built from the live set.
+- `snapshot_drift: bool` on `AssignmentDetailSerializer` — the teacher view reads this; the same payload's `problem_set.questions` is already the snapshot view from AIV-2b.
+
+## Files
+
+- `backend/openshiksha/apps/core/snapshots.py` — `snapshot_has_drifted`
+- `backend/openshiksha/apps/api/serializers/core.py` — `snapshot_drift` field on `AssignmentDetailSerializer`
+- `backend/openshiksha/apps/core/tests/test_snapshot_drift.py` (new) — 7 tests
+- `frontend_modern/src/types/index.ts` — `Assignment.snapshot_drift?`, new `AssignmentDetail` interface
+- `frontend_modern/src/features/teacher/useTeacherAssignmentDetail.ts` — types the meta query as `AssignmentDetail`
+- `frontend_modern/src/features/teacher/AssignmentSnapshotPreview.tsx` (new)
+- `frontend_modern/src/features/teacher/AssignmentSnapshotPreview.test.tsx` (new) — 4 tests
+- `frontend_modern/src/features/teacher/TeacherAssignmentDetailPage.tsx` — renders the preview section
+
+## Verify
+
+- pytest: 16 passed (drift + snapshot + assignment-snapshot-view).
+- Vitest: 65 passed across `src/features/teacher/`.
+- `npm run type-check` clean; `npm run lint` clean (max-warnings 0); `npm run build` clean.
+
+## Notes
+
+- The teacher response keeps the existing student-safe shape — `correct_answer` is still stripped. Teachers needing answer keys still go through the question bank / question editor; this view is "see what students see".
+- Drift detection ignores volatile fields (`captured_at`, `problem_set_title`) so renaming the set or re-snapshotting doesn't false-positive.
+
+## Next
+
+- **Phase 3** — AIV-6 (guarded re-sync of an assignment to the latest content, with a preview of the blast radius) → AIV-7 (`ProblemSetVersion` model; assignments pin a version) → AIV-8 (version history + audit UI).

--- a/frontend_modern/src/features/teacher/AssignmentSnapshotPreview.test.tsx
+++ b/frontend_modern/src/features/teacher/AssignmentSnapshotPreview.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+import { AssignmentSnapshotPreview } from './AssignmentSnapshotPreview';
+import type { ProblemSetWithQuestions } from '@/types/index';
+
+vi.mock('../student/QuestionCard', () => ({
+  QuestionCard: ({ question }: { question: { id: number; subparts: { question_text: string }[] } }) => (
+    <div data-testid={`qcard-${question.id}`}>{question.subparts[0]?.question_text ?? ''}</div>
+  ),
+}));
+
+const renderPreview = (overrides: Partial<{ drift: boolean }> & { questions?: unknown[] } = {}) => {
+  const problemSet = {
+    id: 9,
+    title: 'Algebra',
+    description: '',
+    chapter: { id: 1, name: 'Algebra' },
+    subject: { id: 1, name: 'Math' },
+    standard: { id: 1, name: '9' },
+    question_count: 1,
+    estimated_minutes: null,
+    is_active: true,
+    is_remedial: false,
+    source_assignment: null,
+    questions: overrides.questions ?? [{ id: 101, subparts: [{ question_text: 'Frozen prompt' }] }],
+  } as unknown as ProblemSetWithQuestions;
+  return render(
+    <MemoryRouter>
+      <AssignmentSnapshotPreview
+        problemSet={problemSet}
+        snapshotDrift={overrides.drift ?? false}
+      />
+    </MemoryRouter>,
+  );
+};
+
+describe('<AssignmentSnapshotPreview />', () => {
+  it('starts collapsed and reveals the question cards on toggle', () => {
+    renderPreview();
+    // Collapsed: no question card rendered yet.
+    expect(screen.queryByTestId('qcard-101')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('snapshot-toggle'));
+    expect(screen.getByTestId('qcard-101')).toBeInTheDocument();
+    expect(screen.getByText('Frozen prompt')).toBeInTheDocument();
+  });
+
+  it('does not render the drift banner when the snapshot matches the live set', () => {
+    renderPreview({ drift: false });
+    expect(screen.queryByTestId('snapshot-drift-banner')).not.toBeInTheDocument();
+  });
+
+  it('renders the drift banner with a link to the live preview when drift is true', () => {
+    renderPreview({ drift: true });
+    const banner = screen.getByTestId('snapshot-drift-banner');
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveTextContent(/live set has changed/i);
+    const link = screen.getByRole('link', { name: /compare with the live set/i });
+    expect(link).toHaveAttribute('href', '/teacher/problem-sets/9/preview');
+  });
+
+  it('renders an empty-state message when the snapshot has no questions', () => {
+    renderPreview({ questions: [] });
+    fireEvent.click(screen.getByTestId('snapshot-toggle'));
+    expect(screen.getByText(/snapshot is empty/i)).toBeInTheDocument();
+  });
+});

--- a/frontend_modern/src/features/teacher/AssignmentSnapshotPreview.tsx
+++ b/frontend_modern/src/features/teacher/AssignmentSnapshotPreview.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { QuestionCard } from '../student/QuestionCard';
+import type { ProblemSetWithQuestions } from '@/types/index';
+
+/**
+ * AIV-5: collapsible "what students see" preview embedded on the teacher
+ * assignment-detail page. Renders the **frozen snapshot** sourced from
+ * ``Assignment.assigned_content`` — the same payload AIV-2b serves to the
+ * student. Inputs are locked via ``isSubmitted`` so nothing can be typed.
+ *
+ * When ``snapshotDrift`` is true the live ``ProblemSet`` has moved past the
+ * snapshot; show an amber notice that links to the editable preview so the
+ * teacher can compare. The frozen snapshot is what was actually assigned —
+ * editing the live set does not retroactively change it (AIV-1/2).
+ */
+interface Props {
+  problemSet: ProblemSetWithQuestions;
+  snapshotDrift: boolean;
+}
+
+export function AssignmentSnapshotPreview({ problemSet, snapshotDrift }: Props) {
+  const [open, setOpen] = useState(false);
+  const questions = problemSet.questions ?? [];
+
+  return (
+    <section className="os-card overflow-hidden p-0" data-testid="snapshot-preview">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        data-testid="snapshot-toggle"
+        className="flex w-full items-center justify-between gap-3 border-b border-ink-100 px-6 py-4 text-left hover:bg-ink-50"
+      >
+        <div>
+          <h2 className="font-display text-base font-semibold text-ink-900">
+            What students see · snapshot
+          </h2>
+          <p className="mt-0.5 text-xs text-ink-400">
+            Frozen at assign time — editing the set later doesn't change this view.
+          </p>
+        </div>
+        <span className="text-sm font-medium text-brand-700">
+          {open ? 'Hide' : 'Show'}
+        </span>
+      </button>
+
+      {snapshotDrift && (
+        <div
+          role="status"
+          data-testid="snapshot-drift-banner"
+          className="border-b border-amber-200 bg-amber-50 px-6 py-3 text-sm text-amber-900"
+        >
+          <p className="font-semibold">The live set has changed since this assignment was given.</p>
+          <p className="mt-0.5 text-amber-800">
+            What students see and how this assignment grades come from the frozen snapshot above —
+            newer assignments will use the updated set.{' '}
+            <Link
+              to={`/teacher/problem-sets/${problemSet.id}/preview`}
+              className="font-semibold underline hover:text-amber-950"
+            >
+              Compare with the live set
+            </Link>
+            .
+          </p>
+        </div>
+      )}
+
+      {open && (
+        <div className="space-y-4 bg-paper px-6 py-5">
+          {questions.length === 0 ? (
+            <p className="text-sm italic text-ink-400">
+              This assignment's snapshot is empty.
+            </p>
+          ) : (
+            questions.map((q, i) => (
+              <QuestionCard
+                key={q.id}
+                question={q}
+                questionNumber={i + 1}
+                answers={{}}
+                onAnswerChange={() => {}}
+                isSubmitted
+              />
+            ))
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend_modern/src/features/teacher/TeacherAssignmentDetailPage.tsx
+++ b/frontend_modern/src/features/teacher/TeacherAssignmentDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTeacherAssignmentDetail } from './useTeacherAssignmentDetail';
 import { useQuestionMistakes } from './useQuestionMistakes';
+import { AssignmentSnapshotPreview } from './AssignmentSnapshotPreview';
 import {
   Badge,
   EmptyState,
@@ -191,6 +192,11 @@ export const TeacherAssignmentDetailPage = () => {
           <p className="mt-1 text-xs text-ink-400">{Math.round(submissionPct)}% submitted</p>
         </div>
       </div>
+
+      <AssignmentSnapshotPreview
+        problemSet={assignment.problem_set}
+        snapshotDrift={assignment.snapshot_drift === true}
+      />
 
       <div className="os-card overflow-hidden p-0">
         <div className="border-b border-ink-100 px-6 py-4">

--- a/frontend_modern/src/features/teacher/useTeacherAssignmentDetail.ts
+++ b/frontend_modern/src/features/teacher/useTeacherAssignmentDetail.ts
@@ -1,17 +1,21 @@
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from '@/api/client';
-import type { Assignment, Submission } from '@/types/index';
+import type { AssignmentDetail, Submission } from '@/types/index';
 
 export interface SubmissionWithStudent extends Submission {
   student_name: string;
 }
 
-export interface TeacherAssignmentDetail extends Assignment {
+export interface TeacherAssignmentDetail extends AssignmentDetail {
   submissions: SubmissionWithStudent[];
 }
 
-const fetchAssignmentMeta = async (id: number): Promise<Assignment> => {
-  const response = await apiClient.get<Assignment>(`/assignments/${id}/`);
+const fetchAssignmentMeta = async (id: number): Promise<AssignmentDetail> => {
+  // The retrieve endpoint serves AssignmentDetailSerializer — it embeds the
+  // snapshot-rendered problem-set + questions (AIV-2b) and ``snapshot_drift``
+  // (AIV-5). The list endpoint uses AssignmentSerializer (no questions); only
+  // the detail view carries this richer shape.
+  const response = await apiClient.get<AssignmentDetail>(`/assignments/${id}/`);
   return response.data;
 };
 
@@ -21,7 +25,7 @@ const fetchAssignmentSubmissions = async (id: number): Promise<SubmissionWithStu
 };
 
 export const useTeacherAssignmentDetail = (id: number) => {
-  const metaQuery = useQuery<Assignment>({
+  const metaQuery = useQuery<AssignmentDetail>({
     queryKey: ['teacher-assignment', id],
     queryFn: () => fetchAssignmentMeta(id),
     staleTime: 60 * 1000,

--- a/frontend_modern/src/types/index.ts
+++ b/frontend_modern/src/types/index.ts
@@ -233,6 +233,17 @@ export interface Assignment {
   child_submission_status?: 'submitted' | 'not_submitted' | null;
   closed_at?: string | null;
   status?: 'active' | 'overdue' | 'closed';
+  /**
+   * AIV-5: true when the live ProblemSet has moved past this assignment's
+   * frozen ``assigned_content`` snapshot. Drives the drift banner on the
+   * teacher assignment detail view; students never see this field act on
+   * anything because they grade and render from the snapshot regardless.
+   */
+  snapshot_drift?: boolean;
+}
+
+export interface AssignmentDetail extends Assignment {
+  problem_set: ProblemSetWithQuestions;
 }
 
 export interface Subject {


### PR DESCRIPTION
## Summary

Authoring Integrity Phase 2 increment. Teachers viewing an assignment now see a collapsible **\"What students see · snapshot\"** section that renders the frozen `Assignment.assigned_content` through the same `QuestionCard` students use (locked, no input). When the live `ProblemSet` has moved past the snapshot, an **amber drift banner** explains the situation and deep-links to the editable live-set preview for comparison.

## Backend

- `apps.core.snapshots.snapshot_has_drifted(snapshot, problem_set)` — true iff the snapshot's `questions` block differs from a fresh one built from the live set. Ignores volatile fields (`captured_at`, `problem_set_title`) so renaming or re-snapshotting doesn't false-positive.
- `snapshot_drift: bool` on `AssignmentDetailSerializer`. The same payload's `problem_set.questions` is already the snapshot view (AIV-2b), so nothing else changes shape.

## Frontend

- `Assignment.snapshot_drift?` on the type; new `AssignmentDetail` interface
- `AssignmentSnapshotPreview` — collapsible section with the optional drift banner; deep-links to `/teacher/problem-sets/:id/preview`
- `TeacherAssignmentDetailPage` renders it between the stats card and the submissions table

## Test plan

- [x] pytest 16 passed — drift detection (no-drift after assign, drift on subpart edit / question add / question remove / no-snapshot defensive) + serializer (drift field surfaces, snapshot still served unchanged)
- [x] Vitest 4 new + 65 total in `src/features/teacher/` passing
- [x] `type-check`, `lint --max-warnings 0`, `build` clean

## Stack

Depends on AIV-1/2 ([#270](https://github.com/openshiksha/openshiksha/pull/270), [#271](https://github.com/openshiksha/openshiksha/pull/271), [#272](https://github.com/openshiksha/openshiksha/pull/272)). Independent of TW-2 / AIV-4 ([#276](https://github.com/openshiksha/openshiksha/pull/276)) — merge order doesn't matter.

## Next

- **Phase 3** — AIV-6 (guarded re-sync of an assignment to the latest content with a preview of the blast radius) → AIV-7 (`ProblemSetVersion` model) → AIV-8 (version history + audit UI).