### PR TITLE
feat(student): ASA-8 — AI explanations on the SRS drill result screens

### DIFF
--- a/docs/changes/2026-06-10-srs-drill-result-explanations.md
+++ b/docs/changes/2026-06-10-srs-drill-result-explanations.md
@@ -1,0 +1,56 @@
+# SRS drill result screen — per-subpart AI explanations (ASA-8)
+
+**Date:** 2026-06-10
+**Classification:** Improve
+**Initiative:** AI Surface Activation — ASA-8 (daily plan 2026-06-10 PR 4)
+
+## Summary
+
+After a scored SRS drill round the student used to see only a score card —
+right/wrong with no way to learn *why*, which is exactly the moment
+`/ai/explanations/` exists for. Both drill result screens (review and
+practice) now render the answered questions read-only below the result card,
+which unlocks the same per-subpart "✨ Explain this answer" affordance that
+assignments got in ASA-4 (#288). Initiative principle 5: an insight you can't
+act on is half-shipped.
+
+## Legacy reference
+
+None — SRS is a modern addition; legacy students saw only marks, never
+explanations (fixed for assignments in ASA-4).
+
+## What changed
+
+- `frontend_modern/src/features/student/SRSDrillPage.tsx`
+  - New `renderAnswerReview(explanationScore)` section: "Go over your
+    answers" heading + the drill's `QuestionCard`s with `isSubmitted` and
+    `explanationScore`, appended to both the review-result and
+    practice-result screens.
+  - Reuses `QuestionCard`'s existing ASA-4 wiring — `explanationScore`
+    enables `ExplanationPanel` per subpart (collapsed by default; on expand
+    it generates via 202 → polls → renders with the `✨ AI-generated` /
+    `Auto-explanation` provenance label). Students also get the worked
+    solution reveal for free, since `QuestionCard` shows it when submitted.
+  - Review round passes the graded `result.score` (ASA-4's conservative
+    derivation: correct framing only on a perfect score). Practice rounds
+    are never graded client-side, so they pass `null` — the affordance still
+    works (generation is per subpart, not per submission) with the
+    "where this went wrong" framing.
+- `frontend_modern/src/features/student/SRSDrillPage.test.tsx`
+  - QuestionCard mock now surfaces `isSubmitted`/`explanationScore`; 3 new
+    tests: no answer review mid-drill; review result passes the graded score;
+    practice result passes `null`.
+
+No new hooks, no backend change. `ExplanationPanel` stays inside the student
+chunk (no bundle change).
+
+## Tests
+
+`npx vitest run SRSDrillPage` — 6 passed (3 existing repeat-guard tests
+untouched, 3 new). The generate → poll → explanation / error+retry flows are
+covered by `ExplanationPanel.test.tsx` (ASA-4); the new tests assert the
+page-level wiring boundary rather than duplicating that coverage.
+
+## Next steps
+
+ASA-6 (assignment draft builder) is the batch anchor, next in this run.

--- a/frontend_modern/src/features/student/SRSDrillPage.test.tsx
+++ b/frontend_modern/src/features/student/SRSDrillPage.test.tsx
@@ -19,17 +19,31 @@ vi.mock('@/api/client', () => ({
 }));
 
 // The drill page only forwards answers into QuestionCard; the card's own
-// rendering (KaTeX, option shuffling) is covered by its own tests.
+// rendering (KaTeX, option shuffling) and the ExplanationPanel behaviour
+// (generate → poll → explanation / error+retry) are covered by their own
+// test files. Here we assert the page-level wiring: result screens render
+// the cards read-only with the explanationScore that unlocks the per-subpart
+// "Explain this answer" affordance (ASA-8).
 vi.mock('./QuestionCard', () => ({
   QuestionCard: ({
     onAnswerChange,
+    isSubmitted,
+    explanationScore,
   }: {
     onAnswerChange: (subpartId: number, value: string) => void;
-  }) => (
-    <button type="button" onClick={() => onAnswerChange(101, '42')}>
-      Answer subpart
-    </button>
-  ),
+    isSubmitted: boolean;
+    explanationScore?: number | null;
+  }) =>
+    isSubmitted ? (
+      <p>
+        submitted-card score:
+        {explanationScore === undefined ? 'undefined' : String(explanationScore)}
+      </p>
+    ) : (
+      <button type="button" onClick={() => onAnswerChange(101, '42')}>
+        Answer subpart
+      </button>
+    ),
 }));
 
 const DRILL: SRSDrillData = {
@@ -135,5 +149,54 @@ describe('SRSDrillPage repeat-review guard', () => {
     }
 
     expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SRSDrillPage result-screen explanations (ASA-8)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue({ data: DRILL });
+    mockPost.mockResolvedValue({ data: REVIEW_RESULT });
+  });
+
+  it('does not render the answer review while the drill is in progress', async () => {
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Polynomials')).toBeDefined());
+    expect(screen.queryByText('Go over your answers')).toBeNull();
+    expect(screen.queryByText(/submitted-card/)).toBeNull();
+  });
+
+  it('review result shows the answered questions with the graded score for explanations', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Polynomials')).toBeDefined());
+    await user.click(screen.getByText('Answer subpart'));
+    await user.click(screen.getByRole('button', { name: 'Submit Review' }));
+    await waitFor(() => expect(screen.getByText('Great review!')).toBeDefined());
+
+    expect(screen.getByText('Go over your answers')).toBeDefined();
+    // The graded score flows into QuestionCard, which unlocks the per-subpart
+    // ExplanationPanel affordance exactly as on assignments (ASA-4).
+    expect(screen.getByText(/submitted-card score:0\.8/)).toBeDefined();
+  });
+
+  it('practice result shows the answer review with a null score (round is ungraded)', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Polynomials')).toBeDefined());
+    await user.click(screen.getByText('Answer subpart'));
+    await user.click(screen.getByRole('button', { name: 'Submit Review' }));
+    await waitFor(() => expect(screen.getByText('Great review!')).toBeDefined());
+
+    await user.click(screen.getByRole('button', { name: 'Practice again' }));
+    await user.click(screen.getByText('Answer subpart'));
+    await user.click(screen.getByRole('button', { name: 'Finish Practice' }));
+    await waitFor(() => expect(screen.getByText('Practice round complete!')).toBeDefined());
+
+    expect(screen.getByText('Go over your answers')).toBeDefined();
+    expect(screen.getByText(/submitted-card score:null/)).toBeDefined();
   });
 });

--- a/frontend_modern/src/features/student/SRSDrillPage.tsx
+++ b/frontend_modern/src/features/student/SRSDrillPage.tsx
@@ -9,7 +9,9 @@ import { useMarkReviewed, useSRSDrill, type SRSReviewResult } from './useSRSDril
  * 1. Load chapter questions via /ai/spaced-repetition/{id}/review/
  * 2. Student answers each subpart in a familiar QuestionCard
  * 3. Submit POSTs {answers} to /mark-reviewed/ → server grades + updates SM-2
- * 4. Result screen shows score and next review date
+ * 4. Result screen shows score and next review date, plus the answered
+ *    questions read-only so the student can ask for an AI explanation per
+ *    subpart (ASA-8 — same ExplanationPanel affordance as assignments)
  *
  * Only the first completed pass per visit updates the SM-2 schedule; repeat
  * passes are practice-only so one sitting can never double-move the interval.
@@ -64,6 +66,36 @@ export const SRSDrillPage = () => {
     setAnswers({});
     setPhase('practice');
   };
+
+  // Answered questions, read-only, under the result card — the moment of
+  // seeing right/wrong is exactly when /ai/explanations/ is useful. The
+  // per-subpart "Explain" affordance comes from QuestionCard's ASA-4 wiring:
+  // pass the graded score for the review round; practice rounds are never
+  // graded client-side, so pass null (conservative "went wrong" framing).
+  const renderAnswerReview = (explanationScore: number | null) =>
+    drill && drill.questions.length > 0 ? (
+      <div className="mt-8">
+        <h3 className="font-display text-lg font-semibold text-ink-900 mb-1">
+          Go over your answers
+        </h3>
+        <p className="text-sm text-ink-500 mb-4">
+          Ask for an explanation under any question to see the why behind it.
+        </p>
+        <div className="space-y-4">
+          {drill.questions.map((question, idx) => (
+            <QuestionCard
+              key={question.id}
+              question={question}
+              questionNumber={idx + 1}
+              answers={answers}
+              onAnswerChange={handleAnswerChange}
+              isSubmitted
+              explanationScore={explanationScore}
+            />
+          ))}
+        </div>
+      </div>
+    ) : null;
 
   if (isLoading) {
     return (
@@ -135,6 +167,7 @@ export const SRSDrillPage = () => {
             Extra practice won&apos;t change your review schedule.
           </p>
         </div>
+        {renderAnswerReview(result.score)}
       </div>
     );
   }
@@ -163,6 +196,7 @@ export const SRSDrillPage = () => {
             </Button>
           </div>
         </div>
+        {renderAnswerReview(null)}
       </div>
     );
   }


### PR DESCRIPTION
## Classification
Improve — ASA-8, daily plan 2026-06-10 PR 4.

## What
After a scored drill round the student saw right/wrong with no way to learn *why* — the exact moment `/ai/explanations/` exists for. Both result screens (review **and** practice) now render the answered questions read-only under the result card ("Go over your answers"), which unlocks:
- the per-subpart **✨ Explain this answer** affordance — `QuestionCard`'s existing ASA-4 (#288) wiring: collapsed by default, 202 → poll → explanation with the AI/Auto provenance label, error + Retry;
- the worked-solution reveal, for free.

Review rounds pass the graded `result.score` (ASA-4's conservative correctness derivation); practice rounds pass `null` — they're never graded client-side, and generation is per subpart, not per submission.

No new hooks, no backend change, no bundle change.

## Legacy reference
None — SRS is a modern addition.

## Tests
`npx vitest run SRSDrillPage` — 6 passed (3 new: no review mid-drill; review result wires the graded score; practice result wires null). The generate/poll/error flows are covered by `ExplanationPanel.test.tsx` (ASA-4) — the new tests assert the page-level wiring boundary instead of duplicating that coverage. Lint + tsc clean.

## How to verify
Student → SRS drill → submit → result card now has "Go over your answers" below it; expand ✨ Explain this answer on any subpart → explanation generates and renders with provenance label. Same on practice-round results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)