### PR TITLE
polish(ai): ASA-1 — DueForReviewPanel loading skeleton + empty state

### DIFF
--- a/docs/changes/2026-06-09-asa1-due-review-states.md
+++ b/docs/changes/2026-06-09-asa1-due-review-states.md
@@ -1,0 +1,53 @@
+# ASA-1 — DueForReviewPanel: loading skeleton + explanatory empty state
+
+**Date**: 2026-06-09
+**Classification**: Improve
+**Initiative**: AI Surface Activation (ASA-1)
+
+## Summary
+
+`DueForReviewPanel` on the student dashboard rendered `null` until the SRS
+due-entries fetch resolved, then popped in and shoved the dashboard layout. It
+also disappeared silently when a student had nothing due, leaving no hint that
+a review schedule exists. This applies the exact state-handling pattern shipped
+for `RecommendationsPanel` in #283 to its sibling panel.
+
+## Legacy reference
+
+None — spaced repetition has no legacy equivalent (modern-only feature, SM-2
+engine in `backend/openshiksha/apps/ai/`). The pattern reference is internal:
+`RecommendationsPanel.tsx` as polished in PR #283.
+
+## What changed
+
+- `frontend_modern/src/features/student/DueForReviewPanel.tsx`
+  - Destructured `isLoading` / `isError` from `useSpacedRepetitionDue()` (the
+    hook already exposed them via React Query).
+  - Loading: shape-matched skeleton card (header + 3 rows with dot, two text
+    lines, pill-shaped action placeholder) inside the same
+    `os-card border-amber-200 p-5 mt-6` footprint so the layout doesn't reflow
+    on resolve.
+  - Empty: compact explanatory card — "Due for Review" heading + "Nothing due
+    yet — finish a few assignments and your review schedule will appear here."
+  - Error: panel returns `null` with the same explanatory comment used in
+    `RecommendationsPanel` (dashboard already surfaces connectivity errors).
+- `frontend_modern/src/features/student/DueForReviewPanel.test.tsx` (new)
+
+## Tests
+
+`npx vitest run DueForReviewPanel` — 4 tests, all passing:
+1. Skeleton renders while loading (no pop-in).
+2. Populated render: urgency labels, overdue badge, sorted practice links.
+3. Empty state shows the explanatory copy.
+4. Panel hides entirely on fetch error.
+
+Also: `npx tsc --noEmit` and `npm run lint` clean.
+
+## Migration notes
+
+None — frontend only.
+
+## Next steps
+
+ASA-2..5 in this batch (recommendation click-through, SRS repeat-review guard,
+answer explanations, misconception clusters panel).

--- a/frontend_modern/src/features/student/DueForReviewPanel.test.tsx
+++ b/frontend_modern/src/features/student/DueForReviewPanel.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { DueForReviewPanel } from './DueForReviewPanel';
+import type { SRSEntry } from './useSpacedRepetitionDue';
+
+const { mockGet } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    get: mockGet,
+  },
+}));
+
+const today = new Date().toISOString().slice(0, 10);
+
+const ENTRY: SRSEntry = {
+  id: 7,
+  knowledge_node: 3,
+  chapter_name: 'Polynomials',
+  interval_days: 6,
+  easiness_factor: 2.5,
+  repetitions: 2,
+  next_review_date: today,
+  last_reviewed_at: '2026-06-03T08:00:00Z',
+};
+
+const OVERDUE_ENTRY: SRSEntry = {
+  ...ENTRY,
+  id: 8,
+  chapter_name: 'Fractions',
+  next_review_date: '2020-01-01',
+};
+
+function mockDueEntries(entries: SRSEntry[] | Error) {
+  mockGet.mockImplementation((url: string) => {
+    if (url.startsWith('/ai/spaced-repetition/due/')) {
+      if (entries instanceof Error) return Promise.reject(entries);
+      return Promise.resolve({ data: entries });
+    }
+    return Promise.reject(new Error(`unexpected GET ${url}`));
+  });
+}
+
+function renderPanel() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <DueForReviewPanel />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('DueForReviewPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows a skeleton while due entries load instead of popping in', async () => {
+    mockDueEntries([ENTRY]);
+    renderPanel();
+
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0);
+
+    await waitFor(() => expect(screen.getByText('Polynomials')).toBeDefined());
+  });
+
+  it('renders due entries with urgency labels and a practice link', async () => {
+    mockDueEntries([ENTRY, OVERDUE_ENTRY]);
+    renderPanel();
+
+    await waitFor(() => expect(screen.getByText('Polynomials')).toBeDefined());
+    expect(screen.getByText('Due today')).toBeDefined();
+    expect(screen.getByText(/Overdue since 2020-01-01/)).toBeDefined();
+    expect(screen.getByText('1 overdue')).toBeDefined();
+
+    const links = screen.getAllByRole('link', { name: /practice/i });
+    expect(links.length).toBe(2);
+    // Overdue entries sort first.
+    expect(links[0].getAttribute('href')).toBe('/student/srs-drill/8');
+  });
+
+  it('explains what unlocks the review schedule when nothing is due', async () => {
+    mockDueEntries([]);
+    renderPanel();
+
+    await waitFor(() =>
+      expect(screen.getByText(/finish a few assignments/i)).toBeDefined()
+    );
+    expect(screen.getByText('Due for Review')).toBeDefined();
+  });
+
+  it('hides the panel entirely when the fetch fails', async () => {
+    mockDueEntries(new Error('boom'));
+    const { container } = renderPanel();
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+    await waitFor(() => expect(container.firstChild).toBeNull());
+  });
+});

--- a/frontend_modern/src/features/student/DueForReviewPanel.tsx
+++ b/frontend_modern/src/features/student/DueForReviewPanel.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { Skeleton } from '@/shared/ui';
 import { useSpacedRepetitionDue } from './useSpacedRepetitionDue';
 import type { SRSEntry } from './useSpacedRepetitionDue';
 
@@ -55,9 +56,45 @@ const SRSRow = ({ entry }: { entry: SRSEntry }) => {
 };
 
 export const DueForReviewPanel = () => {
-  const { data: entries } = useSpacedRepetitionDue();
+  const { data: entries, isLoading, isError } = useSpacedRepetitionDue();
 
-  if (!entries || entries.length === 0) return null;
+  // On a failed fetch the panel steps aside rather than stacking another error
+  // banner on the dashboard — the assignments list already surfaces
+  // connectivity problems prominently.
+  if (isError) return null;
+
+  if (isLoading) {
+    return (
+      <div className="os-card border-amber-200 p-5 mt-6">
+        <Skeleton w="w-40" h="h-5" className="mb-4" />
+        <div className="space-y-1.5">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="flex items-center justify-between gap-3 py-2.5 px-3">
+              <div className="flex items-center gap-2 min-w-0 flex-1">
+                <Skeleton w="w-2" h="h-2" rounded="rounded-full" />
+                <div className="flex-1 space-y-1.5">
+                  <Skeleton w="w-2/3" h="h-4" />
+                  <Skeleton w="w-1/3" h="h-3" />
+                </div>
+              </div>
+              <Skeleton w="w-16" h="h-6" rounded="rounded-full" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!entries || entries.length === 0) {
+    return (
+      <div className="os-card p-5 mt-6">
+        <h2 className="text-base font-display font-semibold text-ink-900">Due for Review</h2>
+        <p className="text-sm text-ink-500 mt-1">
+          Nothing due yet — finish a few assignments and your review schedule will appear here.
+        </p>
+      </div>
+    );
+  }
 
   const sorted = [...entries].sort((a, b) =>
     a.next_review_date.localeCompare(b.next_review_date),


### PR DESCRIPTION
## Classification
Improve — AI Surface Activation initiative, ASA-1 (docs/daily-plans/2026-06-09-plan.md).

## Legacy reference
None (SRS is modern-only). Internal pattern reference: RecommendationsPanel as polished in #283.

## What changed
- `DueForReviewPanel` no longer renders `null` until the SRS fetch resolves — shape-matched skeleton card prevents dashboard reflow.
- Explanatory empty state instead of a silently missing section.
- Hidden-on-error (same convention + comment as RecommendationsPanel).

## Tests
- New `DueForReviewPanel.test.tsx`: skeleton, populated (urgency labels, overdue badge, sorted practice links), empty copy, hidden-on-error — 4/4 passing.
- `npx tsc --noEmit` + `npm run lint` clean.

## How to verify
Student dashboard: panel area shows an amber skeleton during load, an explanatory card when nothing is due, and no layout jump when entries arrive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)