### PR TITLE
feat(teacher): ASA-5 — class misconception clusters panel (first /ai/misconception-clusters/ consumer)

### DIFF
--- a/docs/changes/2026-06-09-asa5-misconception-clusters.md
+++ b/docs/changes/2026-06-09-asa5-misconception-clusters.md
@@ -1,0 +1,60 @@
+# ASA-5 — Teacher MisconceptionClustersPanel (first consumer of /ai/misconception-clusters/)
+
+**Date**: 2026-06-09
+**Classification**: New
+**Initiative**: AI Surface Activation (ASA-5)
+
+## Summary
+
+`/ai/misconception-clusters/` (list + async refresh, teacher-scoped, fully
+built and tested on the backend) had zero frontend consumers. The teacher
+dashboard's per-room insights disclosure now includes a "Class Misconceptions"
+panel: aggregated misconception patterns across the class, each with affected
+student count, a sample diagnosis, and a concrete remediation tip.
+
+## Legacy reference
+
+Legacy `edge/` gave teachers aggregate scores per class — never anything
+diagnostic. Clusters give the *why* behind low scores; legacy never attempted
+this. Internal pattern reference: `InterventionsPanel` (collapsible section,
+per-room scoping, refresh action, lazy fetch).
+
+## What changed
+
+- `frontend_modern/src/features/teacher/useMisconceptionClusters.ts` (new):
+  list query (`?subject_room=<id>`, handles paginated + plain shapes, lazy via
+  `enabled`) + refresh mutation (`POST /refresh/` → 202; delayed invalidate
+  ~2.5 s later to pick up the async recompute, same convention as
+  `useGenerateInterventions`).
+- `frontend_modern/src/features/teacher/MisconceptionClustersPanel.tsx` (new):
+  collapsed by default; count badge in the header; per-cluster card renders
+  exactly what the serializer exposes (`misconception_label`, `student_count`
+  with attention-tone badge at ≥3, `sample_diagnosis`,
+  `sample_remediation_tip`, `occurrence_count`, `last_seen`, `refreshed_at`).
+  Refresh button → "Recomputing…" status note; inline error on failure.
+  No AI/stub badge — the cluster serializer carries no `model_used` field
+  (clusters are aggregations of per-student diagnoses).
+- `frontend_modern/src/features/teacher/TeacherDashboard.tsx`: panel mounted
+  in `RoomInsights` between `InterventionsPanel` and `QuestionQualityPanel` —
+  inside the existing lazy disclosure, so no extra fetches on first paint.
+
+## Tests
+
+`npx vitest run MisconceptionClustersPanel` — 5 tests passing: collapsed by
+default + fetch-on-open (loading state asserted via deferred promise);
+populated cluster details; explanatory empty state; refresh queued +
+recompute status; inline refresh error. Role gating is server-side
+(teacher-scoped queryset) and the panel only mounts on the teacher dashboard.
+
+`npx tsc --noEmit`, `npm run lint`, `npm run build` clean. No backend changes.
+
+## Migration notes
+
+None — frontend only.
+
+## Next steps
+
+Batch ASA-1..5 complete. ASA-6 (assignment-draft builder UI) and ASA-7
+(open-response grading UI) are the remaining dark surfaces — each a
+batch-anchor for a future run. ASA-9 (backend same-day review idempotency)
+remains in the backlog.

--- a/frontend_modern/src/features/teacher/MisconceptionClustersPanel.test.tsx
+++ b/frontend_modern/src/features/teacher/MisconceptionClustersPanel.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { MisconceptionClustersPanel } from './MisconceptionClustersPanel';
+import type { MisconceptionCluster } from './useMisconceptionClusters';
+
+const { mockGet, mockPost } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPost: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    get: mockGet,
+    post: mockPost,
+  },
+}));
+
+const CLUSTER: MisconceptionCluster = {
+  id: 3,
+  subject_room: 1,
+  subject_name: 'Mathematics',
+  misconception_label: 'Adds denominators when adding fractions',
+  student_count: 4,
+  occurrence_count: 11,
+  sample_diagnosis: 'Students treat 1/2 + 1/3 as 2/5 by adding tops and bottoms separately.',
+  sample_remediation_tip: 'Re-derive common denominators with a fraction-wall visual.',
+  window_start: '2026-05-10',
+  last_seen: '2026-06-08T10:00:00Z',
+  refreshed_at: '2026-06-09T06:00:00Z',
+};
+
+function renderPanel() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MisconceptionClustersPanel subjectRoomId={1} />
+    </QueryClientProvider>
+  );
+}
+
+describe('MisconceptionClustersPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is collapsed by default and only fetches when opened', async () => {
+    const user = userEvent.setup();
+    let resolveGet!: (value: { data: { results: MisconceptionCluster[] } }) => void;
+    mockGet.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveGet = resolve;
+        })
+    );
+
+    renderPanel();
+    expect(mockGet).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: /class misconceptions/i }));
+    expect(screen.getByText(/loading misconceptions/i)).toBeDefined();
+
+    resolveGet({ data: { results: [CLUSTER] } });
+    await waitFor(() =>
+      expect(screen.getByText('Adds denominators when adding fractions')).toBeDefined()
+    );
+    expect(mockGet).toHaveBeenCalledWith('/ai/misconception-clusters/?subject_room=1');
+  });
+
+  it('renders cluster details: affected students, diagnosis, tip, occurrences', async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue({ data: [CLUSTER] });
+
+    renderPanel();
+    await user.click(screen.getByRole('button', { name: /class misconceptions/i }));
+
+    await waitFor(() => expect(screen.getByText('4 students')).toBeDefined());
+    expect(screen.getByText(/treat 1\/2 \+ 1\/3 as 2\/5/)).toBeDefined();
+    expect(screen.getByText(/fraction-wall visual/)).toBeDefined();
+    expect(screen.getByText(/Seen 11 times/)).toBeDefined();
+  });
+
+  it('explains what unlocks clusters when there are none yet', async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue({ data: [] });
+
+    renderPanel();
+    await user.click(screen.getByRole('button', { name: /class misconceptions/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/no misconception patterns detected yet/i)).toBeDefined()
+    );
+  });
+
+  it('queues a refresh and confirms the recompute is underway', async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue({ data: [CLUSTER] });
+    mockPost.mockResolvedValue({ data: { detail: 'queued' } });
+
+    renderPanel();
+    await user.click(screen.getByRole('button', { name: /class misconceptions/i }));
+    await waitFor(() => expect(screen.getByText('4 students')).toBeDefined());
+
+    await user.click(screen.getByRole('button', { name: /refresh/i }));
+
+    await waitFor(() =>
+      expect(mockPost).toHaveBeenCalledWith('/ai/misconception-clusters/refresh/', {
+        subject_room_id: 1,
+      })
+    );
+    await waitFor(() => expect(screen.getByRole('status')).toBeDefined());
+  });
+
+  it('shows an inline error when the refresh fails', async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue({ data: [CLUSTER] });
+    mockPost.mockRejectedValue(new Error('boom'));
+
+    renderPanel();
+    await user.click(screen.getByRole('button', { name: /class misconceptions/i }));
+    await waitFor(() => expect(screen.getByText('4 students')).toBeDefined());
+
+    await user.click(screen.getByRole('button', { name: /refresh/i }));
+
+    await waitFor(() => expect(screen.getByText(/couldn't refresh just now/i)).toBeDefined());
+  });
+});

--- a/frontend_modern/src/features/teacher/MisconceptionClustersPanel.tsx
+++ b/frontend_modern/src/features/teacher/MisconceptionClustersPanel.tsx
@@ -1,0 +1,112 @@
+import { useState } from 'react';
+import { Badge, Button } from '@/shared/ui';
+import {
+  useMisconceptionClusters,
+  useRefreshMisconceptionClusters,
+  type MisconceptionCluster,
+} from './useMisconceptionClusters';
+
+const formatDate = (iso: string): string =>
+  new Date(iso).toLocaleDateString('en-IN', { day: 'numeric', month: 'short' });
+
+const ClusterCard = ({ cluster }: { cluster: MisconceptionCluster }) => (
+  <div className="rounded-xl border border-ink-100 bg-paper p-4">
+    <div className="flex items-start justify-between gap-3">
+      <p className="font-display text-base text-ink-900 leading-tight min-w-0">
+        {cluster.misconception_label}
+      </p>
+      <Badge tone={cluster.student_count >= 3 ? 'attention' : 'neutral'} className="shrink-0">
+        {cluster.student_count} student{cluster.student_count !== 1 ? 's' : ''}
+      </Badge>
+    </div>
+
+    {cluster.sample_diagnosis && (
+      <p className="mt-2 text-sm text-ink-700 leading-relaxed">{cluster.sample_diagnosis}</p>
+    )}
+
+    {cluster.sample_remediation_tip && (
+      <p className="mt-2 text-xs text-ink-600">
+        <span className="font-semibold">Try in class:</span> {cluster.sample_remediation_tip}
+      </p>
+    )}
+
+    <p className="mt-3 text-xs text-ink-400">
+      Seen {cluster.occurrence_count} time{cluster.occurrence_count !== 1 ? 's' : ''} · last on{' '}
+      {formatDate(cluster.last_seen)} · updated {formatDate(cluster.refreshed_at)}
+    </p>
+  </div>
+);
+
+interface Props {
+  subjectRoomId: number;
+}
+
+/**
+ * Class-level misconception clusters — the first consumer of
+ * /ai/misconception-clusters/. Aggregates per-student misconception
+ * diagnoses into patterns a teacher can address with the whole class.
+ * Collapsed by default like its sibling insight panels; data only loads
+ * when a teacher opens it.
+ */
+export const MisconceptionClustersPanel = ({ subjectRoomId }: Props) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const { data: clusters, isLoading } = useMisconceptionClusters(subjectRoomId, isExpanded);
+  const refresh = useRefreshMisconceptionClusters(subjectRoomId);
+
+  const items = clusters ?? [];
+
+  return (
+    <div className="mt-3 border-t border-ink-100 pt-3">
+      <button
+        onClick={() => setIsExpanded((v) => !v)}
+        aria-expanded={isExpanded}
+        className="flex items-center gap-1.5 text-xs font-semibold text-ink-500 hover:text-ink-800 transition-colors w-full text-left"
+      >
+        <span>Class Misconceptions</span>
+        {items.length > 0 && <Badge tone="brand">{items.length}</Badge>}
+        <span className={`ml-auto transition-transform ${isExpanded ? 'rotate-180' : ''}`}>▾</span>
+      </button>
+
+      {isExpanded && (
+        <div className="mt-3 space-y-3">
+          {isLoading && <p className="text-xs text-ink-400 py-2">Loading misconceptions…</p>}
+
+          {!isLoading && items.length === 0 && (
+            <div className="text-xs text-ink-500 py-2">
+              No misconception patterns detected yet — they appear once students have a few graded
+              assignments in this class.
+            </div>
+          )}
+
+          {!isLoading && items.map((c) => <ClusterCard key={c.id} cluster={c} />)}
+
+          {refresh.isError && (
+            <p className="text-xs text-rose-600 pt-1">
+              Couldn&apos;t refresh just now. Please try again in a moment.
+            </p>
+          )}
+
+          {refresh.isSuccess && (
+            <p className="text-xs text-ink-400 pt-1" role="status">
+              Recomputing from recent submissions — new patterns appear here shortly.
+            </p>
+          )}
+
+          <div className="flex items-center justify-between pt-1">
+            <p className="text-xs text-ink-400">
+              Patterns across the whole class — address them once, help everyone.
+            </p>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={refresh.isPending}
+              onClick={() => refresh.mutate()}
+            >
+              {refresh.isPending ? 'Refreshing…' : 'Refresh'}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend_modern/src/features/teacher/TeacherDashboard.tsx
+++ b/frontend_modern/src/features/teacher/TeacherDashboard.tsx
@@ -6,6 +6,7 @@ import { useProblemSets } from './useProblemSets';
 import { ClassHealthPanel } from './ClassHealthPanel';
 import { WeeklyReportPanel } from './WeeklyReportPanel';
 import { InterventionsPanel } from './InterventionsPanel';
+import { MisconceptionClustersPanel } from './MisconceptionClustersPanel';
 import { QuestionQualityPanel } from './QuestionQualityPanel';
 import { ClassroomCodeWidget } from './ClassroomCodeWidget';
 import { NeedsAttentionPanel } from './NeedsAttentionPanel';
@@ -81,6 +82,7 @@ const RoomInsights = ({ subjectRoomId }: { subjectRoomId: number }) => {
           <ClassHealthPanel subjectRoomId={subjectRoomId} />
           <WeeklyReportPanel subjectRoomId={subjectRoomId} />
           <InterventionsPanel subjectRoomId={subjectRoomId} />
+          <MisconceptionClustersPanel subjectRoomId={subjectRoomId} />
           <QuestionQualityPanel subjectRoomId={subjectRoomId} />
         </div>
       )}

--- a/frontend_modern/src/features/teacher/useMisconceptionClusters.ts
+++ b/frontend_modern/src/features/teacher/useMisconceptionClusters.ts
@@ -1,0 +1,50 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+
+export interface MisconceptionCluster {
+  id: number;
+  subject_room: number;
+  subject_name: string;
+  misconception_label: string;
+  student_count: number;
+  occurrence_count: number;
+  sample_diagnosis: string;
+  sample_remediation_tip: string;
+  window_start: string;
+  last_seen: string;
+  refreshed_at: string;
+}
+
+const fetchClusters = async (subjectRoomId: number): Promise<MisconceptionCluster[]> => {
+  const { data } = await apiClient.get<
+    MisconceptionCluster[] | { results: MisconceptionCluster[] }
+  >(`/ai/misconception-clusters/?subject_room=${subjectRoomId}`);
+  return Array.isArray(data) ? data : data.results ?? [];
+};
+
+export const useMisconceptionClusters = (subjectRoomId: number, enabled: boolean) =>
+  useQuery<MisconceptionCluster[]>({
+    queryKey: ['ai', 'misconception-clusters', subjectRoomId],
+    queryFn: () => fetchClusters(subjectRoomId),
+    staleTime: 5 * 60 * 1000,
+    enabled,
+  });
+
+export const useRefreshMisconceptionClusters = (subjectRoomId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      await apiClient.post('/ai/misconception-clusters/refresh/', {
+        subject_room_id: subjectRoomId,
+      });
+    },
+    onSuccess: () => {
+      // Recompute is async on the server; refetch shortly after to pick up new rows.
+      setTimeout(() => {
+        queryClient.invalidateQueries({
+          queryKey: ['ai', 'misconception-clusters', subjectRoomId],
+        });
+      }, 2500);
+    },
+  });
+};


### PR DESCRIPTION
## Classification
New — AI Surface Activation initiative, ASA-5 (docs/daily-plans/2026-06-09-plan.md). Lights up the second of the four dark AI endpoint groups; completes today's ASA-1..5 batch.

## Legacy reference
Legacy `edge/` gave teachers aggregate scores only — nothing diagnostic. Internal pattern reference: `InterventionsPanel` (collapsible, per-room, lazy fetch, refresh convention).

## What changed
- **`MisconceptionClustersPanel`** (new): collapsed-by-default 'Class Misconceptions' section in each room's insights disclosure. Cluster cards render exactly the serializer's fields: label, student-count badge (attention tone at ≥3), sample diagnosis, 'Try in class' remediation tip, occurrence/recency footer. Refresh → POST `/refresh/` (202) with a 'Recomputing…' status note and delayed refetch; inline error on failure. No AI/stub badge — `ClassMisconceptionClusterSerializer` carries no `model_used`.
- **`useMisconceptionClusters.ts`** (new): lazy list query + refresh mutation (same delayed-invalidate convention as interventions).
- **`TeacherDashboard`**: mounted between `InterventionsPanel` and `QuestionQualityPanel` — inside the existing lazy disclosure, zero extra fetches on first paint.

## Tests
- `MisconceptionClustersPanel.test.tsx` — 5 tests: collapsed/fetch-on-open with asserted loading state, populated details, explanatory empty state, refresh queued + status, refresh error.
- `tsc --noEmit`, `eslint`, `vite build` clean. No backend changes.

## How to verify
Teacher dashboard → a subject room → 'View class insights' → 'Class Misconceptions' → expand (with `seed_demo_data`, clusters render; otherwise the explanatory empty state). Refresh queues a recompute and notes it inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)