### PR TITLE
feat(ai): ASA-9 — same-day idempotency guard on SRS mark-reviewed

### DIFF
--- a/backend/openshiksha/apps/ai/tests/test_srs_drill_api.py
+++ b/backend/openshiksha/apps/ai/tests/test_srs_drill_api.py
@@ -255,6 +255,110 @@ class TestMarkReviewedAction:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Same-day idempotency guard (ASA-9)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestMarkReviewedSameDayGuard:
+    def test_second_review_same_day_leaves_schedule_unchanged(self):
+        student = make_user(role="student", username="srs_guard_student")
+        entry, _ = _make_entry(student)
+        client = _client_for(student)
+        url = f"/api/v1/ai/spaced-repetition/{entry.id}/mark-reviewed/"
+
+        first = client.post(url, data=json.dumps({"score": 0.9}), content_type="application/json")
+        assert first.status_code == 200
+        assert first.json()["already_reviewed_today"] is False
+        entry.refresh_from_db()
+        ef, reps, interval, next_review = (
+            entry.easiness_factor,
+            entry.repetitions,
+            entry.interval_days,
+            entry.next_review_date,
+        )
+
+        second = client.post(url, data=json.dumps({"score": 1.0}), content_type="application/json")
+        assert second.status_code == 200
+        assert second.json()["already_reviewed_today"] is True
+        entry.refresh_from_db()
+        assert entry.easiness_factor == ef
+        assert entry.repetitions == reps
+        assert entry.interval_days == interval
+        assert entry.next_review_date == next_review
+
+    def test_review_on_a_later_day_still_updates(self):
+        from datetime import timedelta
+
+        student = make_user(role="student", username="srs_guard_later_day")
+        entry, _ = _make_entry(student)
+        entry.last_reviewed_at = timezone.now() - timedelta(days=2)
+        entry.save()
+
+        client = _client_for(student)
+        response = client.post(
+            f"/api/v1/ai/spaced-repetition/{entry.id}/mark-reviewed/",
+            data=json.dumps({"score": 0.9}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.json()["already_reviewed_today"] is False
+        entry.refresh_from_db()
+        assert entry.repetitions == 1
+
+    def test_guarded_call_still_grades_answers(self):
+        student = make_user(role="student", username="srs_guard_grades")
+        entry, chapter = _make_entry(student)
+        _, subpart = _make_question_with_subpart(chapter, qtype="numeric", correct="42", options=None)
+        client = _client_for(student)
+        url = f"/api/v1/ai/spaced-repetition/{entry.id}/mark-reviewed/"
+
+        client.post(url, data=json.dumps({"score": 0.9}), content_type="application/json")
+
+        response = client.post(
+            url,
+            data=json.dumps({"answers": {str(subpart.id): "42"}}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["already_reviewed_today"] is True
+        assert body["score"] == 1.0
+        # Practice round only — the schedule stayed where the first review put it.
+        entry.refresh_from_db()
+        assert entry.repetitions == 1
+
+    def test_guarded_call_does_not_double_count_proficiency_ticks(self):
+        from openshiksha.apps.edge.models import Tick
+
+        student = make_user(role="student", username="srs_guard_ticks")
+        entry, chapter = _make_entry(student, subject_name="Physics_Guard", chapter_name="Waves_Guard")
+        _, subpart = _make_question_with_subpart(chapter, qtype="numeric", correct="7", options=None)
+        _make_subject_room_for(student, chapter.subject)
+
+        client = _client_for(student)
+        url = f"/api/v1/ai/spaced-repetition/{entry.id}/mark-reviewed/"
+        payload = json.dumps({"answers": {str(subpart.id): "7"}})
+
+        client.post(url, data=payload, content_type="application/json")
+        assert Tick.objects.filter(student=student).count() == 1
+
+        client.post(url, data=payload, content_type="application/json")
+        assert Tick.objects.filter(student=student).count() == 1
+
+    def test_guarded_call_still_validates_bad_bodies(self):
+        student = make_user(role="student", username="srs_guard_400")
+        entry, _ = _make_entry(student)
+        client = _client_for(student)
+        url = f"/api/v1/ai/spaced-repetition/{entry.id}/mark-reviewed/"
+
+        client.post(url, data=json.dumps({"score": 0.9}), content_type="application/json")
+
+        response = client.post(url, data=json.dumps({}), content_type="application/json")
+        assert response.status_code == 400
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # SRS → Proficiency + Streak integration
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/backend/openshiksha/apps/ai/views.py
+++ b/backend/openshiksha/apps/ai/views.py
@@ -528,6 +528,14 @@ class SpacedRepetitionViewSet(ReadOnlyModelViewSet):
         Updates SM-2 schedule:
           score >= 0.6 → successful recall, interval grows
           score <  0.6 → failed recall, reset to interval=1
+
+        Idempotency contract (ASA-9): the SM-2 schedule mutates at most once
+        per entry per local day. If the entry was already reviewed today, the
+        call still grades submitted answers (the practice round stays useful)
+        but skips the schedule update, the proficiency ticks and the streak,
+        and returns 200 with `"already_reviewed_today": true` alongside the
+        unchanged entry. Normal calls return the same shape with the flag set
+        to false.
         """
         entry = self.get_object()
         if entry.student_id != request.user.id:
@@ -536,6 +544,10 @@ class SpacedRepetitionViewSet(ReadOnlyModelViewSet):
         from datetime import timedelta
 
         from django.utils import timezone
+
+        already_reviewed_today = (
+            entry.last_reviewed_at is not None and timezone.localdate(entry.last_reviewed_at) == timezone.localdate()
+        )
 
         from openshiksha.apps.core.models import QuestionSubpart
         from openshiksha.apps.core.tasks import _grade_subpart
@@ -590,6 +602,16 @@ class SpacedRepetitionViewSet(ReadOnlyModelViewSet):
                     {"detail": "Provide either answers (object) or score (0.0–1.0)."},
                     status=400,
                 )
+
+        if already_reviewed_today:
+            # Defence-in-depth (ASA-9): the client already avoids the double
+            # call in-app (ASA-3), but the server must guarantee one sitting
+            # can never compound the interval/easiness-factor. Grade, don't
+            # schedule — and don't double-count proficiency or streak either.
+            data = self.get_serializer(entry).data
+            data["score"] = round(score, 4)
+            data["already_reviewed_today"] = True
+            return Response(data)
 
         if score >= 0.60:
             if entry.repetitions == 0:
@@ -656,6 +678,7 @@ class SpacedRepetitionViewSet(ReadOnlyModelViewSet):
 
         data = self.get_serializer(entry).data
         data["score"] = round(score, 4)
+        data["already_reviewed_today"] = False
         return Response(data)
 
     @action(detail=False, methods=["get"], url_path="due")

--- a/docs/changes/2026-06-10-srs-same-day-idempotency-guard.md
+++ b/docs/changes/2026-06-10-srs-same-day-idempotency-guard.md
@@ -1,0 +1,62 @@
+# SRS mark-reviewed — same-day idempotency guard (ASA-9)
+
+**Date:** 2026-06-10
+**Classification:** Improve (hardening)
+**Initiative:** AI Surface Activation — ASA-9 (daily plan 2026-06-10 PR 3)
+
+## Summary
+
+`POST /api/v1/ai/spaced-repetition/{id}/mark-reviewed/` now guarantees the
+SM-2 schedule mutates at most once per entry per local day. ASA-3 (#287)
+guards client-side (a repeat pass in a sitting is practice-only), but the
+endpoint itself would still compound the interval/easiness-factor if called
+twice — by a stale tab, a retried request, or a hand-crafted call. The ledger
+kept ASA-9 open as the server-side defence-in-depth; this closes it.
+
+## Legacy reference
+
+None — SRS is a modern addition (no legacy equivalent; legacy grading was a
+nightly batch in `grader/`).
+
+## Contract
+
+- If `entry.last_reviewed_at` falls on today's local date
+  (`timezone.localdate(entry.last_reviewed_at) == timezone.localdate()`):
+  - The SM-2 mutation (interval, easiness factor, repetitions,
+    next_review_date, last_reviewed_at) is **skipped entirely**.
+  - Submitted `answers` are **still graded** and the score returned — the
+    practice round stays useful. Grade, don't schedule.
+  - Proficiency `Tick`s and the streak update are also skipped (no
+    double-counting; the streak is same-day idempotent anyway).
+  - Response is `200 OK` with the unchanged serialized entry plus
+    `"already_reviewed_today": true`.
+- Normal calls keep their exact prior shape, plus
+  `"already_reviewed_today": false` (additive only).
+- Body validation (400 on bad shapes) is unchanged on both paths.
+
+## What changed
+
+- `backend/openshiksha/apps/ai/views.py` —
+  `SpacedRepetitionViewSet.mark_reviewed`: guard computed up front from
+  `last_reviewed_at`, early return after grading; docstring documents the
+  contract. No model change (`last_reviewed_at` already existed), no
+  migration.
+- `backend/openshiksha/apps/ai/tests/test_srs_drill_api.py` — new
+  `TestMarkReviewedSameDayGuard` (5 tests): schedule unchanged on same-day
+  repeat + flag returned; later-day review still updates; guarded call still
+  grades answers; no duplicate proficiency ticks; bad bodies still 400.
+
+## Frontend
+
+No change required — `SRSDrillPage` ignores unknown response fields, and
+ASA-3 already prevents the double call in-app.
+
+## Tests
+
+`pytest openshiksha/` — 923 passed, coverage 93.76%.
+
+## Next steps
+
+ASA-9 closes the SRS hardening thread. Remaining ASA work: ASA-8 (drill
+explanations) and ASA-6 (assignment draft builder) in this batch; ASA-7
+(open-response grading UI) as a future batch-anchor.


### PR DESCRIPTION
## Classification
Improve (hardening) — ASA-9, daily plan 2026-06-10 PR 3.

## What
`POST /ai/spaced-repetition/{id}/mark-reviewed/` now guarantees the **SM-2 schedule mutates at most once per entry per local day**:
- Same-day repeat: submitted answers are **still graded** (practice round stays useful — grade, don't schedule) but the SM-2 update, proficiency `Tick`s and streak are skipped; returns 200 with the unchanged entry + `"already_reviewed_today": true`.
- Normal path: exact prior shape, plus `"already_reviewed_today": false` (additive only).
- Uses `timezone.localdate()` consistently; no model change, no migration (`last_reviewed_at` existed).

ASA-3 (#287) guards client-side; the ledger kept ASA-9 open as server-side defence-in-depth — a stale tab, retried request or hand-crafted call can no longer compound the interval/easiness-factor.

## Legacy reference
None — SRS is a modern addition.

## Tests
New `TestMarkReviewedSameDayGuard` (5 cases): schedule unchanged on same-day repeat + flag; later-day review still updates; guarded call still grades answers; no duplicate ticks; bad bodies still 400.
Full suite: **923 passed, coverage 93.76%**.

## Frontend
No change needed — `SRSDrillPage` ignores unknown fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)