### PR TITLE
polish(ai): ASA-3 — SRS drill repeat-review guard (practice rounds never re-run SM-2)

### DIFF
--- a/docs/changes/2026-06-09-asa3-srs-repeat-guard.md
+++ b/docs/changes/2026-06-09-asa3-srs-repeat-guard.md
@@ -1,0 +1,61 @@
+# ASA-3 — SRS drill repeat-review guard
+
+**Date**: 2026-06-09
+**Classification**: Improve
+**Initiative**: AI Surface Activation (ASA-3)
+
+## Summary
+
+The SRS drill result screen's "Review again" button reset `answers`/`result`
+and let the student resubmit — calling `mark-reviewed` again and double-moving
+the SM-2 interval in one sitting (flagged in the 2026-06-09 polish-backlog
+audit). The page now has an explicit phase machine: only the first completed
+pass per visit updates the schedule; every later pass is a practice round that
+never fires the mutation.
+
+## Legacy reference
+
+None — spaced repetition is modern-only. Audit reference:
+`docs/ai-features/polish-backlog.md` (2026-06-09 entry).
+
+## What changed
+
+- `frontend_modern/src/features/student/SRSDrillPage.tsx`
+  - New `DrillPhase` state: `review → reviewResult → practice → practiceResult`
+    (practice loops). First-pass behaviour is unchanged.
+  - Graded result screen: button renamed "Practice again" with sub-line
+    "Extra practice won't change your review schedule."
+  - Practice phase: brand-tinted banner on the form, submit button reads
+    "Finish Practice", and submission **skips `markReviewed` entirely** —
+    completion shows a "Practice round complete!" screen confirming the next
+    review date is unchanged.
+- `frontend_modern/src/features/student/SRSDrillPage.test.tsx` (new) —
+  QuestionCard stubbed (its rendering is covered by its own tests).
+
+## Deviation from plan
+
+The plan suggested grading the practice round locally "since the page already
+computes correctness for display" — it doesn't (grading is server-side via
+`mark-reviewed`, and the student payload carries no correct answers). The
+practice-round completion screen is therefore unscored; the guard itself (no
+second SM-2 update) is unaffected.
+
+## Tests
+
+`npx vitest run SRSDrillPage` — 3 tests passing:
+1. First submit POSTs `mark-reviewed` once and shows the graded result.
+2. Second pass shows practice-round copy and never re-fires the mutation.
+3. Chained practice rounds still total exactly one POST.
+
+`npx tsc --noEmit` + `npm run lint` clean.
+
+## Migration notes
+
+None — frontend only. Backend idempotency guard (reject/no-op a second
+same-day review of the same entry) remains ASA-9 in the initiative backlog as
+defence-in-depth; a fresh page visit on the same day is still unguarded until
+then (documented, accepted).
+
+## Next steps
+
+ASA-4 and ASA-5 in this batch.

--- a/frontend_modern/src/features/student/SRSDrillPage.test.tsx
+++ b/frontend_modern/src/features/student/SRSDrillPage.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { SRSDrillPage } from './SRSDrillPage';
+import type { SRSDrillData } from './useSRSDrill';
+
+const { mockGet, mockPost } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPost: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    get: mockGet,
+    post: mockPost,
+  },
+}));
+
+// The drill page only forwards answers into QuestionCard; the card's own
+// rendering (KaTeX, option shuffling) is covered by its own tests.
+vi.mock('./QuestionCard', () => ({
+  QuestionCard: ({
+    onAnswerChange,
+  }: {
+    onAnswerChange: (subpartId: number, value: string) => void;
+  }) => (
+    <button type="button" onClick={() => onAnswerChange(101, '42')}>
+      Answer subpart
+    </button>
+  ),
+}));
+
+const DRILL: SRSDrillData = {
+  entry_id: 7,
+  chapter_name: 'Polynomials',
+  subject_name: 'Mathematics',
+  questions: [
+    {
+      id: 1,
+      subparts: [{ id: 101 }],
+    } as unknown as SRSDrillData['questions'][number],
+  ],
+};
+
+const REVIEW_RESULT = {
+  id: 7,
+  knowledge_node: 3,
+  chapter_name: 'Polynomials',
+  interval_days: 12,
+  easiness_factor: 2.5,
+  repetitions: 3,
+  next_review_date: '2026-06-21',
+  last_reviewed_at: '2026-06-09T10:00:00Z',
+  score: 0.8,
+};
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/student/srs-drill/7']}>
+        <Routes>
+          <Route path="/student/srs-drill/:entryId" element={<SRSDrillPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('SRSDrillPage repeat-review guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue({ data: DRILL });
+    mockPost.mockResolvedValue({ data: REVIEW_RESULT });
+  });
+
+  it('first submit marks the review and shows the graded result', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Polynomials')).toBeDefined());
+    await user.click(screen.getByText('Answer subpart'));
+    await user.click(screen.getByRole('button', { name: 'Submit Review' }));
+
+    await waitFor(() => expect(screen.getByText('Great review!')).toBeDefined());
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    expect(mockPost).toHaveBeenCalledWith('/ai/spaced-repetition/7/mark-reviewed/', {
+      answers: { '101': '42' },
+    });
+    expect(screen.getByText(/Next review scheduled for 2026-06-21/)).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Practice again' })).toBeDefined();
+    expect(screen.getByText(/Extra practice won't change your review schedule/)).toBeDefined();
+  });
+
+  it('a second pass in the same sitting never fires mark-reviewed again', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Polynomials')).toBeDefined());
+    await user.click(screen.getByText('Answer subpart'));
+    await user.click(screen.getByRole('button', { name: 'Submit Review' }));
+    await waitFor(() => expect(screen.getByText('Great review!')).toBeDefined());
+
+    await user.click(screen.getByRole('button', { name: 'Practice again' }));
+
+    // Practice round: banner + relabelled submit.
+    expect(
+      screen.getByText(/Practice round — extra practice won't change your review schedule/)
+    ).toBeDefined();
+    await user.click(screen.getByText('Answer subpart'));
+    await user.click(screen.getByRole('button', { name: 'Finish Practice' }));
+
+    await waitFor(() => expect(screen.getByText('Practice round complete!')).toBeDefined());
+    expect(screen.getByText(/your next review stays on 2026-06-21/)).toBeDefined();
+    // The SM-2 update ran exactly once, on the first pass.
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+
+  it('can chain further practice rounds without ever re-marking', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Polynomials')).toBeDefined());
+    await user.click(screen.getByText('Answer subpart'));
+    await user.click(screen.getByRole('button', { name: 'Submit Review' }));
+    await waitFor(() => expect(screen.getByText('Great review!')).toBeDefined());
+
+    for (let round = 0; round < 2; round++) {
+      await user.click(screen.getByRole('button', { name: 'Practice again' }));
+      await user.click(screen.getByText('Answer subpart'));
+      await user.click(screen.getByRole('button', { name: 'Finish Practice' }));
+      await waitFor(() => expect(screen.getByText('Practice round complete!')).toBeDefined());
+    }
+
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend_modern/src/features/student/SRSDrillPage.tsx
+++ b/frontend_modern/src/features/student/SRSDrillPage.tsx
@@ -10,7 +10,12 @@ import { useMarkReviewed, useSRSDrill, type SRSReviewResult } from './useSRSDril
  * 2. Student answers each subpart in a familiar QuestionCard
  * 3. Submit POSTs {answers} to /mark-reviewed/ → server grades + updates SM-2
  * 4. Result screen shows score and next review date
+ *
+ * Only the first completed pass per visit updates the SM-2 schedule; repeat
+ * passes are practice-only so one sitting can never double-move the interval.
  */
+type DrillPhase = 'review' | 'reviewResult' | 'practice' | 'practiceResult';
+
 export const SRSDrillPage = () => {
   const { entryId } = useParams<{ entryId: string }>();
   const navigate = useNavigate();
@@ -21,6 +26,7 @@ export const SRSDrillPage = () => {
 
   const [answers, setAnswers] = useState<Record<string, string>>({});
   const [result, setResult] = useState<SRSReviewResult | null>(null);
+  const [phase, setPhase] = useState<DrillPhase>('review');
 
   const answeredCount = useMemo(
     () => Object.values(answers).filter((v) => v && v.trim().length > 0).length,
@@ -37,10 +43,26 @@ export const SRSDrillPage = () => {
 
   const handleSubmit = () => {
     if (!drill || answeredCount === 0) return;
+    if (phase === 'practice') {
+      // Practice round: the SM-2 schedule was already updated this visit —
+      // never fire a second mark-reviewed for the same sitting.
+      setPhase('practiceResult');
+      return;
+    }
     markReviewed(
       { entryId: drill.entry_id, answers },
-      { onSuccess: (data) => setResult(data) },
+      {
+        onSuccess: (data) => {
+          setResult(data);
+          setPhase('reviewResult');
+        },
+      },
     );
+  };
+
+  const startPracticeRound = () => {
+    setAnswers({});
+    setPhase('practice');
   };
 
   if (isLoading) {
@@ -78,7 +100,7 @@ export const SRSDrillPage = () => {
     );
   }
 
-  if (result) {
+  if (phase === 'reviewResult' && result) {
     const pct = Math.round(result.score * 100);
     const passed = result.score >= 0.6;
     return (
@@ -105,14 +127,39 @@ export const SRSDrillPage = () => {
           </p>
           <div className="flex flex-wrap gap-2 justify-center">
             <Button onClick={() => navigate('/student')}>Back to Dashboard</Button>
-            <Button
-              variant="ghost"
-              onClick={() => {
-                setAnswers({});
-                setResult(null);
-              }}
-            >
-              Review again
+            <Button variant="ghost" onClick={startPracticeRound}>
+              Practice again
+            </Button>
+          </div>
+          <p className="text-xs text-ink-400 mt-3">
+            Extra practice won&apos;t change your review schedule.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'practiceResult' && result) {
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-10">
+        <div className="rounded-2xl border border-brand-200 bg-brand-50 p-8 text-center">
+          <div className="text-5xl mb-4" aria-hidden>
+            💪
+          </div>
+          <h2 className="text-2xl font-display font-semibold text-ink-900 mb-2">
+            Practice round complete!
+          </h2>
+          <p className="text-ink-700 mb-1">
+            Nice extra rep on <span className="font-semibold">{drill.chapter_name}</span>
+          </p>
+          <p className="text-sm text-ink-500 mb-6">
+            Practice rounds don&apos;t change your schedule — your next review stays on{' '}
+            {result.next_review_date}.
+          </p>
+          <div className="flex flex-wrap gap-2 justify-center">
+            <Button onClick={() => navigate('/student')}>Back to Dashboard</Button>
+            <Button variant="ghost" onClick={startPracticeRound}>
+              Practice again
             </Button>
           </div>
         </div>
@@ -163,6 +210,11 @@ export const SRSDrillPage = () => {
         />
       ) : (
         <>
+          {phase === 'practice' && (
+            <div className="mb-4 rounded-lg border border-brand-200 bg-brand-50 px-3 py-2 text-xs text-brand-800">
+              Practice round — extra practice won&apos;t change your review schedule.
+            </div>
+          )}
           <div className="mb-4 flex items-center justify-between text-xs text-ink-500">
             <span>
               {answeredCount} / {totalSubparts} answered
@@ -192,7 +244,11 @@ export const SRSDrillPage = () => {
               onClick={handleSubmit}
               disabled={isPending || answeredCount === 0}
             >
-              {isPending ? 'Submitting…' : 'Submit Review'}
+              {isPending
+                ? 'Submitting…'
+                : phase === 'practice'
+                  ? 'Finish Practice'
+                  : 'Submit Review'}
             </Button>
             {answeredCount === 0 && (
               <p className="text-xs text-center text-ink-400 mt-2">


### PR DESCRIPTION
## Classification
Improve — AI Surface Activation initiative, ASA-3 (docs/daily-plans/2026-06-09-plan.md).

## Legacy reference
None (SRS is modern-only). Source: 2026-06-09 polish-backlog audit — 'Review again' reset state and let a second submit double-move the SM-2 interval in one sitting.

## What changed
- Explicit drill phase machine: `review → reviewResult → practice (loops) → practiceResult`. First-pass behaviour unchanged.
- Graded result: button is now **Practice again** + sub-line 'Extra practice won't change your review schedule.'
- Practice rounds: banner on the form, **Finish Practice** submit, and the `mark-reviewed` mutation is skipped entirely; completion screen confirms the next review date is unchanged.

## Deviation from plan
Plan assumed local grading existed for the practice round — it doesn't (grading is server-side; student payload has no correct answers), so the practice completion screen is unscored. The guard itself is unaffected. Backend same-day idempotency stays ASA-9 (defence-in-depth).

## Tests
- New `SRSDrillPage.test.tsx` (3 tests): first pass POSTs once; second pass shows practice copy and never re-fires; chained rounds still total one POST.
- `npx tsc --noEmit` + `npm run lint` clean.

## How to verify
Complete an SRS drill → result screen → 'Practice again' → finish the round: no second `mark-reviewed` request in the network tab; schedule date unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)