### PR TITLE
polish(ai): misconception clusters — list-error state + skeleton loading

### DIFF
--- a/docs/ai-features/polish-backlog.md
+++ b/docs/ai-features/polish-backlog.md
@@ -158,31 +158,65 @@ full reload.
 
 ---
 
-## Remaining gaps (audit notes — not yet addressed)
+## 2026-06-10 — Class misconception insights: list-error state + skeleton loading
 
-- **Natural language explanations** — backend `SubpartExplanationViewSet` is
-  registered (`/ai/explanations/`) but is **not consumed anywhere in
-  `frontend_modern`**. The post-grading student feedback surface appears to be
-  unwired in the V2 app. Needs UX placement work (inline after feedback) — sizeable,
-  flag before treating as polish vs. feature.
-- **Interventions (`InterventionsPanel`)** — ✅ done 2026-06-08. Per-card
-  `✨ AI-generated` vs `Auto-strategy` badge + stub note, plus a generation-error
-  state, now consistent with `WeeklyReportPanel` and `NarrativeCard`.
+**Surface:** Class misconception insights (teacher dashboard
+`MisconceptionClustersPanel`, shipped the previous day in ASA-5 / #289).
+
+**Gaps (checklist #1 error states, #2 loading states):**
+1. The list query's `isError` was never read, so a **failed fetch rendered the
+   empty state** — "No misconception patterns detected yet" — telling the
+   teacher their class looks clean when the server was simply unreachable.
+   An error must never masquerade as an all-clear.
+2. Loading was a bare "Loading misconceptions…" text line instead of the
+   shape-matched skeleton its sibling student panels adopted in ASA-1, so the
+   expanded section reflowed when data landed.
+
+**Fix:**
+- Destructured `isError`/`refetch` from `useMisconceptionClusters`; a failed
+  fetch now shows "Couldn't load misconception patterns just now." with an
+  inline **Retry** button (same pattern as `ExplanationPanel`). The empty
+  state only renders on a *successful* empty response.
+- Added `ClusterCardSkeleton` (mirrors the `ClusterCard` layout: label line +
+  badge pill + two body lines + footer line) shown twice while loading.
+- Tests: loading shows skeletons not the empty state; failed fetch shows the
+  error + Retry (and not the empty state); retry recovers to real data
+  (checklist #8).
+
+**Verify:** Teacher dashboard → expand "Class Misconceptions" with the API
+unreachable → red "Couldn't load…" line with Retry, not the empty state.
+While loading → two pulsing card skeletons.
+
+---
+
+## Remaining gaps (audit notes — updated 2026-06-10)
+
+- **Error-as-empty-state in `InterventionsPanel` and `WeeklyReportPanel`** —
+  both ignore the list query's `isError`, so a failed fetch renders "No
+  struggling students flagged yet" / "No weekly summary yet". Same misleading
+  pattern just fixed on `MisconceptionClustersPanel`; both also use bare-text
+  loading instead of skeletons. Prime candidate for the next polish run
+  (one panel per PR).
+- **Misconception cluster cards lack AI provenance** — `sample_diagnosis` /
+  `sample_remediation_tip` are copied from LLM-generated `StudentMisconception`
+  rows but `ClassMisconceptionCluster` carries no `model_used`, so the cards
+  can't show the `✨ AI-generated` vs stub badge used everywhere else. Needs a
+  model field + migration → guardrailed out of polish runs; note for ASA.
+- **Refresh confirmation lingers** — `MisconceptionClustersPanel`'s
+  "Recomputing from recent submissions…" status stays visible after the
+  delayed refetch lands; could clear once new data arrives. Minor.
 - **Hint system** — solid: loading ("Thinking of a good hint…"), error, and
   exhausted states all present. Low priority.
-- **Unwired backend surfaces (2026-06-09 audit)** — besides `/ai/explanations/`,
-  three more AI endpoints have **no `frontend_modern` consumer at all**:
-  `/ai/misconception-clusters/` (class misconception insights),
-  `/ai/assignment-drafts/` (assignment draft builder), and
-  `/ai/open-rubrics/` + `/ai/open-grades/` (open-response grading). Wiring each
-  is UI-build work, not polish — flagging here rather than building.
-- **Content recommendations rows are inert** — each row shows chapter + reason
-  but offers no click-through to actually practice that chapter
-  (`problem_set` is on the payload but unused). Needs a routing decision
-  (browse-by-chapter vs problem-set link); small feature, not pure polish.
-- **SRS drill result screen** — "Review again" lets a student immediately
-  resubmit the same drill, which re-runs the SM-2 update and can double-move
-  the interval in one sitting. Worth a guard or copy tweak on a future run.
-- **`DueForReviewPanel`** — same render-`null`-while-loading pop-in pattern
-  that was just fixed on `RecommendationsPanel`; lower impact (panel is below
-  the fold) but should be made consistent on a future run.
+- **Unwired backend surfaces** — `/ai/assignment-drafts/` (assignment draft
+  builder) and `/ai/open-rubrics/` + `/ai/open-grades/` (open-response
+  grading) still have **no `frontend_modern` consumer**. Wiring each is
+  UI-build work (ASA-6/ASA-7 batch-anchors), not polish.
+  ✅ `/ai/explanations/` wired 2026-06-09 (ASA-4, `ExplanationPanel`);
+  ✅ `/ai/misconception-clusters/` wired 2026-06-09 (ASA-5).
+- **`ExplanationPanel` provenance label is a bare span** — uses a hand-rolled
+  uppercase span for `✨ AI-generated` / `Auto-explanation` instead of the
+  shared `Badge` used by `InterventionsPanel`/`WeeklyReportPanel`/`NarrativeCard`.
+  Cosmetic consistency tweak for a future run.
+- ✅ **Content recommendations click-through** — done 2026-06-09 (ASA-2).
+- ✅ **SRS drill repeat-review guard** — done 2026-06-09 (ASA-3).
+- ✅ **`DueForReviewPanel` skeleton/empty states** — done 2026-06-09 (ASA-1).

--- a/frontend_modern/src/features/teacher/MisconceptionClustersPanel.test.tsx
+++ b/frontend_modern/src/features/teacher/MisconceptionClustersPanel.test.tsx
@@ -59,7 +59,9 @@ describe('MisconceptionClustersPanel', () => {
     expect(mockGet).not.toHaveBeenCalled();
 
     await user.click(screen.getByRole('button', { name: /class misconceptions/i }));
-    expect(screen.getByText(/loading misconceptions/i)).toBeDefined();
+    // Shape-matched skeleton cards, not bare text, while the list loads.
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0);
+    expect(screen.queryByText(/no misconception patterns detected yet/i)).toBeNull();
 
     resolveGet({ data: { results: [CLUSTER] } });
     await waitFor(() =>
@@ -91,6 +93,40 @@ describe('MisconceptionClustersPanel', () => {
     await waitFor(() =>
       expect(screen.getByText(/no misconception patterns detected yet/i)).toBeDefined()
     );
+  });
+
+  it('shows an error with retry — not the empty state — when the list fetch fails', async () => {
+    const user = userEvent.setup();
+    mockGet.mockRejectedValue(new Error('network down'));
+
+    renderPanel();
+    await user.click(screen.getByRole('button', { name: /class misconceptions/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/couldn't load misconception patterns/i)).toBeDefined()
+    );
+    // A failed fetch must not read as "your class has no misconceptions".
+    expect(screen.queryByText(/no misconception patterns detected yet/i)).toBeNull();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeDefined();
+  });
+
+  it('recovers when retry succeeds after a failed list fetch', async () => {
+    const user = userEvent.setup();
+    mockGet.mockRejectedValueOnce(new Error('network down'));
+    mockGet.mockResolvedValue({ data: [CLUSTER] });
+
+    renderPanel();
+    await user.click(screen.getByRole('button', { name: /class misconceptions/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/couldn't load misconception patterns/i)).toBeDefined()
+    );
+
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText('Adds denominators when adding fractions')).toBeDefined()
+    );
+    expect(screen.queryByText(/couldn't load misconception patterns/i)).toBeNull();
   });
 
   it('queues a refresh and confirms the recompute is underway', async () => {

--- a/frontend_modern/src/features/teacher/MisconceptionClustersPanel.tsx
+++ b/frontend_modern/src/features/teacher/MisconceptionClustersPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Badge, Button } from '@/shared/ui';
+import { Badge, Button, Skeleton } from '@/shared/ui';
 import {
   useMisconceptionClusters,
   useRefreshMisconceptionClusters,
@@ -37,6 +37,21 @@ const ClusterCard = ({ cluster }: { cluster: MisconceptionCluster }) => (
   </div>
 );
 
+// Mirrors the ClusterCard layout so the list doesn't reflow when data lands.
+const ClusterCardSkeleton = () => (
+  <div className="rounded-xl border border-ink-100 bg-paper p-4">
+    <div className="flex items-start justify-between gap-3">
+      <Skeleton w="w-2/3" h="h-5" />
+      <Skeleton w="w-20" h="h-5" rounded="rounded-full" />
+    </div>
+    <div className="mt-3 space-y-1.5">
+      <Skeleton w="w-full" h="h-3" />
+      <Skeleton w="w-5/6" h="h-3" />
+    </div>
+    <Skeleton w="w-1/2" h="h-3" className="mt-3" />
+  </div>
+);
+
 interface Props {
   subjectRoomId: number;
 }
@@ -50,7 +65,12 @@ interface Props {
  */
 export const MisconceptionClustersPanel = ({ subjectRoomId }: Props) => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const { data: clusters, isLoading } = useMisconceptionClusters(subjectRoomId, isExpanded);
+  const {
+    data: clusters,
+    isLoading,
+    isError,
+    refetch,
+  } = useMisconceptionClusters(subjectRoomId, isExpanded);
   const refresh = useRefreshMisconceptionClusters(subjectRoomId);
 
   const items = clusters ?? [];
@@ -69,9 +89,30 @@ export const MisconceptionClustersPanel = ({ subjectRoomId }: Props) => {
 
       {isExpanded && (
         <div className="mt-3 space-y-3">
-          {isLoading && <p className="text-xs text-ink-400 py-2">Loading misconceptions…</p>}
+          {isLoading && (
+            <>
+              <ClusterCardSkeleton />
+              <ClusterCardSkeleton />
+            </>
+          )}
 
-          {!isLoading && items.length === 0 && (
+          {/* A failed fetch must not masquerade as "no patterns detected" —
+              that would tell the teacher their class is fine when we just
+              couldn't reach the server. */}
+          {!isLoading && isError && (
+            <p className="text-xs text-rose-600 py-2">
+              Couldn&apos;t load misconception patterns just now.{' '}
+              <button
+                type="button"
+                onClick={() => void refetch()}
+                className="font-medium underline hover:text-rose-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 rounded"
+              >
+                Retry
+              </button>
+            </p>
+          )}
+
+          {!isLoading && !isError && items.length === 0 && (
             <div className="text-xs text-ink-500 py-2">
               No misconception patterns detected yet — they appear once students have a few graded
               assignments in this class.


### PR DESCRIPTION
## What gap was fixed

`MisconceptionClustersPanel` (shipped yesterday in ASA-5, #289) violated two items of the AI-surface polish checklist:

1. **Error masquerading as empty state (checklist #1).** The list query's `isError` was never read, so a failed `GET /ai/misconception-clusters/` rendered the empty state — *"No misconception patterns detected yet"* — telling the teacher their class looks clean when the server was simply unreachable.
2. **Bare-text loading (checklist #2).** Loading showed a "Loading misconceptions…" text line instead of the shape-matched skeleton pattern the sibling panels adopted in ASA-1, so the expanded section reflowed when data landed.

## Before / after

| | Before | After |
|---|---|---|
| Fetch fails | "No misconception patterns detected yet" (misleading all-clear) | "Couldn't load misconception patterns just now." + inline **Retry** button |
| Loading | Bare text line, layout jumps when cards land | Two pulsing `ClusterCardSkeleton`s mirroring the real card layout |
| Successful empty response | Empty state | Unchanged — empty state only renders on success now |

## How to verify

1. Teacher dashboard → expand a class → expand **Class Misconceptions** with the backend stopped → red error line with Retry, not the empty state. Retry recovers once the backend is back.
2. With the backend up, the section shows two card skeletons while loading, then real cluster cards with no reflow.
3. `npx vitest run src/features/teacher/MisconceptionClustersPanel.test.tsx` — 7 tests (3 new: skeleton-not-empty-state while loading, error+Retry on failed fetch, retry recovery). `tsc --noEmit` and `eslint` clean.

Also updates `docs/ai-features/polish-backlog.md`: logs this run and refreshes the stale gap list (ASA-1..5 closed several entries; `InterventionsPanel`/`WeeklyReportPanel` share this exact error-as-empty-state gap and are queued for the next run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)