### PR TITLE
polish(ai): ASA-2 — recommendation rows click through to chapter practice

### DIFF
--- a/docs/changes/2026-06-09-asa2-recommendation-links.md
+++ b/docs/changes/2026-06-09-asa2-recommendation-links.md
@@ -1,0 +1,48 @@
+# ASA-2 — Recommendation rows: click-through to chapter practice
+
+**Date**: 2026-06-09
+**Classification**: Improve
+**Initiative**: AI Surface Activation (ASA-2)
+
+## Summary
+
+"What to Practice Next" rows on the student dashboard were insight without
+action: the `ContentRecommendation` payload carries `chapter` (and
+`problem_set`), but the panel never used either — students couldn't act on a
+recommendation without manually navigating the browse tree. Each row now gets a
+"Practice" pill linking straight to chapter practice, closing the
+insight→action loop.
+
+## Legacy reference
+
+`focus/` remedial auto-creation embodied the same principle (insight must lead
+to action in-flow); no direct legacy UI to port. Routing decision per the daily
+plan: link to `/student/browse/chapter/:chapterId` (existing `ProtectedRoute`,
+App.tsx:170, valid for `student` and `open_student`; `BrowsePracticePage`
+builds a quick-practice session per chapter) rather than the raw problem set.
+
+## What changed
+
+- `frontend_modern/src/features/student/RecommendationsPanel.tsx`
+  - Per-row "Practice" pill `Link` to `/student/browse/chapter/${rec.chapter}`,
+    styled identically to `DueForReviewPanel`'s Practice pill (rounded-full,
+    brand border, hover fill) for cross-panel consistency.
+  - Row text stays non-clickable (avoids nested-link a11y traps; keeps
+    truncation/layout intact).
+  - Score block now hides on <sm screens (same convention as
+    `DueForReviewPanel`'s interval block) so the action pill always fits.
+- `frontend_modern/src/features/student/RecommendationsPanel.test.tsx`
+  - New test: each row exposes a practice link with the correct chapter href.
+
+## Tests
+
+`npx vitest run RecommendationsPanel` — 5 tests passing (1 new, 4 existing
+untouched). `npx tsc --noEmit` + `npm run lint` clean.
+
+## Migration notes
+
+None — frontend only.
+
+## Next steps
+
+ASA-3..5 in this batch.

--- a/frontend_modern/src/features/student/RecommendationsPanel.test.tsx
+++ b/frontend_modern/src/features/student/RecommendationsPanel.test.tsx
@@ -104,6 +104,25 @@ describe('RecommendationsPanel', () => {
     expect(screen.getByText(/~20 min/)).toBeDefined();
   });
 
+  it('links each recommendation row to chapter practice', async () => {
+    const second: ContentRecommendation = {
+      ...REC,
+      id: 12,
+      chapter: 9,
+      chapter_name: 'Polynomials',
+      priority: 3,
+      priority_display: 'Medium',
+    };
+    mockEndpoints({ recommendations: [REC, second], plan: PLAN });
+    renderPanel();
+
+    await waitFor(() => expect(screen.getByText('Fractions')).toBeDefined());
+    const links = screen.getAllByRole('link', { name: /^practice$/i });
+    expect(links.length).toBe(2);
+    expect(links[0].getAttribute('href')).toBe('/student/browse/chapter/4');
+    expect(links[1].getAttribute('href')).toBe('/student/browse/chapter/9');
+  });
+
   it('explains what unlocks recommendations when there are none yet', async () => {
     mockEndpoints({ recommendations: [], plan: null });
     renderPanel();

--- a/frontend_modern/src/features/student/RecommendationsPanel.tsx
+++ b/frontend_modern/src/features/student/RecommendationsPanel.tsx
@@ -82,11 +82,19 @@ export const RecommendationsPanel = () => {
                 <p className="text-xs text-ink-500 mt-0.5">{rec.reason_display}</p>
               </div>
             </div>
-            <div className="text-right shrink-0">
-              <p className="text-sm font-semibold text-ink-700">
-                {Math.round(rec.score_snapshot * 100)}%
-              </p>
-              <p className="text-xs text-ink-400">your score</p>
+            <div className="flex items-center gap-3 shrink-0">
+              <div className="text-right hidden sm:block">
+                <p className="text-sm font-semibold text-ink-700">
+                  {Math.round(rec.score_snapshot * 100)}%
+                </p>
+                <p className="text-xs text-ink-400">your score</p>
+              </div>
+              <Link
+                to={`/student/browse/chapter/${rec.chapter}`}
+                className="text-xs font-semibold text-brand-700 hover:text-white border border-brand-200 rounded-full px-3 py-1 hover:bg-brand-600 hover:border-brand-600 transition-colors motion-reduce:transition-none focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2"
+              >
+                Practice
+              </Link>
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Classification
Improve — AI Surface Activation initiative, ASA-2 (docs/daily-plans/2026-06-09-plan.md).

## Legacy reference
Principle ported from `focus/` (insight → action in-flow); no legacy UI equivalent. Routing decision per plan: chapter practice (`/student/browse/chapter/:chapterId`, existing route valid for student + open_student), not the raw problem set.

## What changed
- Per-row **Practice** pill `Link` using the recommendation's `chapter` id (previously unused on the payload).
- Styled identically to `DueForReviewPanel`'s Practice pill; row text stays non-clickable (no nested-link a11y traps).
- Score block hides on <sm screens so the pill always fits (same convention as the sibling panel).

## Tests
- Extended `RecommendationsPanel.test.tsx`: practice links with correct hrefs — 5/5 passing.
- `npx tsc --noEmit` + `npm run lint` clean.

## How to verify
Student dashboard → 'What to Practice Next' → click Practice on any row → lands on chapter quick-practice without a full reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)