### PR TITLE
feat(student): ASA-4 — post-submit answer explanations (first /ai/explanations/ consumer)

### DIFF
--- a/backend/openshiksha/apps/ai/serializers.py
+++ b/backend/openshiksha/apps/ai/serializers.py
@@ -276,6 +276,7 @@ class SubpartExplanationSerializer(serializers.ModelSerializer):
             "explanation_text",
             "language",
             "grade_level",
+            "model_used",
             "generated_at",
         ]
         read_only_fields = fields

--- a/docs/changes/2026-06-09-asa4-answer-explanations.md
+++ b/docs/changes/2026-06-09-asa4-answer-explanations.md
@@ -1,0 +1,74 @@
+# ASA-4 — Post-submit answer explanations (first consumer of /ai/explanations/)
+
+**Date**: 2026-06-09
+**Classification**: New
+**Initiative**: AI Surface Activation (ASA-4)
+
+## Summary
+
+The `/ai/explanations/` endpoint group (generate + list, fully built and
+tested on the backend) had zero frontend consumers. Students now get an
+"✨ Explain this answer" affordance per subpart after submitting an
+assignment — the platform's first surface that explains *why* an answer was
+right or wrong, not just the mark.
+
+## Legacy reference
+
+None — legacy showed marks only after grading; no explanation capability ever
+existed. This is the "improve, don't just migrate" thesis applied to the core
+grading loop.
+
+## What changed
+
+**Backend (one line)**
+- `SubpartExplanationSerializer` now exposes `model_used` so the frontend can
+  apply the standard AI/stub provenance badge (same vocabulary as
+  `NarrativeCard`/`InterventionsPanel`/`WeeklyReportPanel`). The plan assumed
+  the field was already serialized; it wasn't.
+
+**Frontend**
+- `useExplanation.ts` (new): `useExplanationList(subpartId, enabled)` — GET
+  `/ai/explanations/?subpart=<id>`, handles both list and paginated shapes,
+  `staleTime: Infinity` (explanations persist server-side);
+  `useGenerateExplanation()` — POST `/ai/explanations/generate/` (202, async
+  Celery task).
+- `ExplanationPanel.tsx` (new): collapsed trigger → on click checks for an
+  existing explanation (shows it directly, never re-generates) → otherwise
+  fires generate exactly once and polls the list (default 2 s cadence, 15
+  attempts ≈ 30 s budget) → renders the explanation with `✨ AI-generated`
+  badge, or `Auto-explanation` + stub note when `model_used === 'stub'`.
+  Timeout/API failure → friendly inline error with a working Retry. Poll
+  cadence and budget are props, overridable for tests.
+- `QuestionCard.tsx`: new optional `explanationScore` prop (graded
+  submission's 0–1 score). When provided and `isSubmitted`, mounts
+  `ExplanationPanel` after the worked solution per subpart.
+- `AssignmentDetailPage.tsx`: passes `explanationScore={submitScore}`.
+
+## Correctness caveat (documented decision)
+
+Per-subpart correctness is not exposed anywhere in the API (`Submission` has
+only an overall `score`). Per the plan's fallback, `is_correct` sent to the
+generator is derived from the overall score — `true` only on a perfect score.
+Conservative on purpose: for partially-correct submissions the explanation
+takes the "where this went wrong" framing, which still teaches even if that
+particular subpart happened to be right. A per-subpart grading breakdown is a
+candidate backlog item.
+
+## Tests
+
+- `ExplanationPanel.test.tsx` (5 tests): trigger→generate→poll→render;
+  existing-explanation short-circuit (no POST); stub badge + note; poll-budget
+  timeout with working retry; generation failure surfaces instead of polling
+  forever.
+- Backend: `pytest openshiksha/apps/ai/` — 357 passed (serializer change
+  covered by existing list/retrieve tests).
+- Full frontend suite 265 passed; `tsc --noEmit`, `eslint`, `vite build` clean.
+
+## Migration notes
+
+No model/migration changes — serializer-only on the backend.
+
+## Next steps
+
+ASA-5 (misconception clusters panel) closes today's batch. ASA-6/7 (assignment
+drafts, open-response grading) remain the next dark surfaces.

--- a/frontend_modern/src/features/student/AssignmentDetailPage.tsx
+++ b/frontend_modern/src/features/student/AssignmentDetailPage.tsx
@@ -219,6 +219,7 @@ export const AssignmentDetailPage = () => {
               answers={answers}
               onAnswerChange={handleAnswerChange}
               isSubmitted={isSubmitted}
+              explanationScore={submitScore}
             />
           ))}
         </div>

--- a/frontend_modern/src/features/student/ExplanationPanel.test.tsx
+++ b/frontend_modern/src/features/student/ExplanationPanel.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ExplanationPanel } from './ExplanationPanel';
+import type { SubpartExplanation } from './useExplanation';
+
+const { mockGet, mockPost } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPost: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    get: mockGet,
+    post: mockPost,
+  },
+}));
+
+const EXPLANATION: SubpartExplanation = {
+  id: 1,
+  question_subpart: 101,
+  question_text: 'What is 6 × 7?',
+  subpart_index: 0,
+  submission: 55,
+  student_answer: '41',
+  is_correct: false,
+  explanation_text: 'Close — 6 × 7 is 42, not 41. Think of it as 6 × 7 = 6 × 5 + 6 × 2.',
+  language: 'en',
+  grade_level: 8,
+  model_used: 'claude-haiku-4-5-20251001',
+  generated_at: '2026-06-09T10:00:00Z',
+};
+
+function renderPanel(props?: Partial<Parameters<typeof ExplanationPanel>[0]>) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ExplanationPanel
+        subpartId={101}
+        studentAnswer="41"
+        isCorrect={false}
+        pollIntervalMs={10}
+        maxPollAttempts={3}
+        {...props}
+      />
+    </QueryClientProvider>
+  );
+}
+
+describe('ExplanationPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts collapsed and generates then polls until the explanation arrives', async () => {
+    const user = userEvent.setup();
+    // First two list calls: empty (pre-generate check + first poll); then ready.
+    mockGet
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValue({ data: [EXPLANATION] });
+    mockPost.mockResolvedValue({ data: { detail: 'queued' } });
+
+    renderPanel();
+
+    const trigger = screen.getByRole('button', { name: /explain this answer/i });
+    expect(mockGet).not.toHaveBeenCalled();
+
+    await user.click(trigger);
+    await waitFor(() =>
+      expect(mockPost).toHaveBeenCalledWith('/ai/explanations/generate/', {
+        subpart_id: 101,
+        student_answer: '41',
+        is_correct: false,
+      })
+    );
+    expect(screen.getByText(/writing your explanation/i)).toBeDefined();
+
+    await waitFor(() => expect(screen.getByText(/6 × 7 is 42/)).toBeDefined());
+    expect(screen.getByText('✨ AI-generated')).toBeDefined();
+    expect(screen.getByText('Where this went wrong')).toBeDefined();
+  });
+
+  it('shows an existing explanation directly without re-generating', async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue({ data: { results: [EXPLANATION] } });
+
+    renderPanel();
+    await user.click(screen.getByRole('button', { name: /explain this answer/i }));
+
+    await waitFor(() => expect(screen.getByText(/6 × 7 is 42/)).toBeDefined());
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('labels stub-generated explanations transparently', async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue({ data: [{ ...EXPLANATION, model_used: 'stub' }] });
+
+    renderPanel({ isCorrect: true });
+    await user.click(screen.getByRole('button', { name: /explain this answer/i }));
+
+    await waitFor(() => expect(screen.getByText('Auto-explanation')).toBeDefined());
+    expect(screen.queryByText('✨ AI-generated')).toBeNull();
+    expect(screen.getByText('Why this answer is right')).toBeDefined();
+    expect(screen.getByText(/without an AI model/i)).toBeDefined();
+  });
+
+  it('gives up after the poll budget with a friendly error and a working retry', async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue({ data: [] });
+    mockPost.mockResolvedValue({ data: { detail: 'queued' } });
+
+    renderPanel();
+    await user.click(screen.getByRole('button', { name: /explain this answer/i }));
+
+    await waitFor(
+      () => expect(screen.getByText(/couldn't fetch an explanation just now/i)).toBeDefined(),
+      { timeout: 3000 }
+    );
+
+    // Retry: the explanation is ready this time.
+    mockGet.mockResolvedValue({ data: [EXPLANATION] });
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+    await waitFor(() => expect(screen.getByText(/6 × 7 is 42/)).toBeDefined());
+  });
+
+  it('surfaces a generation failure instead of polling forever', async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue({ data: [] });
+    mockPost.mockRejectedValue(new Error('rate limited'));
+
+    renderPanel();
+    await user.click(screen.getByRole('button', { name: /explain this answer/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/couldn't fetch an explanation just now/i)).toBeDefined()
+    );
+  });
+});

--- a/frontend_modern/src/features/student/ExplanationPanel.tsx
+++ b/frontend_modern/src/features/student/ExplanationPanel.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from 'react';
+import { RichContent } from '@/shared/ui/RichContent';
+import { Skeleton } from '@/shared/ui';
+import { useExplanationList, useGenerateExplanation } from './useExplanation';
+
+interface ExplanationPanelProps {
+  subpartId: number;
+  studentAnswer: string;
+  isCorrect: boolean;
+  /** Poll cadence while the async generation task runs. Overridable for tests. */
+  pollIntervalMs?: number;
+  /** Polls before giving up (~30 s at the default cadence). */
+  maxPollAttempts?: number;
+}
+
+/**
+ * Post-submit "Explain this answer" affordance — the first consumer of the
+ * /ai/explanations/ endpoints. Generation is async (202 + Celery), so after
+ * triggering it the panel polls the student-scoped list until the explanation
+ * row appears, then renders it with the standard AI-provenance badge.
+ *
+ * Explanations persist server-side: if one already exists for the subpart the
+ * panel shows it directly and never re-generates.
+ */
+export const ExplanationPanel = ({
+  subpartId,
+  studentAnswer,
+  isCorrect,
+  pollIntervalMs = 2000,
+  maxPollAttempts = 15,
+}: ExplanationPanelProps) => {
+  const [requested, setRequested] = useState(false);
+  const [attempts, setAttempts] = useState(0);
+
+  const listQuery = useExplanationList(subpartId, requested);
+  const generate = useGenerateExplanation();
+
+  const explanation = listQuery.data?.[0];
+  const timedOut = attempts >= maxPollAttempts;
+
+  // First list fetch came back empty → kick off generation exactly once
+  // (generate.isIdle guards re-fires; reset() re-arms it for retry).
+  useEffect(() => {
+    if (requested && listQuery.isSuccess && !explanation && generate.isIdle && !timedOut) {
+      generate.mutate({
+        subpart_id: subpartId,
+        student_answer: studentAnswer,
+        is_correct: isCorrect,
+      });
+    }
+  }, [requested, listQuery.isSuccess, explanation, generate, timedOut, subpartId, studentAnswer, isCorrect]);
+
+  // Poll the list while the Celery task runs; give up after maxPollAttempts.
+  useEffect(() => {
+    if (!requested || explanation || !generate.isSuccess || timedOut) return;
+    const timer = setTimeout(() => {
+      setAttempts((n) => n + 1);
+      void listQuery.refetch();
+    }, pollIntervalMs);
+    return () => clearTimeout(timer);
+  }, [requested, explanation, generate.isSuccess, timedOut, attempts, pollIntervalMs, listQuery]);
+
+  if (!requested) {
+    return (
+      <div className="mt-3">
+        <button
+          type="button"
+          onClick={() => setRequested(true)}
+          className="text-xs font-medium text-brand-700 hover:text-brand-800 transition-colors motion-reduce:transition-none focus:outline-none focus-visible:underline"
+        >
+          ✨ Explain this answer
+        </button>
+      </div>
+    );
+  }
+
+  if (explanation) {
+    const isStub = explanation.model_used === 'stub';
+    return (
+      <div className="mt-3 rounded-lg border border-brand-100 bg-brand-50 p-3">
+        <div className="flex items-center justify-between mb-1.5">
+          <span className="text-xs font-medium text-brand-800">
+            {isCorrect ? 'Why this answer is right' : 'Where this went wrong'}
+          </span>
+          <span className="text-[10px] font-medium uppercase tracking-wide text-ink-400">
+            {isStub ? 'Auto-explanation' : '✨ AI-generated'}
+          </span>
+        </div>
+        <div className="text-sm text-ink-800 leading-relaxed">
+          <RichContent text={explanation.explanation_text} variant="block" />
+        </div>
+        {isStub && (
+          <p className="mt-1.5 text-[10px] text-ink-400">
+            Generated without an AI model — explanations get richer once AI is configured.
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  if (generate.isError || listQuery.isError || timedOut) {
+    return (
+      <div className="mt-3 text-xs text-rose-600">
+        Couldn&apos;t fetch an explanation just now. Please try again in a moment.{' '}
+        <button
+          type="button"
+          onClick={() => {
+            setAttempts(0);
+            generate.reset();
+            void listQuery.refetch();
+          }}
+          className="font-medium underline hover:text-rose-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 rounded"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-3 rounded-lg border border-brand-100 bg-brand-50 p-3">
+      <p className="text-xs text-brand-800 mb-2">Writing your explanation…</p>
+      <div className="space-y-1.5">
+        <Skeleton w="w-full" h="h-3" />
+        <Skeleton w="w-5/6" h="h-3" />
+        <Skeleton w="w-2/3" h="h-3" />
+      </div>
+    </div>
+  );
+};

--- a/frontend_modern/src/features/student/QuestionCard.tsx
+++ b/frontend_modern/src/features/student/QuestionCard.tsx
@@ -4,6 +4,7 @@ import { InteractiveWidget } from '@/shared/ui/InteractiveWidget';
 import { RichContent } from '@/shared/ui/RichContent';
 import { getWidgetModule } from '@/widgets/registry';
 import { useHints } from './useHints';
+import { ExplanationPanel } from './ExplanationPanel';
 
 interface QuestionCardProps {
   question: Question;
@@ -11,6 +12,14 @@ interface QuestionCardProps {
   answers: Record<string, string>;
   onAnswerChange: (subpartId: number, value: string) => void;
   isSubmitted: boolean;
+  /**
+   * Graded submission's overall score (0–1). Providing it enables the
+   * post-submit "Explain this answer" affordance per subpart. Per-subpart
+   * correctness isn't exposed by the API, so the explanation's framing is
+   * derived from the overall score (correct only on a perfect score —
+   * conservative, the "what went wrong" framing still teaches).
+   */
+  explanationScore?: number | null;
 }
 
 /**
@@ -232,6 +241,7 @@ export const QuestionCard = ({
   answers,
   onAnswerChange,
   isSubmitted,
+  explanationScore,
 }: QuestionCardProps) => {
   const handleChange = useCallback(
     (subpartId: number, value: string) => onAnswerChange(subpartId, value),
@@ -379,6 +389,14 @@ export const QuestionCard = ({
                 label="Show worked solution"
                 content={subpart.solution_text}
                 tone="solution"
+              />
+            )}
+
+            {isSubmitted && explanationScore !== undefined && (
+              <ExplanationPanel
+                subpartId={subpart.id}
+                studentAnswer={value}
+                isCorrect={explanationScore != null && explanationScore >= 0.999}
               />
             )}
           </div>

--- a/frontend_modern/src/features/student/useExplanation.ts
+++ b/frontend_modern/src/features/student/useExplanation.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+
+export interface SubpartExplanation {
+  id: number;
+  question_subpart: number;
+  question_text: string;
+  subpart_index: number;
+  submission: number | null;
+  student_answer: unknown;
+  is_correct: boolean;
+  explanation_text: string;
+  language: string;
+  grade_level: number;
+  model_used: string;
+  generated_at: string;
+}
+
+/**
+ * Explanations are generated asynchronously (POST /generate/ returns 202 and
+ * queues a Celery task), so the consumer polls this list query until the row
+ * for the subpart appears. Explanations persist server-side — once one exists
+ * for a subpart it is shown directly and never re-generated.
+ */
+export const useExplanationList = (subpartId: number, enabled: boolean) =>
+  useQuery<SubpartExplanation[]>({
+    queryKey: ['ai', 'explanations', subpartId],
+    queryFn: async () => {
+      const { data } = await apiClient.get<
+        SubpartExplanation[] | { results: SubpartExplanation[] }
+      >(`/ai/explanations/?subpart=${subpartId}`);
+      return Array.isArray(data) ? data : data.results ?? [];
+    },
+    enabled,
+    staleTime: Infinity,
+  });
+
+export interface GenerateExplanationPayload {
+  subpart_id: number;
+  student_answer: string;
+  is_correct: boolean;
+}
+
+export const useGenerateExplanation = () =>
+  useMutation<void, Error, GenerateExplanationPayload>({
+    mutationFn: async (payload) => {
+      await apiClient.post('/ai/explanations/generate/', payload);
+    },
+  });


### PR DESCRIPTION
## Classification
New — AI Surface Activation initiative, ASA-4 (docs/daily-plans/2026-06-09-plan.md). Lights up the first of the four dark AI endpoint groups.

## Legacy reference
None — legacy showed marks only after grading. This turns the grading surface into a teaching moment.

## What changed
- **`ExplanationPanel`** (new): collapsed '✨ Explain this answer' per subpart in the post-submit block → checks for an existing explanation (shown directly, never re-generated) → otherwise POST `/ai/explanations/generate/` (202) and bounded poll (2 s × 15 ≈ 30 s) → labelled panel with the standard `✨ AI-generated` / `Auto-explanation` + stub-note badge pair. Timeout/error → friendly inline error with working Retry; trigger is idempotent.
- **`useExplanation.ts`** (new): list query (handles paginated + plain shapes, `staleTime: Infinity`) + generate mutation.
- **`QuestionCard`**: opt-in `explanationScore` prop; **`AssignmentDetailPage`** passes the graded score.
- **Backend (1 line)**: `SubpartExplanationSerializer` exposes `model_used` for the provenance badge (plan assumed it was already serialized; it wasn't).

## Documented decision
Per-subpart correctness isn't exposed by the API — `is_correct` is derived from the overall score (true only on a perfect score). Conservative: the 'where this went wrong' framing still teaches when a subpart was actually right. Per-subpart grade breakdown is a backlog candidate.

## Tests
- `ExplanationPanel.test.tsx` — 5 tests: generate→poll→render, existing-explanation short-circuit, stub badge, timeout+retry, generation-failure path.
- Backend `pytest apps/ai/` 357 passed; full frontend suite 265 passed; tsc/eslint/build clean.

## How to verify
Submit an assignment → each subpart shows '✨ Explain this answer' → click → skeleton 'Writing your explanation…' → explanation panel with provenance badge appears (stub text if no ANTHROPIC_API_KEY).

🤖 Generated with [Claude Code](https://claude.com/claude-code)