### PR TITLE
docs(initiatives): close Authoring Integrity & Versioning (Phase 3 done)

### DIFF
--- a/docs/initiatives/STATUS.md
+++ b/docs/initiatives/STATUS.md
@@ -4,23 +4,21 @@
 > task advances the **top active initiative** here. See [`README.md`](README.md)
 > for how. Keep this file short - one row per initiative.
 
-**Last updated:** 2026-06-09 — **Teacher Workspace closed, Authoring Integrity
-Phase 2 done.** TW-2 (editable preview) shipped alongside the matching
-**AIV-4** in [#276](https://github.com/openshiksha/openshiksha/pull/276): the
-preview now has an edit mode (remove / edit / add questions) backed by a new
-`remove-question` endpoint, with an API-level regression test pinning the
-property that makes it safe — mutating the live set does not change any
-pre-existing assignment's snapshot. **AIV-5** in
-[#277](https://github.com/openshiksha/openshiksha/pull/277): teachers viewing an
-assignment now see a collapsible "What students see · snapshot" section + an
-amber drift banner when the live set has moved past the snapshot. Phase 2 closes
-the editable-preview ask the initiative was originally promoted to enable.
-Earlier (2026-06-08): **Phase 1 (AIV-1..3)** shipped across
-[#270](https://github.com/openshiksha/openshiksha/pull/270)–[#274](https://github.com/openshiksha/openshiksha/pull/274)
-— snapshot foundation, grader reads snapshot (golden re-grade-after-edit test),
-student-detail serves snapshot, edit-safety flags + banner; the
-silent-data-corruption hole closed. Next bet is **AIV Phase 3** (versioning +
-guarded re-sync).
+**Last updated:** 2026-06-09 — **Authoring Integrity & Versioning closed —
+North Star reached.** Phase 3 shipped across
+[#279](https://github.com/openshiksha/openshiksha/pull/279)–[#281](https://github.com/openshiksha/openshiksha/pull/281):
+**AIV-6** (guarded re-sync: blast-radius preview → atomic snapshot swap +
+selective re-grade → undo from history),
+**AIV-7** (`ProblemSetVersion` deduplicated immutable content versions;
+assignments pin a version FK; idempotent dedup backfill of every legacy
+snapshot), **AIV-8** (version history list + structured diff between any two
+versions, surfaced on a new versions page deep-linked from the preview).
+Combined with Phase 1 (AIV-1..3, [#270](https://github.com/openshiksha/openshiksha/pull/270)–[#274](https://github.com/openshiksha/openshiksha/pull/274))
+and Phase 2 (AIV-4/5, [#276](https://github.com/openshiksha/openshiksha/pull/276)–[#277](https://github.com/openshiksha/openshiksha/pull/277))
+the initiative's full DoD is met. Teacher Workspace closed 2026-06-09 with
+TW-2 (editable preview, also #276). **Every active initiative is now Done or
+Paused** — no unblocked next bet on the board until a new initiative is
+promoted.
 Earlier (2026-06-07): all unblocked TW increments shipped across **#250, #261–#266**
 (TW-1, TW-5, TW-4, TW-3a, TW-3b, TW-6, TW-7); the planned **TW-T** Playwright smoke
 was dropped (seams already covered by Vitest + pytest). Earlier batch:
@@ -32,8 +30,8 @@ at 160 kB defends the cut.
 
 | Priority | Initiative | Status | Headline progress | Next increment |
 |:--:|---|---|---|---|
-| 1 | [Authoring Integrity & Versioning](authoring-integrity-versioning.md) | Active | **Phase 1 + Phase 2 done.** Phase 1 (AIV-1..3) in [#270](https://github.com/openshiksha/openshiksha/pull/270)–[#274](https://github.com/openshiksha/openshiksha/pull/274): snapshot foundation, grader + student-detail read snapshot, edit-safety flags + banner. Phase 2: **AIV-4** in [#276](https://github.com/openshiksha/openshiksha/pull/276) (editable preview + `remove-question` endpoint + API-level safety test) and **AIV-5** in [#277](https://github.com/openshiksha/openshiksha/pull/277) (assignment-level snapshot preview + drift banner). | **Phase 3: AIV-6** (guarded re-sync — opt-in action that re-snapshots an assignment from the live set, with a blast-radius preview + optional re-grade) → **AIV-7** (`ProblemSetVersion`; assignments pin a version, dedup storage) → **AIV-8** (version history + audit UI). |
-| - | [Teacher Workspace](teacher-workspace.md) | Done | Closed 2026-06-09 with **TW-2** (editable preview) shipped in [#276](https://github.com/openshiksha/openshiksha/pull/276). The last open increment is in; the initiative's North Star (authoring → assigning → monitoring as one preview-driven flow) is reached. Earlier increments: TW-1, TW-3a/b, TW-4, TW-5, TW-6, TW-7 closed 2026-06-07 across [#250](https://github.com/openshiksha/openshiksha/pull/250), [#261](https://github.com/openshiksha/openshiksha/pull/261)–[#266](https://github.com/openshiksha/openshiksha/pull/266). | - |
+| - | [Authoring Integrity & Versioning](authoring-integrity-versioning.md) | Done | **All three phases shipped 2026-06-08/09.** Phase 1 (AIV-1..3, [#270](https://github.com/openshiksha/openshiksha/pull/270)–[#274](https://github.com/openshiksha/openshiksha/pull/274)): snapshot foundation + grader/student readers + edit-safety UI. Phase 2 (AIV-4/5, [#276](https://github.com/openshiksha/openshiksha/pull/276)–[#277](https://github.com/openshiksha/openshiksha/pull/277)): editable preview + drift surface. Phase 3 (AIV-6/7/8, [#279](https://github.com/openshiksha/openshiksha/pull/279)–[#281](https://github.com/openshiksha/openshiksha/pull/281)): guarded re-sync + `ProblemSetVersion` dedup + version history & diff UI. DoD met end-to-end. | - |
+| - | [Teacher Workspace](teacher-workspace.md) | Done | Closed 2026-06-09 with **TW-2** (editable preview) shipped in [#276](https://github.com/openshiksha/openshiksha/pull/276). Earlier increments: TW-1, TW-3a/b, TW-4, TW-5, TW-6, TW-7 closed 2026-06-07 across [#250](https://github.com/openshiksha/openshiksha/pull/250), [#261](https://github.com/openshiksha/openshiksha/pull/261)–[#266](https://github.com/openshiksha/openshiksha/pull/266). | - |
 | - | [Performance Budget](performance-budget.md) | Done | Closed 2026-06-07. PERF-01..04 + PERF-06 shipped in one batch ([#251](https://github.com/openshiksha/openshiksha/pull/251)–[#255](https://github.com/openshiksha/openshiksha/pull/255)); follow-up ([#256](https://github.com/openshiksha/openshiksha/pull/256)) dropped `ReactQueryDevtools` in prod, added a measurement harness, and fixed a `@/shared/ui` barrel-export leak that was dragging DOMPurify into the entry chunk. Entry chunk **855 → 93 kB / 247 → 29 kB gzip** (88% gzip drop); vendor split, route-level `React.lazy`, lazy KaTeX behind `<RichContent>`, CI budget guard at 160 kB. Measured `/login` FCP under Slow 4G + 4× CPU: 4.4 s. | - |
 | - | [Interactive Widgets Framework](interactive-widgets-framework.md) | Paused | Tier 1 **Configure** is usable (`WidgetGalleryPanel` + registry schemas). Tier 3 **Code** is usable (`defineWidget`, `npm run widget:new`, `npm run widget:dev -- <kind>`, `/widgets/dev`, docs). First-party library currently includes `_hello`, `thermo-piston`, `number-line`, `function-plotter`, `fraction-bar`, plus admin-only `custom-html`; all render through the same sandboxed iframe and answer-producing widgets report through the shared protocol. | Defer **IW-9 - IW-11** until product discovery proves Widget Studio is more valuable than more first-party/developer-authored widgets. |
 | - | [V2 "Chalk & Unlock" design overhaul](2026-design-system-v2.md) | Done | M1-M7 are closed for the current scope. Mobile shell now has role-aware bottom tabs, account drawer, safe-area/dynamic-viewport padding, large touch targets, responsive surface audit, and focused a11y baseline. Legacy parity gaps are closed or explicitly skipped. Only optional activation remains: run the [seed-visual-baselines](../../.github/workflows/seed-visual-baselines.yaml) workflow once for M6-03 baselines. | - |

--- a/docs/initiatives/authoring-integrity-versioning.md
+++ b/docs/initiatives/authoring-integrity-versioning.md
@@ -7,14 +7,13 @@
 > the assigned, frozen copy are clearly separate, and moving changes from one to
 > the other is an explicit, reviewable act.
 >
-> **Status:** 🟢 **Active** — Phase 1 + Phase 2 done.
-> Phase 1 (AIV-1..3) 2026-06-08 across [#270](https://github.com/openshiksha/openshiksha/pull/270)–[#274](https://github.com/openshiksha/openshiksha/pull/274);
-> Phase 2 2026-06-09 with **AIV-4** in [#276](https://github.com/openshiksha/openshiksha/pull/276)
-> (editable preview + `remove-question` API + safety regression test) and
-> **AIV-5** in [#277](https://github.com/openshiksha/openshiksha/pull/277)
-> (assignment-level snapshot preview + drift banner). Editing is safe by
-> construction and the editable-preview ask is delivered end-to-end.
-> Next bet is **Phase 3** (AIV-6/7/8 — guarded re-sync, `ProblemSetVersion`, audit UI).
+> **Status:** ✅ **Done.** All three phases shipped 2026-06-08/09.
+> Phase 1 (AIV-1..3) in [#270](https://github.com/openshiksha/openshiksha/pull/270)–[#274](https://github.com/openshiksha/openshiksha/pull/274);
+> Phase 2 (AIV-4/5) in [#276](https://github.com/openshiksha/openshiksha/pull/276)–[#277](https://github.com/openshiksha/openshiksha/pull/277);
+> Phase 3 (AIV-6/7/8) in [#279](https://github.com/openshiksha/openshiksha/pull/279)–[#281](https://github.com/openshiksha/openshiksha/pull/281).
+> Editing never silently rewrites assigned content; teachers can preview, edit,
+> re-sync (with blast-radius preview + undo), and audit version history. The
+> initiative's full DoD is reached.
 
 **Last updated:** 2026-06-09
 
@@ -239,3 +238,7 @@ real silent-data-corruption risk even if editable preview never ships.
 | 2026-06-09 | **AIV-4 done** — `ProblemSetPreviewPage` gains an edit mode (per-question Remove + Edit-question deep-link + Add-question entry to the bank, AIV-3b banner when in use). Backend adds `remove-question` to mirror `add-question`, plus an API-level regression test pinning the property that makes TW-2 safe by construction: mutating the live question list does NOT change any pre-existing assignment's snapshot. Reorder is deferred (would need a through-table; doesn't belong in this atomic slice). Also shipped Teacher Workspace **TW-2** — the editable preview the user asked for, end-to-end. | [#276](https://github.com/openshiksha/openshiksha/pull/276) | One PR closes two initiative increments. `created_by_me` flag added so the frontend doesn't re-derive the creator-only rule. |
 | 2026-06-09 | **AIV-5 done** — `snapshot_has_drifted(snapshot, problem_set)` helper + `snapshot_drift` field on `AssignmentDetailSerializer`. Teacher `TeacherAssignmentDetailPage` gains a collapsible "What students see · snapshot" section rendering the frozen content + an amber drift banner deep-linking to the live preview when the set has moved past the snapshot. | [#277](https://github.com/openshiksha/openshiksha/pull/277) | Independent of AIV-4 (could land first). Drift detection ignores volatile fields (`captured_at`, `problem_set_title`). |
 | 2026-06-09 | **Phase 2 closed.** Editable preview is delivered; teachers can see "what was assigned" vs "what the live set looks like now". Teacher Workspace's North Star is reached. Next bet: **Phase 3** (AIV-6 guarded re-sync → AIV-7 `ProblemSetVersion` → AIV-8 audit UI). | — | The initiative now turns to the durable versioning model. |
+| 2026-06-09 | **AIV-6 done** — `AssignmentSnapshotHistory` model + `diff_snapshots` helper + three actions on `AssignmentViewSet`: `resync-preview` (read-only blast radius), `resync` (atomic snapshot swap; drops stale ticks + queues `grade_submission` only when `answer_changes` is non-empty), `undo-resync` (restores the most recent history row). Frontend: `ResyncAssignmentModal` mounted off the drift banner, plus an Undo bar when history exists. | [#279](https://github.com/openshiksha/openshiksha/pull/279) | Closes the "drift shown but not actionable" gap left by AIV-5. 12 backend tests + 12 vitests. |
+| 2026-06-09 | **AIV-7 done** — `ProblemSetVersion(problem_set, version_number, content_hash, content, created_at, created_by)` immutable, deduplicated content versions; `unique_together(problem_set, content_hash)` enforces dedup. `Assignment.problem_set_version` FK (nullable for backfill safety). Helpers: `_content_hash` (sha256 of canonical-JSON `questions`), `get_or_create_version_for` (select-for-update, idempotent factory), `resolve_assignment_content` (single source of truth: FK content → legacy JSONField fallback). All capture sites + all reader sites switched. Migrations 0025 (schema) + 0026 (idempotent dedup backfill of every legacy snapshot). | [#280](https://github.com/openshiksha/openshiksha/pull/280) | Heaviest PR of the batch — 85 tests pass, no regressions. `assigned_content` retained as deprecated fallback so legacy data keeps working through the cutover. |
+| 2026-06-09 | **AIV-8 done** — `versions` + `version_diff` actions on `ProblemSetViewSet`; `versions` annotates `Count('assignments')` so the list is N+1-free, `version_diff` defaults `against` to the prior version. Frontend: new `ProblemSetVersionsPage` (timeline + click-to-select target → click-to-select against → structured diff summary), `/teacher/problem-sets/:id/versions` route, and a *View version history* button on the preview page. | [#281](https://github.com/openshiksha/openshiksha/pull/281) | Builds entirely on AIV-7's table; reuses `diff_snapshots` for the diff. 7 backend tests + 4 vitests. |
+| 2026-06-09 | **Phase 3 closed → initiative ✅ Done.** All eight AIV increments shipped; the DoD is met end-to-end. Editing never silently rewrites assigned content; re-sync is opt-in with preview + undo; assignments pin immutable, deduplicated versions; version history is auditable + diffable. | — | Initiative status flipped from Active to Done; no successor increments queued. |


### PR DESCRIPTION
## Summary

Ledger close-out for the AIV-6/7/8 batch ([#279](https://github.com/openshiksha/openshiksha/pull/279)–[#281](https://github.com/openshiksha/openshiksha/pull/281)) that merged today. No code changes.

- **STATUS.md** — Authoring Integrity flipped to **Done**. Headline note rewritten to cite the Phase 3 PRs and note that every initiative on the board is now Done or Paused.
- **authoring-integrity-versioning.md** — status line flipped to ✅ Done; ledger appended with one row per Phase 3 PR + a closing summary.

## Initiative DoD met

With AIV-1..8 shipped:

1. Editing never silently rewrites assigned content (AIV-1/2)
2. Editing is safe by construction and surfaced as such (AIV-3/4)
3. Teachers see "what was assigned" vs "what the live set looks like now" (AIV-5)
4. Re-sync is opt-in, previewed, reversible (AIV-6)
5. Assignments pin an immutable, deduplicated content version (AIV-7)
6. Version history is auditable + diffable (AIV-8)

## What's next

No active initiative is queued. The next scheduled run should either:
- promote a backlog item from `STATUS.md`'s "Backlog of future initiatives" (Mobile shell, AI tutor surface, Accessibility pass, etc.), or
- harvest a polish/foundation-hardening tick from the most recently closed initiative.

Whichever the plan agent picks tomorrow.