### PR TITLE
feat(teacher): AIV-8 — version history + diff UI

### DIFF
--- a/backend/openshiksha/apps/api/serializers/core.py
+++ b/backend/openshiksha/apps/api/serializers/core.py
@@ -622,6 +622,32 @@ class ProblemSetStudentDetailSerializer(ProblemSetSerializer):
         fields = ProblemSetSerializer.Meta.fields + ["questions"]
 
 
+class ProblemSetVersionSummarySerializer(serializers.Serializer):
+    """
+    AIV-8: lightweight row for the version-history list. ``assignment_count``
+    is annotated by the viewset's queryset to keep the list endpoint N+1-free.
+    """
+
+    id = serializers.IntegerField()
+    version_number = serializers.IntegerField()
+    content_hash = serializers.CharField()
+    created_at = serializers.DateTimeField()
+    created_by_name = serializers.SerializerMethodField()
+    question_count = serializers.SerializerMethodField()
+    assignment_count = serializers.IntegerField()
+
+    def get_created_by_name(self, obj) -> str | None:
+        if obj.created_by_id is None:
+            return None
+        # ``created_by`` is the User row; fall back to username when no name set.
+        user = obj.created_by
+        full = (user.get_full_name() or "").strip()
+        return full or user.username
+
+    def get_question_count(self, obj) -> int:
+        return len((obj.content or {}).get("questions") or [])
+
+
 class AssignmentSerializer(serializers.ModelSerializer):
     problem_set = ProblemSetSerializer(read_only=True)
     problem_set_id = serializers.PrimaryKeyRelatedField(

--- a/backend/openshiksha/apps/api/tests/test_problem_set_versions_api.py
+++ b/backend/openshiksha/apps/api/tests/test_problem_set_versions_api.py
@@ -1,0 +1,204 @@
+"""
+AIV-8: list-versions + version-diff endpoints on ``ProblemSetViewSet``.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from openshiksha.apps.core.models import (
+    Assignment,
+    Board,
+    Chapter,
+    ClassRoom,
+    ProblemSet,
+    Question,
+    QuestionSubpart,
+    School,
+    Standard,
+    Subject,
+    SubjectRoom,
+    User,
+    UserRole,
+)
+from openshiksha.apps.core.snapshots import build_assignment_snapshot, get_or_create_version_for
+
+
+@pytest.fixture
+def board(db):
+    return Board.objects.create(name="CBSE")
+
+
+@pytest.fixture
+def school(db, board):
+    return School.objects.create(name="S", board=board)
+
+
+@pytest.fixture
+def standard(db):
+    return Standard.objects.create(number=9)
+
+
+@pytest.fixture
+def subject(db):
+    return Subject.objects.create(name="Math")
+
+
+@pytest.fixture
+def chapter(db, subject, standard):
+    return Chapter.objects.create(name="Algebra", subject=subject, standard=standard, order=1)
+
+
+@pytest.fixture
+def classroom(db, school, standard):
+    return ClassRoom.objects.create(school=school, standard=standard, division="A", academic_year="2025-26")
+
+
+@pytest.fixture
+def teacher(db, school):
+    return User.objects.create_user(
+        username="t", password="pw", role=UserRole.TEACHER, school=school, first_name="Tara"
+    )
+
+
+@pytest.fixture
+def subject_room(db, classroom, subject, teacher):
+    return SubjectRoom.objects.create(classroom=classroom, subject=subject, teacher=teacher)
+
+
+@pytest.fixture
+def problem_set(db, school, standard, subject, chapter, teacher):
+    ps = ProblemSet.objects.create(
+        school=school,
+        standard=standard,
+        subject=subject,
+        chapter=chapter,
+        title="Set",
+        number=1,
+        created_by=teacher,
+    )
+    q = Question.objects.create(school=school, standard=standard, subject=subject, chapter=chapter, created_by=teacher)
+    QuestionSubpart.objects.create(
+        question=q,
+        index=0,
+        subpart_type="fill_blank",
+        question_text="6*7?",
+        correct_answer={"type": "fill_blank", "answer": "42"},
+    )
+    ps.questions.add(q)
+    return ps
+
+
+@pytest.fixture
+def two_versions(db, problem_set, teacher):
+    """Mint v1, edit the live set, then mint v2 → two distinct version rows."""
+    v1, _ = get_or_create_version_for(problem_set, created_by=teacher)
+    sp = problem_set.questions.first().subparts.first()
+    sp.correct_answer = {"type": "fill_blank", "answer": "999"}
+    sp.save(update_fields=["correct_answer"])
+    v2, _ = get_or_create_version_for(problem_set, created_by=teacher)
+    return v1, v2
+
+
+@pytest.fixture
+def teacher_api(teacher):
+    c = APIClient()
+    c.force_authenticate(user=teacher)
+    return c
+
+
+class TestListVersions:
+    def test_returns_versions_newest_first(self, teacher_api, problem_set, two_versions):
+        v1, v2 = two_versions
+        resp = teacher_api.get(f"/api/v1/problem-sets/{problem_set.pk}/versions/")
+        assert resp.status_code == 200
+        ids = [row["id"] for row in resp.data["versions"]]
+        assert ids == [v2.pk, v1.pk]
+
+    def test_each_row_has_summary_fields(self, teacher_api, problem_set, two_versions):
+        resp = teacher_api.get(f"/api/v1/problem-sets/{problem_set.pk}/versions/")
+        first = resp.data["versions"][0]
+        for key in (
+            "id",
+            "version_number",
+            "content_hash",
+            "created_at",
+            "created_by_name",
+            "question_count",
+            "assignment_count",
+        ):
+            assert key in first
+        assert first["created_by_name"] == "Tara"
+
+    def test_assignment_count_reflects_pinned_assignments(
+        self, teacher_api, problem_set, two_versions, subject_room, teacher
+    ):
+        v1, _v2 = two_versions
+        Assignment.objects.create(
+            problem_set=problem_set,
+            subject_room=subject_room,
+            assigned_by=teacher,
+            due_at=timezone.now() + timedelta(days=3),
+            problem_set_version=v1,
+            assigned_content=build_assignment_snapshot(problem_set),
+        )
+        resp = teacher_api.get(f"/api/v1/problem-sets/{problem_set.pk}/versions/")
+        by_id = {row["id"]: row for row in resp.data["versions"]}
+        assert by_id[v1.pk]["assignment_count"] == 1
+        # v2 has no pinned assignment.
+        v2 = next(row for row in resp.data["versions"] if row["version_number"] == 2)
+        assert v2["assignment_count"] == 0
+
+
+class TestVersionDiff:
+    def test_default_against_is_previous_version(self, teacher_api, problem_set, two_versions):
+        v1, v2 = two_versions
+        resp = teacher_api.get(f"/api/v1/problem-sets/{problem_set.pk}/versions/{v2.pk}/diff/")
+        assert resp.status_code == 200
+        assert resp.data["target"]["id"] == v2.pk
+        assert resp.data["against"]["id"] == v1.pk
+        # The change between v1 and v2 was a correct_answer edit ⇒ answer_changes.
+        assert len(resp.data["diff"]["answer_changes"]) == 1
+
+    def test_explicit_against_param(self, teacher_api, problem_set, two_versions):
+        v1, v2 = two_versions
+        resp = teacher_api.get(f"/api/v1/problem-sets/{problem_set.pk}/versions/{v1.pk}/diff/?against={v2.pk}")
+        # v1 against v2 — the "before"/"after" roles flip relative to the default call.
+        assert resp.data["diff"]["answer_changes"][0]["before"] == {
+            "type": "fill_blank",
+            "answer": "999",
+        }
+        assert resp.data["diff"]["answer_changes"][0]["after"] == {
+            "type": "fill_blank",
+            "answer": "42",
+        }
+
+    def test_first_version_against_none_returns_no_diff(self, teacher_api, problem_set, two_versions):
+        v1, _v2 = two_versions
+        # v1 has no earlier version ⇒ against = None ⇒ diff still includes the
+        # whole set as additions (every question is "new" relative to empty).
+        resp = teacher_api.get(f"/api/v1/problem-sets/{problem_set.pk}/versions/{v1.pk}/diff/")
+        assert resp.data["against"] is None
+        # diff_snapshots returns the diff against an empty old ⇒ questions_added
+        assert len(resp.data["diff"]["questions_added"]) >= 1
+
+    def test_404_when_target_belongs_to_other_problem_set(
+        self, teacher_api, problem_set, two_versions, school, standard, subject, chapter, teacher
+    ):
+        v1, _v2 = two_versions
+        other = ProblemSet.objects.create(
+            school=school,
+            standard=standard,
+            subject=subject,
+            chapter=chapter,
+            title="Other",
+            number=99,
+            created_by=teacher,
+        )
+        resp = teacher_api.get(f"/api/v1/problem-sets/{other.pk}/versions/{v1.pk}/diff/")
+        assert resp.status_code == 404

--- a/backend/openshiksha/apps/api/views/core.py
+++ b/backend/openshiksha/apps/api/views/core.py
@@ -750,6 +750,72 @@ class ProblemSetViewSet(viewsets.ModelViewSet):
         problem_set.questions.add(question)
         return Response({"detail": "Question added.", "question_id": question.id, "problem_set_id": problem_set.id})
 
+    @action(detail=True, methods=["get"], url_path="versions")
+    def versions(self, request, pk=None):
+        """
+        GET /api/v1/problem-sets/<id>/versions/
+
+        AIV-8: list immutable ``ProblemSetVersion`` rows for this set, newest
+        first, with the number of assignments pinned to each version. Read-only.
+        """
+        from django.db.models import Count
+
+        from openshiksha.apps.api.serializers.core import ProblemSetVersionSummarySerializer
+        from openshiksha.apps.core.models import ProblemSetVersion
+
+        problem_set = get_object_or_404(self.get_queryset(), pk=pk)
+        rows = (
+            ProblemSetVersion.objects.filter(problem_set=problem_set)
+            .select_related("created_by")
+            .annotate(assignment_count=Count("assignments"))
+            .order_by("-version_number")
+        )
+        return Response(
+            {
+                "problem_set_id": problem_set.pk,
+                "versions": ProblemSetVersionSummarySerializer(rows, many=True).data,
+            }
+        )
+
+    @action(detail=True, methods=["get"], url_path=r"versions/(?P<version_pk>[0-9]+)/diff")
+    def version_diff(self, request, pk=None, version_pk=None):
+        """
+        GET /api/v1/problem-sets/<id>/versions/<version_pk>/diff/?against=<other_version_pk>
+
+        AIV-8: structured diff between two versions of this problem set.
+        ``against`` defaults to the previous version (by version_number) when
+        omitted so the common "what changed from the prior version" path is
+        one fewer round-trip. Read-only.
+        """
+        from openshiksha.apps.core.models import ProblemSetVersion
+        from openshiksha.apps.core.snapshots import diff_snapshots
+
+        problem_set = get_object_or_404(self.get_queryset(), pk=pk)
+        target = get_object_or_404(ProblemSetVersion, pk=version_pk, problem_set=problem_set)
+
+        against_pk = request.query_params.get("against")
+        if against_pk:
+            against = get_object_or_404(ProblemSetVersion, pk=against_pk, problem_set=problem_set)
+        else:
+            against = (
+                ProblemSetVersion.objects.filter(problem_set=problem_set, version_number__lt=target.version_number)
+                .order_by("-version_number")
+                .first()
+            )
+
+        return Response(
+            {
+                "target": {"id": target.pk, "version_number": target.version_number},
+                "against": (
+                    {"id": against.pk, "version_number": against.version_number} if against is not None else None
+                ),
+                "diff": diff_snapshots(
+                    against.content if against is not None else None,
+                    target.content,
+                ),
+            }
+        )
+
     @action(detail=True, methods=["post"], url_path="remove-question")
     def remove_question(self, request, pk=None):
         """

--- a/docs/changes/2026-06-09-aiv8-version-history.md
+++ b/docs/changes/2026-06-09-aiv8-version-history.md
@@ -1,0 +1,50 @@
+# AIV-8 — Version history + diff UI
+
+**Date:** 2026-06-09
+**Initiative:** Authoring Integrity & Versioning — Phase 3
+**Classification:** New
+**Depends on:** AIV-7 (`ProblemSetVersion` model)
+
+## Summary
+
+Teachers can now browse the immutable version history for a problem set and diff any two versions. Builds directly on AIV-7's `ProblemSetVersion` table — the list is just that table sorted newest-first with an `assignment_count` annotation; the diff reuses AIV-6's `diff_snapshots` server-side helper so both surfaces share one source of truth.
+
+## Backend
+
+- `GET /api/v1/problem-sets/<id>/versions/` — returns `{problem_set_id, versions: [{id, version_number, content_hash, created_at, created_by_name, question_count, assignment_count}]}`. Annotated with `Count` over the reverse `assignments` relation so it's N+1-free.
+- `GET /api/v1/problem-sets/<id>/versions/<version_pk>/diff/?against=<other_version_pk>` — structured diff between two versions of the same set. `against` defaults to the immediately-prior version (by `version_number`) when omitted.
+- `ProblemSetVersionSummarySerializer` — lightweight row shape used by the list endpoint.
+
+## Frontend
+
+- `useProblemSetVersions` + `useVersionDiff` hooks
+- `ProblemSetVersionsPage` — version timeline (newest-first), click-to-select target → click another row to select against → diff panel renders the structured diff summary
+- `/teacher/problem-sets/:id/versions` route + a **View version history** button on `ProblemSetPreviewPage`
+
+## Files
+
+- `backend/openshiksha/apps/api/serializers/core.py` — `ProblemSetVersionSummarySerializer`
+- `backend/openshiksha/apps/api/views/core.py` — `versions` + `version_diff` actions on `ProblemSetViewSet`
+- `backend/openshiksha/apps/api/tests/test_problem_set_versions_api.py` (new) — 7 tests
+- `frontend_modern/src/features/teacher/useProblemSetVersions.ts` (new)
+- `frontend_modern/src/features/teacher/ProblemSetVersionsPage.tsx` (new)
+- `frontend_modern/src/features/teacher/ProblemSetVersionsPage.test.tsx` (new) — 4 tests
+- `frontend_modern/src/features/teacher/ProblemSetPreviewPage.tsx` — link to versions page
+- `frontend_modern/src/App.tsx` — route + lazy import
+
+## Verify
+
+- pytest: 7 passed (list ordering, summary shape, assignment-count annotation, default `against`, explicit `against`, no-prior-version, cross-set 404)
+- Vitest: 4 passed (newest-first list, two-click target+against selection, identical-content empty state, no-versions empty state)
+- `type-check`, `lint --max-warnings 0`, `build` clean
+
+## Closes Phase 3
+
+This is the last increment of Authoring Integrity & Versioning. Together with Phase 1 (snapshot foundation) and Phase 2 (editable preview + drift surface), Phase 3 (re-sync + versions + history) delivers the initiative's full Definition of Done:
+
+- Editing never silently rewrites assigned content (AIV-1/2)
+- Editing is safe by construction and surfaced as such in the UI (AIV-3, AIV-4)
+- Teachers can see what was assigned vs what the live set looks like now (AIV-5)
+- Re-sync is opt-in, previewed, reversible (AIV-6)
+- Assignments pin an immutable, deduplicated content version (AIV-7)
+- Version history is auditable and diffable (AIV-8)

--- a/frontend_modern/src/App.tsx
+++ b/frontend_modern/src/App.tsx
@@ -40,6 +40,7 @@ const CreateAssignmentPage = lazyNamed(() => import('./features/teacher/CreateAs
 const CreateQuestionPage = lazyNamed(() => import('./features/teacher/CreateQuestionPage'), 'CreateQuestionPage');
 const CreateProblemSetPage = lazyNamed(() => import('./features/teacher/CreateProblemSetPage'), 'CreateProblemSetPage');
 const ProblemSetPreviewPage = lazyNamed(() => import('./features/teacher/ProblemSetPreviewPage'), 'ProblemSetPreviewPage');
+const ProblemSetVersionsPage = lazyNamed(() => import('./features/teacher/ProblemSetVersionsPage'), 'ProblemSetVersionsPage');
 const TeacherAssignmentDetailPage = lazyNamed(() => import('./features/teacher/TeacherAssignmentDetailPage'), 'TeacherAssignmentDetailPage');
 const QuestionBankPage = lazyNamed(() => import('./features/teacher/QuestionBankPage'), 'QuestionBankPage');
 const ParentDashboard = lazyNamed(() => import('./features/parent/ParentDashboard'), 'ParentDashboard');
@@ -226,6 +227,17 @@ function App() {
             <ProtectedRoute>
               <AppShell>
                 <ProblemSetPreviewPage />
+              </AppShell>
+            </ProtectedRoute>
+          }
+        />
+
+        <Route
+          path="/teacher/problem-sets/:id/versions"
+          element={
+            <ProtectedRoute>
+              <AppShell>
+                <ProblemSetVersionsPage />
               </AppShell>
             </ProtectedRoute>
           }

--- a/frontend_modern/src/features/teacher/ProblemSetPreviewPage.tsx
+++ b/frontend_modern/src/features/teacher/ProblemSetPreviewPage.tsx
@@ -213,7 +213,14 @@ export const ProblemSetPreviewPage = () => {
         </div>
       )}
 
-      <div className="flex justify-end border-t border-ink-100 pt-5">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-t border-ink-100 pt-5">
+        <Button
+          variant="ghost"
+          onClick={() => setId != null && navigate(`/teacher/problem-sets/${setId}/versions`)}
+          data-testid="view-versions"
+        >
+          View version history
+        </Button>
         <Button variant="ghost" onClick={() => navigate('/teacher')}>
           Back to dashboard
         </Button>

--- a/frontend_modern/src/features/teacher/ProblemSetVersionsPage.test.tsx
+++ b/frontend_modern/src/features/teacher/ProblemSetVersionsPage.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ProblemSetVersionsPage } from './ProblemSetVersionsPage';
+import type {
+  VersionDiffResponse,
+  VersionSummary,
+} from './useProblemSetVersions';
+
+const mockVersions = vi.fn();
+const mockDiff = vi.fn();
+
+vi.mock('./useProblemSetVersions', () => ({
+  useProblemSetVersions: (id: number | null) => mockVersions(id),
+  useVersionDiff: (
+    setId: number | null,
+    targetId: number | null,
+    againstId: number | null,
+  ) => mockDiff(setId, targetId, againstId),
+}));
+
+const renderPage = () => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/teacher/problem-sets/9/versions']}>
+        <Routes>
+          <Route
+            path="/teacher/problem-sets/:id/versions"
+            element={<ProblemSetVersionsPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
+
+const versions: VersionSummary[] = [
+  {
+    id: 2,
+    version_number: 2,
+    content_hash: 'abc',
+    created_at: '2026-06-08T10:00:00Z',
+    created_by_name: 'Tara',
+    question_count: 3,
+    assignment_count: 1,
+  },
+  {
+    id: 1,
+    version_number: 1,
+    content_hash: 'xyz',
+    created_at: '2026-06-07T10:00:00Z',
+    created_by_name: 'Tara',
+    question_count: 2,
+    assignment_count: 4,
+  },
+];
+
+const emptyDiffResponse: VersionDiffResponse = {
+  target: { id: 2, version_number: 2 },
+  against: { id: 1, version_number: 1 },
+  diff: { questions_added: [], questions_removed: [], answer_changes: [], content_changes: [] },
+};
+
+describe('<ProblemSetVersionsPage />', () => {
+  beforeEach(() => {
+    mockVersions.mockReset();
+    mockDiff.mockReset();
+    mockDiff.mockReturnValue({ data: undefined, isLoading: false, isError: false });
+  });
+
+  it('lists every version row newest-first with summary info', () => {
+    mockVersions.mockReturnValue({
+      data: { problem_set_id: 9, versions },
+      isLoading: false,
+      isError: false,
+    });
+    renderPage();
+    const rows = screen.getAllByTestId(/^version-row-/);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveAttribute('data-testid', 'version-row-2');
+    expect(rows[1]).toHaveAttribute('data-testid', 'version-row-1');
+    expect(rows[0]).toHaveTextContent('v2');
+    expect(rows[1]).toHaveTextContent('4 pinned assignments');
+  });
+
+  it('selects a target on first click and an against on second click', () => {
+    mockVersions.mockReturnValue({
+      data: { problem_set_id: 9, versions },
+      isLoading: false,
+      isError: false,
+    });
+    mockDiff.mockReturnValue({
+      data: { ...emptyDiffResponse, diff: { ...emptyDiffResponse.diff, answer_changes: [{ subpart_id: 1, question_id: 1, before: {}, after: {} }] } },
+      isLoading: false,
+      isError: false,
+    });
+    renderPage();
+
+    fireEvent.click(screen.getByTestId('version-row-2'));
+    expect(screen.getByTestId('version-row-2')).toHaveAttribute('data-state', 'target');
+    expect(screen.getByTestId('diff-helper-text')).toHaveTextContent(/another version/i);
+
+    fireEvent.click(screen.getByTestId('version-row-1'));
+    expect(screen.getByTestId('version-row-1')).toHaveAttribute('data-state', 'against');
+
+    expect(screen.getByTestId('diff-panel')).toBeInTheDocument();
+    expect(screen.getByTestId('diff-lines')).toHaveTextContent(/1 answer\(s\) changed/);
+  });
+
+  it('shows "Identical content" when the diff is empty', () => {
+    mockVersions.mockReturnValue({
+      data: { problem_set_id: 9, versions },
+      isLoading: false,
+      isError: false,
+    });
+    mockDiff.mockReturnValue({ data: emptyDiffResponse, isLoading: false, isError: false });
+    renderPage();
+    fireEvent.click(screen.getByTestId('version-row-2'));
+    fireEvent.click(screen.getByTestId('version-row-1'));
+    expect(screen.getByTestId('diff-no-changes')).toBeInTheDocument();
+  });
+
+  it('renders an empty state when the set has no versions', () => {
+    mockVersions.mockReturnValue({
+      data: { problem_set_id: 9, versions: [] },
+      isLoading: false,
+      isError: false,
+    });
+    renderPage();
+    expect(screen.queryByTestId('version-list')).not.toBeInTheDocument();
+    expect(screen.getByText(/No versions yet/i)).toBeInTheDocument();
+  });
+});

--- a/frontend_modern/src/features/teacher/ProblemSetVersionsPage.tsx
+++ b/frontend_modern/src/features/teacher/ProblemSetVersionsPage.tsx
@@ -1,0 +1,243 @@
+import { useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Button, EmptyState, LoadingSpinner } from '@/shared/ui';
+import {
+  useProblemSetVersions,
+  useVersionDiff,
+  type VersionSummary,
+} from './useProblemSetVersions';
+
+/**
+ * AIV-8: version history + diff view for a problem set.
+ *
+ * Lists every immutable `ProblemSetVersion` mint, newest first, with the
+ * number of assignments pinned to each. Click a row to make it the **target**
+ * of a diff; click a second row to make it the **against** side. The diff
+ * panel renders the structured output of ``diff_snapshots`` server-side, so
+ * the UI just summarises counts.
+ */
+export const ProblemSetVersionsPage = () => {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const setId = id ? Number(id) : null;
+  const versions = useProblemSetVersions(setId);
+  const [targetId, setTargetId] = useState<number | null>(null);
+  const [againstId, setAgainstId] = useState<number | null>(null);
+  const diff = useVersionDiff(setId, targetId, againstId);
+
+  const rows = versions.data?.versions ?? [];
+
+  const handleRowClick = (v: VersionSummary) => {
+    if (targetId == null || targetId === v.id) {
+      setTargetId(v.id);
+      setAgainstId(null);
+      return;
+    }
+    setAgainstId(v.id);
+  };
+
+  const stateForRow = (vId: number): 'target' | 'against' | 'idle' => {
+    if (vId === targetId) return 'target';
+    if (vId === againstId) return 'against';
+    return 'idle';
+  };
+
+  const helperText = useMemo(() => {
+    if (rows.length === 0) return null;
+    if (targetId == null) return 'Click a version to start a diff.';
+    if (againstId == null) return 'Click another version to compare against.';
+    return null;
+  }, [rows.length, targetId, againstId]);
+
+  if (versions.isLoading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <LoadingSpinner size="lg" />
+      </div>
+    );
+  }
+
+  if (versions.isError || !versions.data) {
+    return (
+      <div className="mx-auto max-w-2xl px-4 py-10">
+        <EmptyState
+          title="Couldn't load version history"
+          description="The set may have been removed, or you may not have access."
+          action={<Button onClick={() => navigate('/teacher')}>Back to dashboard</Button>}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 px-4 py-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="font-display text-2xl font-semibold text-ink-900">Version history</h1>
+          <p className="mt-1 text-sm text-ink-500">
+            Every published content version for this problem set. Newer assignments pin newer
+            versions; existing assignments stay on the version they were given.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => navigate(setId != null ? `/teacher/problem-sets/${setId}/preview` : '/teacher')}
+          className="text-sm font-medium text-brand-700 hover:text-brand-900"
+        >
+          ← Back to preview
+        </button>
+      </div>
+
+      {rows.length === 0 ? (
+        <EmptyState
+          title="No versions yet"
+          description="A version is minted the first time this set is assigned or re-synced."
+        />
+      ) : (
+        <ul data-testid="version-list" className="overflow-hidden rounded-xl border border-ink-100 bg-paper">
+          {rows.map((v) => {
+            const state = stateForRow(v.id);
+            return (
+              <li
+                key={v.id}
+                data-testid={`version-row-${v.id}`}
+                data-state={state}
+                className={`flex cursor-pointer items-center justify-between gap-3 border-b border-ink-100 px-4 py-3 last:border-b-0 transition-colors ${
+                  state === 'target'
+                    ? 'bg-brand-50'
+                    : state === 'against'
+                      ? 'bg-amber-50'
+                      : 'hover:bg-ink-50'
+                }`}
+                onClick={() => handleRowClick(v)}
+              >
+                <div>
+                  <p className="text-sm font-semibold text-ink-900">
+                    v{v.version_number}
+                    {state === 'target' && (
+                      <span className="ml-2 rounded bg-brand-200 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-brand-900">
+                        Target
+                      </span>
+                    )}
+                    {state === 'against' && (
+                      <span className="ml-2 rounded bg-amber-200 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-amber-900">
+                        Against
+                      </span>
+                    )}
+                  </p>
+                  <p className="mt-0.5 text-xs text-ink-500">
+                    {new Date(v.created_at).toLocaleString('en-IN', {
+                      day: 'numeric',
+                      month: 'short',
+                      year: 'numeric',
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}
+                    {v.created_by_name && <> · {v.created_by_name}</>}
+                  </p>
+                </div>
+                <div className="text-right text-xs text-ink-500">
+                  <p>{v.question_count} question{v.question_count === 1 ? '' : 's'}</p>
+                  <p
+                    className={`mt-0.5 ${v.assignment_count > 0 ? 'font-semibold text-ink-700' : ''}`}
+                  >
+                    {v.assignment_count} pinned assignment{v.assignment_count === 1 ? '' : 's'}
+                  </p>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {helperText && (
+        <p className="text-sm italic text-ink-500" data-testid="diff-helper-text">
+          {helperText}
+        </p>
+      )}
+
+      {targetId != null && (
+        <DiffPanel
+          state={
+            diff.isLoading
+              ? 'loading'
+              : diff.isError || !diff.data
+                ? 'error'
+                : 'ready'
+          }
+          data={diff.data}
+          onClear={() => {
+            setTargetId(null);
+            setAgainstId(null);
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+interface DiffPanelProps {
+  state: 'loading' | 'error' | 'ready';
+  data: ReturnType<typeof useVersionDiff>['data'];
+  onClear: () => void;
+}
+
+function DiffPanel({ state, data, onClear }: DiffPanelProps) {
+  return (
+    <section
+      data-testid="diff-panel"
+      className="overflow-hidden rounded-xl border border-ink-100 bg-paper"
+    >
+      <header className="flex items-center justify-between border-b border-ink-100 px-4 py-3">
+        <h2 className="font-display text-base font-semibold text-ink-900">Diff</h2>
+        <button
+          type="button"
+          onClick={onClear}
+          className="text-xs text-ink-500 hover:text-ink-800"
+        >
+          Clear selection
+        </button>
+      </header>
+
+      <div className="px-4 py-4">
+        {state === 'loading' && <LoadingSpinner size="md" />}
+        {state === 'error' && (
+          <p className="text-sm text-red-700">Couldn't load the diff. Try again.</p>
+        )}
+        {state === 'ready' && data && (
+          <DiffSummary data={data} />
+        )}
+      </div>
+    </section>
+  );
+}
+
+function DiffSummary({ data }: { data: NonNullable<ReturnType<typeof useVersionDiff>['data']> }) {
+  const { target, against, diff } = data;
+  const lines: string[] = [];
+  if (diff.questions_added.length) lines.push(`${diff.questions_added.length} question(s) added`);
+  if (diff.questions_removed.length) lines.push(`${diff.questions_removed.length} question(s) removed`);
+  if (diff.answer_changes.length) lines.push(`${diff.answer_changes.length} answer(s) changed`);
+  if (diff.content_changes.length)
+    lines.push(`${diff.content_changes.length} cosmetic content edit(s)`);
+
+  return (
+    <div className="space-y-3 text-sm text-ink-800">
+      <p>
+        Comparing <strong>v{target.version_number}</strong> against{' '}
+        <strong>{against ? `v${against.version_number}` : 'nothing (initial version)'}</strong>.
+      </p>
+      {lines.length === 0 ? (
+        <p data-testid="diff-no-changes" className="italic text-ink-500">
+          Identical content.
+        </p>
+      ) : (
+        <ul data-testid="diff-lines" className="list-disc pl-5">
+          {lines.map((line) => (
+            <li key={line}>{line}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend_modern/src/features/teacher/useProblemSetVersions.ts
+++ b/frontend_modern/src/features/teacher/useProblemSetVersions.ts
@@ -1,0 +1,64 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+import type { ResyncDiff } from './useAssignmentResync';
+
+export interface VersionSummary {
+  id: number;
+  version_number: number;
+  content_hash: string;
+  created_at: string;
+  created_by_name: string | null;
+  question_count: number;
+  assignment_count: number;
+}
+
+interface VersionsResponse {
+  problem_set_id: number;
+  versions: VersionSummary[];
+}
+
+export interface VersionDiffResponse {
+  target: { id: number; version_number: number };
+  against: { id: number; version_number: number } | null;
+  diff: ResyncDiff;
+}
+
+const fetchVersions = async (problemSetId: number): Promise<VersionsResponse> => {
+  const res = await apiClient.get<VersionsResponse>(`/problem-sets/${problemSetId}/versions/`);
+  return res.data;
+};
+
+export const useProblemSetVersions = (problemSetId: number | null) => {
+  return useQuery<VersionsResponse>({
+    queryKey: ['problem-set-versions', problemSetId],
+    queryFn: () => fetchVersions(problemSetId as number),
+    enabled: problemSetId != null,
+    staleTime: 30 * 1000,
+  });
+};
+
+const fetchVersionDiff = async (
+  problemSetId: number,
+  targetId: number,
+  againstId: number | null,
+): Promise<VersionDiffResponse> => {
+  const url =
+    againstId != null
+      ? `/problem-sets/${problemSetId}/versions/${targetId}/diff/?against=${againstId}`
+      : `/problem-sets/${problemSetId}/versions/${targetId}/diff/`;
+  const res = await apiClient.get<VersionDiffResponse>(url);
+  return res.data;
+};
+
+export const useVersionDiff = (
+  problemSetId: number | null,
+  targetId: number | null,
+  againstId: number | null,
+) => {
+  return useQuery<VersionDiffResponse>({
+    queryKey: ['problem-set-version-diff', problemSetId, targetId, againstId],
+    queryFn: () => fetchVersionDiff(problemSetId as number, targetId as number, againstId),
+    enabled: problemSetId != null && targetId != null,
+    staleTime: 60 * 1000,
+  });
+};


### PR DESCRIPTION
## Summary

Phase 3 / **AIV-8** — the final increment of Authoring Integrity & Versioning. Teachers can browse the immutable version history for a problem set and diff any two versions. Builds directly on AIV-7's `ProblemSetVersion` table.

## Backend

- `GET /api/v1/problem-sets/<id>/versions/` — list of versions newest-first, annotated with `assignment_count` (`Count` over the reverse FK; N+1-free)
- `GET /api/v1/problem-sets/<id>/versions/<version_pk>/diff/?against=<other_version_pk>` — structured diff between two versions; `against` defaults to the immediately-prior version
- `ProblemSetVersionSummarySerializer` — lightweight row shape

## Frontend

- `useProblemSetVersions` + `useVersionDiff` hooks
- `ProblemSetVersionsPage` — version timeline (newest-first), click-to-select **target** → click another row to select **against** → diff panel
- `/teacher/problem-sets/:id/versions` route + a **View version history** button on `ProblemSetPreviewPage`

## Test plan

- [x] pytest 7 passed: list order, summary shape, `assignment_count` annotation, default `against`, explicit `against` (roles flip), no-prior-version, cross-set 404
- [x] Vitest 4 passed: newest-first list, two-click target+against selection, identical-content empty state, no-versions empty state
- [x] `type-check`, `lint --max-warnings 0`, `build` clean

## Stack

Depends on **#280 (AIV-7)**. Mergeable after #279 + #280.

## Closes Phase 3 and the whole initiative

With AIV-1..8 shipped, Authoring Integrity & Versioning reaches its **full Definition of Done**:

- Editing never silently rewrites assigned content (AIV-1/2)
- Editing is safe by construction and surfaced as such (AIV-3, AIV-4)
- Teachers see what was assigned vs what the live set looks like now (AIV-5)
- Re-sync is opt-in, previewed, reversible (AIV-6)
- Assignments pin an immutable, deduplicated content version (AIV-7)
- Version history is auditable and diffable (AIV-8)