### PR TITLE
polish(ai): content recommendations — loading skeleton, empty state, SPA links

### DIFF
--- a/docs/ai-features/polish-backlog.md
+++ b/docs/ai-features/polish-backlog.md
@@ -123,6 +123,41 @@ the Auto-strategy badge + note. Trigger a failing generate → red error line.
 
 ---
 
+## 2026-06-09 — Content recommendations: loading skeleton + empty state + SPA links
+
+**Surface:** Content recommendations (student dashboard `RecommendationsPanel`).
+
+**Gaps (checklist #2 loading states, #4 empty states, #6 V2 consistency):**
+1. The panel returned `null` while loading, so on every dashboard visit the
+   card **popped in after the fetch** and shoved the "Due for Review" panel
+   down — exactly the flash-of-empty-space the checklist forbids.
+2. With zero recommendations the panel rendered nothing at all, so a new
+   student **never learns the feature exists** and gets no explanation of what
+   unlocks it (checklist #4: never a blank section without explanation).
+3. Errors were silently swallowed into the same hidden state (now an explicit,
+   commented decision: the assignments list already surfaces connectivity
+   problems, so the panel steps aside on error rather than stacking banners).
+4. Footer links used raw `<a href>` → **full page reloads** instead of SPA
+   navigation; priority chips were hand-rolled spans instead of the shared
+   `Badge`. The bare score percentage had no label.
+
+**Fix:**
+- Added a shape-matched `Skeleton` card (header + 3 rows) during load.
+- Added a compact empty-state card: "No suggestions yet — answer a few
+  assignment questions and we'll point you to the chapters worth revisiting."
+- Replaced `<a>` with react-router `Link`; priority chips now use the V2
+  `Badge` (1=urgent, 2=attention, 3=brand, 4=neutral); score now labelled
+  "your score".
+- New test file `RecommendationsPanel.test.tsx` covers the skeleton, the
+  populated render, the empty state, and the hide-on-error path (checklist #8).
+
+**Verify:** Student dashboard → "What to Practice Next" shows a skeleton while
+loading, real rows with badges + labelled scores when data exists, and the
+explanatory empty card for a fresh student. Footer links navigate without a
+full reload.
+
+---
+
 ## Remaining gaps (audit notes — not yet addressed)
 
 - **Natural language explanations** — backend `SubpartExplanationViewSet` is
@@ -135,3 +170,19 @@ the Auto-strategy badge + note. Trigger a failing generate → red error line.
   state, now consistent with `WeeklyReportPanel` and `NarrativeCard`.
 - **Hint system** — solid: loading ("Thinking of a good hint…"), error, and
   exhausted states all present. Low priority.
+- **Unwired backend surfaces (2026-06-09 audit)** — besides `/ai/explanations/`,
+  three more AI endpoints have **no `frontend_modern` consumer at all**:
+  `/ai/misconception-clusters/` (class misconception insights),
+  `/ai/assignment-drafts/` (assignment draft builder), and
+  `/ai/open-rubrics/` + `/ai/open-grades/` (open-response grading). Wiring each
+  is UI-build work, not polish — flagging here rather than building.
+- **Content recommendations rows are inert** — each row shows chapter + reason
+  but offers no click-through to actually practice that chapter
+  (`problem_set` is on the payload but unused). Needs a routing decision
+  (browse-by-chapter vs problem-set link); small feature, not pure polish.
+- **SRS drill result screen** — "Review again" lets a student immediately
+  resubmit the same drill, which re-runs the SM-2 update and can double-move
+  the interval in one sitting. Worth a guard or copy tweak on a future run.
+- **`DueForReviewPanel`** — same render-`null`-while-loading pop-in pattern
+  that was just fixed on `RecommendationsPanel`; lower impact (panel is below
+  the fold) but should be made consistent on a future run.

--- a/frontend_modern/src/features/student/RecommendationsPanel.test.tsx
+++ b/frontend_modern/src/features/student/RecommendationsPanel.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { RecommendationsPanel } from './RecommendationsPanel';
+import type { ContentRecommendation } from './useRecommendations';
+import type { PracticePlan } from './usePracticePlan';
+
+const { mockGet } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    get: mockGet,
+  },
+}));
+
+const REC: ContentRecommendation = {
+  id: 11,
+  chapter: 4,
+  chapter_name: 'Fractions',
+  subject_name: 'Mathematics',
+  subject_room: 1,
+  problem_set: null,
+  reason: 'low_score',
+  reason_display: 'Recent scores were low in this chapter',
+  priority: 1,
+  priority_display: 'Urgent',
+  score_snapshot: 0.42,
+  is_actioned: false,
+  is_active: true,
+  generated_at: '2026-06-09T08:00:00Z',
+  actioned_at: null,
+};
+
+const PLAN: PracticePlan = {
+  id: 5,
+  subject_room: 1,
+  plan_date: '2026-06-09',
+  estimated_minutes: 20,
+  is_completed: false,
+  recommendations: [REC],
+  generated_at: '2026-06-09T08:00:00Z',
+};
+
+/** Routes mockGet by URL: recommendations list + today's practice plan. */
+function mockEndpoints({
+  recommendations,
+  plan,
+  failRecommendations = false,
+}: {
+  recommendations: ContentRecommendation[];
+  plan: PracticePlan | null;
+  failRecommendations?: boolean;
+}) {
+  mockGet.mockImplementation((url: string) => {
+    if (url.startsWith('/ai/recommendations/')) {
+      if (failRecommendations) return Promise.reject(new Error('boom'));
+      return Promise.resolve({ data: { results: recommendations } });
+    }
+    if (url.startsWith('/ai/practice-plans/')) {
+      if (plan === null) return Promise.reject({ response: { status: 404 } });
+      return Promise.resolve({ data: plan });
+    }
+    return Promise.reject(new Error(`unexpected GET ${url}`));
+  });
+}
+
+function renderPanel() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <RecommendationsPanel />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('RecommendationsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows a skeleton while recommendations load instead of popping in', async () => {
+    mockEndpoints({ recommendations: [REC], plan: PLAN });
+    renderPanel();
+
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0);
+
+    await waitFor(() => expect(screen.getByText('Fractions')).toBeDefined());
+  });
+
+  it('renders recommendations with a priority badge and the student score', async () => {
+    mockEndpoints({ recommendations: [REC], plan: PLAN });
+    renderPanel();
+
+    await waitFor(() => expect(screen.getByText('Fractions')).toBeDefined());
+    expect(screen.getByText('URGENT')).toBeDefined();
+    expect(screen.getByText('Recent scores were low in this chapter')).toBeDefined();
+    expect(screen.getByText('42%')).toBeDefined();
+    expect(screen.getByText('your score')).toBeDefined();
+    expect(screen.getByText(/~20 min/)).toBeDefined();
+  });
+
+  it('explains what unlocks recommendations when there are none yet', async () => {
+    mockEndpoints({ recommendations: [], plan: null });
+    renderPanel();
+
+    await waitFor(() =>
+      expect(screen.getByText(/answer a few assignment questions/i)).toBeDefined()
+    );
+    expect(screen.getByText('What to Practice Next')).toBeDefined();
+  });
+
+  it('hides the panel entirely when the fetch fails', async () => {
+    mockEndpoints({ recommendations: [], plan: null, failRecommendations: true });
+    const { container } = renderPanel();
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+    await waitFor(() => expect(container.firstChild).toBeNull());
+  });
+});

--- a/frontend_modern/src/features/student/RecommendationsPanel.tsx
+++ b/frontend_modern/src/features/student/RecommendationsPanel.tsx
@@ -1,19 +1,60 @@
+import { Link } from 'react-router-dom';
+import { Badge, Skeleton } from '@/shared/ui';
 import { useRecommendations } from './useRecommendations';
 import { usePracticePlan } from './usePracticePlan';
 
-const PRIORITY_BADGE: Record<number, string> = {
-  1: 'bg-rose-100 text-rose-800 border border-rose-300',
-  2: 'bg-amber-100 text-amber-800 border border-amber-300',
-  3: 'bg-brand-100 text-brand-800 border border-brand-300',
-  4: 'bg-ink-100 text-ink-700 border border-ink-200',
+// ContentRecommendation priority semantics: 1=urgent, 2=high, 3=medium, 4=low.
+const PRIORITY_TONE: Record<number, 'urgent' | 'attention' | 'brand' | 'neutral'> = {
+  1: 'urgent',
+  2: 'attention',
+  3: 'brand',
+  4: 'neutral',
 };
 
 export const RecommendationsPanel = () => {
-  const { data: recommendations, isLoading } = useRecommendations();
+  const { data: recommendations, isLoading, isError } = useRecommendations();
   const { data: plan } = usePracticePlan();
 
-  if (isLoading) return null;
-  if (!recommendations || recommendations.length === 0) return null;
+  // On a failed fetch the panel steps aside rather than stacking another error
+  // banner on the dashboard — the assignments list already surfaces
+  // connectivity problems prominently.
+  if (isError) return null;
+
+  if (isLoading) {
+    return (
+      <div className="os-card border-brand-200 p-5">
+        <Skeleton w="w-48" h="h-5" className="mb-4" />
+        <div className="space-y-3">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="flex items-center justify-between gap-3 py-2">
+              <div className="flex items-center gap-3 min-w-0 flex-1">
+                <Skeleton w="w-16" h="h-5" rounded="rounded-full" />
+                <div className="flex-1 space-y-1.5">
+                  <Skeleton w="w-2/3" h="h-4" />
+                  <Skeleton w="w-1/2" h="h-3" />
+                </div>
+              </div>
+              <Skeleton w="w-10" h="h-4" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!recommendations || recommendations.length === 0) {
+    return (
+      <div className="os-card p-5">
+        <h2 className="text-base font-display font-semibold text-ink-900">
+          What to Practice Next
+        </h2>
+        <p className="text-sm text-ink-500 mt-1">
+          No suggestions yet — answer a few assignment questions and we&apos;ll point you to the
+          chapters worth revisiting.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div className="os-card border-brand-200 p-5">
@@ -33,11 +74,9 @@ export const RecommendationsPanel = () => {
             className="flex items-start justify-between gap-3 py-2 border-b border-ink-100 last:border-0"
           >
             <div className="flex items-start gap-3 min-w-0">
-              <span
-                className={`mt-0.5 shrink-0 text-xs font-semibold px-2 py-0.5 rounded ${PRIORITY_BADGE[rec.priority] ?? PRIORITY_BADGE[3]}`}
-              >
+              <Badge tone={PRIORITY_TONE[rec.priority] ?? 'brand'} className="mt-0.5 shrink-0">
                 {rec.priority_display.toUpperCase()}
-              </span>
+              </Badge>
               <div className="min-w-0">
                 <p className="text-sm font-medium text-ink-900 truncate">{rec.chapter_name}</p>
                 <p className="text-xs text-ink-500 mt-0.5">{rec.reason_display}</p>
@@ -47,6 +86,7 @@ export const RecommendationsPanel = () => {
               <p className="text-sm font-semibold text-ink-700">
                 {Math.round(rec.score_snapshot * 100)}%
               </p>
+              <p className="text-xs text-ink-400">your score</p>
             </div>
           </div>
         ))}
@@ -55,21 +95,22 @@ export const RecommendationsPanel = () => {
       {plan && (
         <div className="mt-4 pt-3 border-t border-ink-100 flex items-center justify-between">
           <span className="text-xs text-ink-500">
-            {plan.recommendations.length} topic{plan.recommendations.length !== 1 ? 's' : ''} in today&apos;s plan
+            {plan.recommendations.length} topic{plan.recommendations.length !== 1 ? 's' : ''} in
+            today&apos;s plan
           </span>
           <div className="flex items-center gap-3">
-            <a
-              href="/student/proficiency"
+            <Link
+              to="/student/proficiency"
               className="text-xs font-medium text-brand-700 hover:text-brand-800 focus:outline-none focus-visible:underline"
             >
               View progress →
-            </a>
-            <a
-              href="/student/learning-path"
+            </Link>
+            <Link
+              to="/student/learning-path"
               className="text-xs font-medium text-brand-700 hover:text-brand-800 focus:outline-none focus-visible:underline"
             >
               View learning path →
-            </a>
+            </Link>
           </div>
         </div>
       )}


### PR DESCRIPTION
## What gap was fixed

The student dashboard **RecommendationsPanel** (content recommendations AI surface) failed two items of the AI-polish checklist:

- **#2 Loading states** — the panel returned `null` while fetching, so on every dashboard visit the card popped in after the response and shoved the "Due for Review" panel down (flash of empty space + layout shift).
- **#4 Empty states** — with zero recommendations the panel rendered nothing at all. A new student never learns the feature exists and gets no explanation of what unlocks it.
- Plus: footer links were raw `<a href>` (full page reload instead of SPA navigation), priority chips were hand-rolled spans instead of the shared V2 `Badge`, and the bare score percentage had no label.

## Before / after

| | Before | After |
|---|---|---|
| Loading | Nothing, then pop-in | Shape-matched `Skeleton` card (header + 3 rows) |
| No recommendations | Panel hidden, no explanation | Compact card: "No suggestions yet — answer a few assignment questions and we'll point you to the chapters worth revisiting." |
| Fetch error | Silently hidden | Still hidden, but now an explicit commented decision (assignments list already surfaces connectivity errors — no banner stacking) |
| Links | `<a href>` full reload | react-router `Link` |
| Priority chip | Custom spans | V2 `Badge` (1=urgent, 2=attention, 3=brand, 4=neutral) |
| Score | Bare "42%" | "42% / your score" |

## How to verify

1. Student dashboard → "What to Practice Next" shows a skeleton while loading, then real rows with priority badges and labelled scores.
2. Fresh student with no analysed submissions → explanatory empty card instead of nothing.
3. "View progress →" / "View learning path →" navigate without a full reload.
4. `npx vitest run src/features/student/RecommendationsPanel.test.tsx` — 4 tests (skeleton, populated, empty, error). Full suite: 260 passed; `tsc --noEmit` clean; eslint clean.

Also updates `docs/ai-features/polish-backlog.md` with this run's fix and new audit findings (4 backend AI endpoints with no frontend consumer, inert recommendation rows, SRS re-submit quirk, same pop-in pattern on `DueForReviewPanel`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)