### PR TITLE
polish(ai): WeeklyReportPanel — list-error state + skeleton loading

### DIFF
--- a/docs/ai-features/polish-backlog.md
+++ b/docs/ai-features/polish-backlog.md
@@ -218,13 +218,44 @@ While loading → two pulsing card skeletons.
 
 ---
 
+## 2026-06-10 — Weekly report: list-error state + skeleton loading
+
+**Surface:** Weekly class reports (teacher dashboard `WeeklyReportPanel`).
+
+**Gaps (checklist #1 error states, #2 loading states):**
+1. The list query's `isError` was never read, so a **failed fetch rendered the
+   empty state** — "No weekly summary yet. Generate one…" — inviting the
+   teacher to regenerate a report that may already exist, instead of saying
+   the server was unreachable. (Only a 404 means "no report yet"; the hook
+   already maps that to a successful `null`.)
+2. Loading was a bare "Loading weekly summary…" text line, so the expanded
+   section reflowed when the report card landed.
+
+**Fix:**
+- Destructured `isError` from `useWeeklyReport`; a failed fetch now shows
+  "Couldn't load the weekly summary just now." with an inline **Retry**
+  button. The empty state only renders on a *successful* `null` response.
+- Added `ReportCardSkeleton` (mirrors the report card: title line + badge
+  pill + 3 body lines, on the same brand-tinted card) shown while loading.
+- List-error and generate-error stay visually distinct: list-error replaces
+  the content area; generate-error remains the inline rose box under the
+  Generate/Regenerate button.
+- Tests: skeleton not the empty state while loading; failed fetch shows the
+  error + Retry (and not the empty state); retry recovers to the report
+  (checklist #8). Existing badge + generate-error tests untouched.
+
+**Verify:** Teacher dashboard → expand "Weekly AI Summary" with the API
+unreachable → red "Couldn't load…" line with Retry, not the generate prompt.
+While loading → a pulsing report-card skeleton.
+
+---
+
 ## Remaining gaps (audit notes — updated 2026-06-10)
 
-- **Error-as-empty-state in `WeeklyReportPanel`** — ignores the list query's
-  `isError`, so a failed fetch renders "No weekly summary yet"; loading is
-  bare text instead of a skeleton. Same misleading pattern fixed on
-  `MisconceptionClustersPanel` (#291) and `InterventionsPanel` (this run).
-  ✅ `InterventionsPanel` fixed 2026-06-10 (this entry).
+- ✅ **Error-as-empty-state sweep complete** — `MisconceptionClustersPanel`
+  (#291), `InterventionsPanel` and `WeeklyReportPanel` (both 2026-06-10) now
+  all distinguish a failed fetch from a genuinely empty response and use
+  shape-matched skeletons while loading.
 - **Misconception cluster cards lack AI provenance** — `sample_diagnosis` /
   `sample_remediation_tip` are copied from LLM-generated `StudentMisconception`
   rows but `ClassMisconceptionCluster` carries no `model_used`, so the cards

--- a/docs/changes/2026-06-10-weekly-report-panel-error-skeleton.md
+++ b/docs/changes/2026-06-10-weekly-report-panel-error-skeleton.md
@@ -1,0 +1,49 @@
+# WeeklyReportPanel — list-error state + skeleton loading
+
+**Date:** 2026-06-10
+**Classification:** Improve (polish)
+**Initiative:** AI Surface Activation — polish pass (ASA-P2, daily plan 2026-06-10 PR 2)
+
+## Summary
+
+Completed the error-as-empty-state sweep on the teacher AI panels: a failed
+weekly-report fetch used to render "No weekly summary yet. Generate one…",
+inviting the teacher to regenerate a report that may already exist instead of
+saying the server was unreachable. The panel now shows an explicit error line
+with inline Retry, and loading uses a shape-matched report-card skeleton.
+
+## Legacy reference
+
+None — modern AI feature. Same SPA-specific failure mode as the sibling
+panels: legacy server-rendered pages failed loudly; a SPA fetch failure can
+look like clean data.
+
+## What changed
+
+- `frontend_modern/src/features/teacher/WeeklyReportPanel.tsx`
+  - Destructured `isError` from `useWeeklyReport`. On list error:
+    "Couldn't load the weekly summary just now." + inline **Retry**.
+  - Empty state ("No weekly summary yet…") and the report card render only
+    when `!isError`. The hook already maps a 404 to a successful `null`, so
+    only real failures hit the error path.
+  - New `ReportCardSkeleton` mirroring the report card (title + badge pill +
+    3 body lines on the brand-tinted card), shown while loading.
+  - Generate-error stays the inline rose box under the button — list-error
+    and generate-error remain visually distinct. Badge logic untouched.
+- `frontend_modern/src/features/teacher/WeeklyReportPanel.test.tsx`
+  - 3 new cases: skeleton (not empty state) while loading; error + Retry
+    (not empty state) on failed fetch; retry recovery.
+- `docs/ai-features/polish-backlog.md` — dated entry; "Remaining gaps" now
+  records the sweep as complete across all three panels.
+
+No hook or backend changes.
+
+## Tests
+
+`npx vitest run WeeklyReportPanel` — 7 passed (4 existing incl. badges +
+generate-error, 3 new). Lint + tsc clean.
+
+## Next steps
+
+Error-as-empty-state sweep is done. Remaining polish notes (cluster card
+provenance field, ExplanationPanel badge consistency) stay in the backlog.

--- a/frontend_modern/src/features/teacher/WeeklyReportPanel.test.tsx
+++ b/frontend_modern/src/features/teacher/WeeklyReportPanel.test.tsx
@@ -79,6 +79,55 @@ describe('WeeklyReportPanel', () => {
     expect(screen.queryByText('✨ AI-generated')).toBeNull();
   });
 
+  it('shows a shape-matched skeleton — not the empty state — while the report loads', async () => {
+    let resolveGet!: (value: { data: WeeklyClassReport }) => void;
+    mockGet.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveGet = resolve;
+        })
+    );
+    renderPanel();
+
+    fireEvent.click(screen.getByText('Weekly AI Summary'));
+
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0);
+    expect(screen.queryByText(/No weekly summary yet/)).toBeNull();
+
+    resolveGet({ data: REPORT });
+    await waitFor(() => expect(screen.getByText(/improving in algebra/)).toBeDefined());
+  });
+
+  it('shows an error with retry — not the empty state — when the list fetch fails', async () => {
+    mockGet.mockRejectedValue(new Error('network down'));
+    renderPanel();
+
+    fireEvent.click(screen.getByText('Weekly AI Summary'));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't load the weekly summary just now/)).toBeDefined()
+    );
+    // A failed fetch must not read as "no report exists — go generate one".
+    expect(screen.queryByText(/No weekly summary yet/)).toBeNull();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeDefined();
+  });
+
+  it('recovers when retry succeeds after a failed list fetch', async () => {
+    mockGet.mockRejectedValueOnce(new Error('network down'));
+    mockGet.mockResolvedValue({ data: REPORT });
+    renderPanel();
+
+    fireEvent.click(screen.getByText('Weekly AI Summary'));
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't load the weekly summary just now/)).toBeDefined()
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+    await waitFor(() => expect(screen.getByText(/improving in algebra/)).toBeDefined());
+    expect(screen.queryByText(/Couldn't load the weekly summary just now/)).toBeNull();
+  });
+
   it('surfaces an error when generation fails instead of silently reverting', async () => {
     mockGet.mockRejectedValue({ response: { status: 404 } });
     mockPost.mockRejectedValue(new Error('boom'));

--- a/frontend_modern/src/features/teacher/WeeklyReportPanel.tsx
+++ b/frontend_modern/src/features/teacher/WeeklyReportPanel.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { apiClient } from '@/api/client';
 import { useWeeklyReport } from './useWeeklyReport';
-import { Badge, Button } from '@/shared/ui';
+import { Badge, Button, Skeleton } from '@/shared/ui';
 
 const triggerWeeklyReport = async (subjectRoomId: number): Promise<void> => {
   await apiClient.post('/ai/weekly-reports/generate/', { subject_room_id: subjectRoomId });
@@ -9,6 +9,22 @@ const triggerWeeklyReport = async (subjectRoomId: number): Promise<void> => {
 
 const formatDate = (iso: string): string =>
   new Date(iso).toLocaleDateString('en-IN', { day: 'numeric', month: 'short' });
+
+// Mirrors the report card layout (title + badge, then summary lines) so the
+// expanded section doesn't reflow when the report lands.
+const ReportCardSkeleton = () => (
+  <div className="rounded-xl border border-brand-100 bg-brand-50/60 p-3">
+    <div className="flex items-start justify-between gap-2">
+      <Skeleton w="w-1/3" h="h-4" />
+      <Skeleton w="w-24" h="h-5" rounded="rounded-full" />
+    </div>
+    <div className="mt-2 space-y-1.5">
+      <Skeleton w="w-full" h="h-3" />
+      <Skeleton w="w-full" h="h-3" />
+      <Skeleton w="w-2/3" h="h-3" />
+    </div>
+  </div>
+);
 
 interface Props {
   subjectRoomId: number;
@@ -19,7 +35,12 @@ export const WeeklyReportPanel = ({ subjectRoomId }: Props) => {
   const [isGenerating, setIsGenerating] = useState(false);
   const [genError, setGenError] = useState(false);
 
-  const { data: report, isLoading, refetch } = useWeeklyReport(subjectRoomId, isExpanded);
+  const {
+    data: report,
+    isLoading,
+    isError,
+    refetch,
+  } = useWeeklyReport(subjectRoomId, isExpanded);
 
   const handleGenerate = async () => {
     setIsGenerating(true);
@@ -60,11 +81,25 @@ export const WeeklyReportPanel = ({ subjectRoomId }: Props) => {
 
       {isExpanded && (
         <div className="mt-3">
-          {isLoading && (
-            <p className="py-2 text-xs text-ink-400">Loading weekly summary…</p>
+          {isLoading && <ReportCardSkeleton />}
+
+          {/* A failed fetch must not masquerade as "no summary yet" — that
+              would invite the teacher to regenerate a report that may already
+              exist, instead of telling them we couldn't reach the server. */}
+          {!isLoading && isError && (
+            <p className="py-2 text-xs text-rose-600">
+              Couldn&apos;t load the weekly summary just now.{' '}
+              <button
+                type="button"
+                onClick={() => void refetch()}
+                className="font-medium underline hover:text-rose-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 rounded"
+              >
+                Retry
+              </button>
+            </p>
           )}
 
-          {!isLoading && !report && (
+          {!isLoading && !isError && !report && (
             <div className="py-2 text-xs text-ink-400">
               No weekly summary yet. Generate one from this week's practice activity.
               <Button
@@ -85,7 +120,7 @@ export const WeeklyReportPanel = ({ subjectRoomId }: Props) => {
             </p>
           )}
 
-          {!isLoading && report && (
+          {!isLoading && !isError && report && (
             <div className="rounded-xl border border-brand-100 bg-brand-50/60 p-3">
               <div className="flex items-start justify-between gap-2">
                 <p className="text-xs font-semibold text-brand-800">


### PR DESCRIPTION
## Classification
Improve (polish) — ASA polish pass, daily plan 2026-06-10 PR 2. **Stacked on #293** (shares the `polish-backlog.md` doc) — merge #293 first, then retarget/merge this one onto `modernization`.

## What
- A failed report fetch no longer renders **"No weekly summary yet. Generate one…"** — which invited regenerating a report that may already exist. It now shows **"Couldn't load the weekly summary just now." + inline Retry**.
- Empty state renders only on a *successful* `null` (the hook already maps 404 → null).
- Loading: shape-matched `ReportCardSkeleton` (title + badge pill + 3 body lines on the brand-tinted card).
- Generate-error stays visually distinct (inline rose box under the button); badge logic untouched.

This completes the error-as-empty-state sweep across all three teacher AI panels (#291, #293, this).

## Legacy reference
None — modern AI surface.

## Tests
`npx vitest run WeeklyReportPanel` — 7 passed (3 new: skeleton-not-empty, error-not-empty + Retry, retry recovery). Lint + tsc clean.

## How to verify
Teacher dashboard → expand "Weekly AI Summary" with the API unreachable → red error line with Retry, not the generate prompt. While loading → pulsing report-card skeleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)