### PR TITLE
docs(initiatives): ASA batch 1 ledger — ASA-1..5 shipped (#285–#289)

### DIFF
--- a/docs/initiatives/STATUS.md
+++ b/docs/initiatives/STATUS.md
@@ -4,14 +4,23 @@
 > task advances the **top active initiative** here. See [`README.md`](README.md)
 > for how. Keep this file short - one row per initiative.
 
-**Last updated:** 2026-06-09 (later) — **New top initiative promoted: [AI
-Surface Activation](ai-surface-activation.md).** The 2026-06-09 AI-surfaces
-audit ([polish-backlog](../ai-features/polish-backlog.md)) found four shipped,
-tested `/ai/` endpoint groups with **zero frontend consumers**
-(explanations, misconception-clusters, assignment-drafts, open-response
-rubrics/grades) plus inert/inconsistent edges on live AI panels. Activation —
-wiring paid-for backend value into the product — is the highest-leverage next
-bet. First batch (ASA-1..5) planned in
+**Last updated:** 2026-06-09 (evening) — **ASA first batch shipped: ASA-1..5
+across [#285](https://github.com/openshiksha/openshiksha/pull/285)–[#289](https://github.com/openshiksha/openshiksha/pull/289).**
+Students now get post-submit AI answer explanations (first `/ai/explanations/`
+consumer, #288); teachers get class misconception clusters (first
+`/ai/misconception-clusters/` consumer, #289); recommendation rows click
+through to chapter practice (#286); `DueForReviewPanel` got the
+skeleton/empty-state pattern (#285); and the SRS drill can no longer
+double-run SM-2 in one sitting (#287). **2 of the 4 dark endpoint groups are
+now lit** — ASA-6 (assignment drafts) and ASA-7 (open-response grading) are
+the remaining ones, each a batch-anchor for a future run.
+
+Earlier same day — **AI Surface Activation promoted as top initiative.** The
+2026-06-09 AI-surfaces audit ([polish-backlog](../ai-features/polish-backlog.md))
+found four shipped, tested `/ai/` endpoint groups with **zero frontend
+consumers** (explanations, misconception-clusters, assignment-drafts,
+open-response rubrics/grades) plus inert/inconsistent edges on live AI panels.
+First batch (ASA-1..5) planned in
 [2026-06-09-plan.md](../daily-plans/2026-06-09-plan.md).
 
 Earlier same day — **Authoring Integrity & Versioning closed —
@@ -40,7 +49,7 @@ at 160 kB defends the cut.
 
 | Priority | Initiative | Status | Headline progress | Next increment |
 |:--:|---|---|---|---|
-| 1 | [AI Surface Activation](ai-surface-activation.md) | Active | Promoted 2026-06-09. Four tested `/ai/` endpoint groups have no frontend consumer; live AI panels have inert edges (inert recommendation rows, `DueForReviewPanel` pop-in, SRS double-review). Backlog ASA-1..9 scoped. | ASA-1 (DueForReviewPanel skeleton/empty) → ASA-2 → ASA-3 → ASA-4 (explanations UI) → ASA-5 (misconception clusters panel) |
+| 1 | [AI Surface Activation](ai-surface-activation.md) | Active | **ASA-1..5 shipped 2026-06-09** ([#285](https://github.com/openshiksha/openshiksha/pull/285)–[#289](https://github.com/openshiksha/openshiksha/pull/289)): panel-state polish, recommendation click-through, SRS repeat-review guard, and first consumers for `/ai/explanations/` + `/ai/misconception-clusters/`. 2 of 4 dark endpoint groups lit. | ASA-6 (assignment-draft builder UI — full generate→review→approve workflow, batch-anchor) → ASA-7 (open-response grading UI) → ASA-8/9 cleanups |
 | - | [Authoring Integrity & Versioning](authoring-integrity-versioning.md) | Done | **All three phases shipped 2026-06-08/09.** Phase 1 (AIV-1..3, [#270](https://github.com/openshiksha/openshiksha/pull/270)–[#274](https://github.com/openshiksha/openshiksha/pull/274)): snapshot foundation + grader/student readers + edit-safety UI. Phase 2 (AIV-4/5, [#276](https://github.com/openshiksha/openshiksha/pull/276)–[#277](https://github.com/openshiksha/openshiksha/pull/277)): editable preview + drift surface. Phase 3 (AIV-6/7/8, [#279](https://github.com/openshiksha/openshiksha/pull/279)–[#281](https://github.com/openshiksha/openshiksha/pull/281)): guarded re-sync + `ProblemSetVersion` dedup + version history & diff UI. DoD met end-to-end. | - |
 | - | [Teacher Workspace](teacher-workspace.md) | Done | Closed 2026-06-09 with **TW-2** (editable preview) shipped in [#276](https://github.com/openshiksha/openshiksha/pull/276). Earlier increments: TW-1, TW-3a/b, TW-4, TW-5, TW-6, TW-7 closed 2026-06-07 across [#250](https://github.com/openshiksha/openshiksha/pull/250), [#261](https://github.com/openshiksha/openshiksha/pull/261)–[#266](https://github.com/openshiksha/openshiksha/pull/266). | - |
 | - | [Performance Budget](performance-budget.md) | Done | Closed 2026-06-07. PERF-01..04 + PERF-06 shipped in one batch ([#251](https://github.com/openshiksha/openshiksha/pull/251)–[#255](https://github.com/openshiksha/openshiksha/pull/255)); follow-up ([#256](https://github.com/openshiksha/openshiksha/pull/256)) dropped `ReactQueryDevtools` in prod, added a measurement harness, and fixed a `@/shared/ui` barrel-export leak that was dragging DOMPurify into the entry chunk. Entry chunk **855 → 93 kB / 247 → 29 kB gzip** (88% gzip drop); vendor split, route-level `React.lazy`, lazy KaTeX behind `<RichContent>`, CI budget guard at 160 kB. Measured `/login` FCP under Slow 4G + 4× CPU: 4.4 s. | - |

--- a/docs/initiatives/ai-surface-activation.md
+++ b/docs/initiatives/ai-surface-activation.md
@@ -62,11 +62,11 @@ the platform earns trust by always labelling what is AI vs. data-derived.
 
 | ID | Increment | Status |
 |----|-----------|--------|
-| ASA-1 | `DueForReviewPanel` consistency: loading skeleton + explanatory empty state (same pattern as #283) | ☐ |
-| ASA-2 | Recommendation rows click-through → `/student/browse/chapter/:id` ("Practice" affordance per row) | ☐ |
-| ASA-3 | SRS drill repeat-review guard: second pass in one sitting is practice-only, never a second SM-2 update | ☐ |
-| ASA-4 | Wire `/ai/explanations/` into post-submit assignment feedback (per-subpart "Explain" → generate → poll → labelled explanation) | ☐ |
-| ASA-5 | Teacher `MisconceptionClustersPanel` on dashboard (list + refresh + AI labels) | ☐ |
+| ASA-1 | `DueForReviewPanel` consistency: loading skeleton + explanatory empty state (same pattern as #283) | ✅ [#285](https://github.com/openshiksha/openshiksha/pull/285) |
+| ASA-2 | Recommendation rows click-through → `/student/browse/chapter/:id` ("Practice" affordance per row) | ✅ [#286](https://github.com/openshiksha/openshiksha/pull/286) |
+| ASA-3 | SRS drill repeat-review guard: second pass in one sitting is practice-only, never a second SM-2 update | ✅ [#287](https://github.com/openshiksha/openshiksha/pull/287) |
+| ASA-4 | Wire `/ai/explanations/` into post-submit assignment feedback (per-subpart "Explain" → generate → poll → labelled explanation) | ✅ [#288](https://github.com/openshiksha/openshiksha/pull/288) |
+| ASA-5 | Teacher `MisconceptionClustersPanel` on dashboard (list + refresh + AI labels) | ✅ [#289](https://github.com/openshiksha/openshiksha/pull/289) |
 | ASA-6 | Assignment draft builder UI (`/ai/assignment-drafts/`): generate → review rationale → approve into a real Assignment / dismiss | ☐ |
 | ASA-7 | Open-response grading UI (`/ai/open-rubrics/` + `/ai/open-grades/`) — teacher review surface | ☐ |
 | ASA-8 | Explanations on the SRS drill result screen (reuse ASA-4's hook/panel) | ☐ |
@@ -99,3 +99,8 @@ frontend consumer; every AI surface passes the checklist audit; recommendations
 | Date | Increment | PR | Learning |
 |------|-----------|----|----------|
 | 2026-06-09 | Initiative promoted; ASA-1..5 planned as today's batch | — | Seeded by the polish-backlog audit: 4 endpoint groups had no consumer. |
+| 2026-06-09 | ASA-1 — DueForReviewPanel skeleton + empty state | [#285](https://github.com/openshiksha/openshiksha/pull/285) | `useSpacedRepetitionDue` already exposed `isLoading`/`isError`; pure pattern copy from #283. |
+| 2026-06-09 | ASA-2 — recommendation rows → chapter practice | [#286](https://github.com/openshiksha/openshiksha/pull/286) | `chapter` was on the payload all along; pill styling shared with DueForReviewPanel keeps the action language consistent. |
+| 2026-06-09 | ASA-3 — SRS repeat-review guard | [#287](https://github.com/openshiksha/openshiksha/pull/287) | Plan's "grade locally" assumption was wrong (no client-side correctness); practice rounds are unscored — the guard (one SM-2 update per sitting) is what matters. ASA-9 stays for defence-in-depth. |
+| 2026-06-09 | ASA-4 — post-submit answer explanations | [#288](https://github.com/openshiksha/openshiksha/pull/288) | Serializer lacked `model_used` (1-line fix). Per-subpart correctness doesn't exist in the API — derived conservatively from overall score; per-subpart grade breakdown is a backlog candidate. |
+| 2026-06-09 | ASA-5 — teacher misconception clusters panel | [#289](https://github.com/openshiksha/openshiksha/pull/289) | Cluster serializer has no `model_used` (aggregation, not generation) — no badge needed. InterventionsPanel pattern copied wholesale; 2 of 4 dark endpoint groups now lit. |


### PR DESCRIPTION
## Classification
Docs — initiative bookkeeping for today's AI Surface Activation batch.

## What changed
- `ai-surface-activation.md`: backlog rows ASA-1..5 marked ✅ with PR links; 5 ledger rows with per-item learnings (incl. the two plan deviations: no client-side grading for ASA-3 practice rounds, and the missing `model_used` serializer field found in ASA-4).
- `STATUS.md`: headline + priority row updated — 2 of 4 dark endpoint groups lit; next increments ASA-6/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)