### PR TITLE
polish(ai): InterventionsPanel — list-error state + skeleton loading

### DIFF
--- a/docs/ai-features/polish-backlog.md
+++ b/docs/ai-features/polish-backlog.md
@@ -189,14 +189,42 @@ While loading → two pulsing card skeletons.
 
 ---
 
+## 2026-06-10 — Interventions: list-error state + skeleton loading
+
+**Surface:** Intervention suggestions (teacher dashboard `InterventionsPanel`).
+
+**Gaps (checklist #1 error states, #2 loading states):**
+1. The list query's `isError` was never read, so a **failed fetch rendered the
+   empty state** — "No struggling students flagged yet" — telling the teacher
+   no one needs help when the server was simply unreachable.
+2. Loading was a bare "Loading suggestions…" text line instead of a
+   shape-matched skeleton, so the expanded section reflowed when data landed.
+
+**Fix:**
+- Destructured `isError`/`refetch` from `useInterventions`; a failed fetch now
+  shows "Couldn't load suggestions just now." with an inline **Retry** button
+  (same recipe as `MisconceptionClustersPanel` / #291). The empty state only
+  renders on a *successful* empty response.
+- Added `SuggestionCardSkeleton` (mirrors the `SuggestionCard` layout: name +
+  meta lines, priority pill, badge + strategy lines, chapter chips) shown
+  twice while loading.
+- Tests: loading shows skeletons not the empty state; failed fetch shows the
+  error + Retry (and not the empty state); retry recovers to real data
+  (checklist #8). Existing generate-error tests untouched.
+
+**Verify:** Teacher dashboard → expand "Intervention Suggestions" with the API
+unreachable → red "Couldn't load…" line with Retry, not the empty state.
+While loading → two pulsing card skeletons.
+
+---
+
 ## Remaining gaps (audit notes — updated 2026-06-10)
 
-- **Error-as-empty-state in `InterventionsPanel` and `WeeklyReportPanel`** —
-  both ignore the list query's `isError`, so a failed fetch renders "No
-  struggling students flagged yet" / "No weekly summary yet". Same misleading
-  pattern just fixed on `MisconceptionClustersPanel`; both also use bare-text
-  loading instead of skeletons. Prime candidate for the next polish run
-  (one panel per PR).
+- **Error-as-empty-state in `WeeklyReportPanel`** — ignores the list query's
+  `isError`, so a failed fetch renders "No weekly summary yet"; loading is
+  bare text instead of a skeleton. Same misleading pattern fixed on
+  `MisconceptionClustersPanel` (#291) and `InterventionsPanel` (this run).
+  ✅ `InterventionsPanel` fixed 2026-06-10 (this entry).
 - **Misconception cluster cards lack AI provenance** — `sample_diagnosis` /
   `sample_remediation_tip` are copied from LLM-generated `StudentMisconception`
   rows but `ClassMisconceptionCluster` carries no `model_used`, so the cards

--- a/docs/changes/2026-06-10-interventions-panel-error-skeleton.md
+++ b/docs/changes/2026-06-10-interventions-panel-error-skeleton.md
@@ -1,0 +1,49 @@
+# InterventionsPanel — list-error state + skeleton loading
+
+**Date:** 2026-06-10
+**Classification:** Improve (polish)
+**Initiative:** AI Surface Activation — polish pass (ASA-P1, daily plan 2026-06-10 PR 1)
+
+## Summary
+
+Fixed the "error masquerades as all-clear" anti-pattern on the teacher
+dashboard's `InterventionsPanel`: a failed list fetch used to render the empty
+state ("No struggling students flagged yet"), telling a teacher nobody needs
+help when the server was simply unreachable. The panel now shows an explicit
+error line with an inline Retry, and loading uses shape-matched skeleton cards
+instead of a bare text line.
+
+## Legacy reference
+
+None — the interventions panel is a modern AI feature. The anti-pattern is an
+SPA-specific failure mode: legacy server-rendered pages failed loudly with a
+500 page; a SPA fetch failure can silently look like clean data.
+
+## What changed
+
+- `frontend_modern/src/features/teacher/InterventionsPanel.tsx`
+  - Destructured `isError` / `refetch` from `useInterventions`.
+  - On list error: "Couldn't load suggestions just now." + inline **Retry**
+    button (exact recipe from `MisconceptionClustersPanel`, PR #291).
+  - Empty state and suggestion cards now render only when `!isError`.
+  - New `SuggestionCardSkeleton` mirroring the `SuggestionCard` layout
+    (name/meta lines, priority pill, badge + strategy lines, chapter chips),
+    rendered twice while loading. Uses the shared `Skeleton` primitive.
+- `frontend_modern/src/features/teacher/InterventionsPanel.test.tsx`
+  - 3 new cases: skeletons (not empty state) while loading; error + Retry
+    (not empty state) on failed fetch; retry recovery to real data.
+- `docs/ai-features/polish-backlog.md` — dated entry added; `InterventionsPanel`
+  removed from "Remaining gaps".
+
+No hook changes needed — `useQuery` already exposes `isError`/`refetch`.
+No backend changes.
+
+## Tests
+
+`npx vitest run InterventionsPanel` — 10 passed (7 existing incl. the
+generate-error path, 3 new). `npm run lint` + `npx tsc --noEmit` clean.
+
+## Next steps
+
+`WeeklyReportPanel` gets the identical treatment in the next PR of this batch
+(ASA-P2) — it is the last panel with the error-as-empty-state pattern.

--- a/frontend_modern/src/features/teacher/InterventionsPanel.test.tsx
+++ b/frontend_modern/src/features/teacher/InterventionsPanel.test.tsx
@@ -132,6 +132,55 @@ describe('InterventionsPanel', () => {
     );
   });
 
+  it('shows shape-matched skeletons — not the empty state — while the list loads', async () => {
+    let resolveGet!: (value: { data: { results: InterventionSuggestion[] } }) => void;
+    mockGet.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveGet = resolve;
+        })
+    );
+    renderPanel();
+
+    fireEvent.click(screen.getByText('Intervention Suggestions'));
+
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0);
+    expect(screen.queryByText(/No struggling students flagged/)).toBeNull();
+
+    resolveGet({ data: { results: [SUGGESTION] } });
+    await waitFor(() => expect(screen.getByText('Asha Rao')).toBeDefined());
+  });
+
+  it('shows an error with retry — not the empty state — when the list fetch fails', async () => {
+    mockGet.mockRejectedValue(new Error('network down'));
+    renderPanel();
+
+    fireEvent.click(screen.getByText('Intervention Suggestions'));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't load suggestions just now/)).toBeDefined()
+    );
+    // A failed fetch must not read as "no struggling students in this class".
+    expect(screen.queryByText(/No struggling students flagged/)).toBeNull();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeDefined();
+  });
+
+  it('recovers when retry succeeds after a failed list fetch', async () => {
+    mockGet.mockRejectedValueOnce(new Error('network down'));
+    mockGet.mockResolvedValue({ data: { results: [SUGGESTION] } });
+    renderPanel();
+
+    fireEvent.click(screen.getByText('Intervention Suggestions'));
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't load suggestions just now/)).toBeDefined()
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+    await waitFor(() => expect(screen.getByText('Asha Rao')).toBeDefined());
+    expect(screen.queryByText(/Couldn't load suggestions just now/)).toBeNull();
+  });
+
   it('shows an empty state and a Generate action when there are no suggestions', async () => {
     mockGet.mockResolvedValue({ data: { results: [] } });
     mockPost.mockResolvedValue({ data: {} });

--- a/frontend_modern/src/features/teacher/InterventionsPanel.tsx
+++ b/frontend_modern/src/features/teacher/InterventionsPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Badge, Button } from '@/shared/ui';
+import { Badge, Button, Skeleton } from '@/shared/ui';
 import {
   useGenerateInterventions,
   useInterventions,
@@ -121,6 +121,28 @@ const SuggestionCard = ({ item, subjectRoomId }: CardProps) => {
   );
 };
 
+// Mirrors the SuggestionCard layout so the list doesn't reflow when data lands.
+const SuggestionCardSkeleton = () => (
+  <div className="rounded-xl border border-ink-100 bg-paper p-4">
+    <div className="flex items-start justify-between gap-3">
+      <div className="min-w-0 flex-1 space-y-1.5">
+        <Skeleton w="w-1/2" h="h-5" />
+        <Skeleton w="w-1/3" h="h-3" />
+      </div>
+      <Skeleton w="w-20" h="h-5" rounded="rounded-full" />
+    </div>
+    <div className="mt-3 space-y-1.5">
+      <Skeleton w="w-24" h="h-5" rounded="rounded-full" />
+      <Skeleton w="w-full" h="h-3" />
+      <Skeleton w="w-5/6" h="h-3" />
+    </div>
+    <div className="mt-3 flex gap-1.5">
+      <Skeleton w="w-24" h="h-5" rounded="rounded-full" />
+      <Skeleton w="w-20" h="h-5" rounded="rounded-full" />
+    </div>
+  </div>
+);
+
 interface Props {
   subjectRoomId: number;
 }
@@ -132,7 +154,12 @@ interface Props {
  */
 export const InterventionsPanel = ({ subjectRoomId }: Props) => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const { data: suggestions, isLoading } = useInterventions(subjectRoomId, isExpanded);
+  const {
+    data: suggestions,
+    isLoading,
+    isError,
+    refetch,
+  } = useInterventions(subjectRoomId, isExpanded);
   const generate = useGenerateInterventions(subjectRoomId);
 
   // Open suggestions sort first (already priority-ordered from the API).
@@ -151,15 +178,37 @@ export const InterventionsPanel = ({ subjectRoomId }: Props) => {
 
       {isExpanded && (
         <div className="mt-3 space-y-3">
-          {isLoading && <p className="text-xs text-ink-400 py-2">Loading suggestions…</p>}
+          {isLoading && (
+            <>
+              <SuggestionCardSkeleton />
+              <SuggestionCardSkeleton />
+            </>
+          )}
 
-          {!isLoading && active.length === 0 && (
+          {/* A failed fetch must not masquerade as "no struggling students" —
+              that would tell the teacher their class is fine when we just
+              couldn't reach the server. */}
+          {!isLoading && isError && (
+            <p className="text-xs text-rose-600 py-2">
+              Couldn&apos;t load suggestions just now.{' '}
+              <button
+                type="button"
+                onClick={() => void refetch()}
+                className="font-medium underline hover:text-rose-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 rounded"
+              >
+                Retry
+              </button>
+            </p>
+          )}
+
+          {!isLoading && !isError && active.length === 0 && (
             <div className="text-xs text-ink-500 py-2">
               No struggling students flagged yet. Generate suggestions from current learning-gap data.
             </div>
           )}
 
           {!isLoading &&
+            !isError &&
             active.map((item) => (
               <SuggestionCard key={item.id} item={item} subjectRoomId={subjectRoomId} />
             ))}


### PR DESCRIPTION
## Classification
Improve (polish) — ASA polish pass, daily plan 2026-06-10 PR 1.

## What
- A failed list fetch no longer renders the empty state ("No struggling students flagged yet") — an error masquerading as an all-clear. It now shows **"Couldn't load suggestions just now." + inline Retry**, same recipe as `MisconceptionClustersPanel` (#291).
- Empty state renders only on a *successful* empty response.
- Loading: two shape-matched `SuggestionCardSkeleton`s (shared `Skeleton` primitive) instead of bare text.

## Legacy reference
None — modern AI surface. SPA-specific failure mode (legacy server-rendered pages failed loudly).

## Tests
`npx vitest run InterventionsPanel` — 10 passed (3 new: skeleton-not-empty, error-not-empty + Retry, retry recovery; existing generate-error tests untouched). Lint + tsc clean.

## How to verify
Teacher dashboard → expand "Intervention Suggestions" with the API unreachable → red error line with Retry, not the empty state. While loading → two pulsing card skeletons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)