### PR TITLE
feat(teacher): ASA-6 — AI assignment drafts panel (first /ai/assignment-drafts/ consumer)

### DIFF
--- a/docs/changes/2026-06-10-assignment-drafts-panel.md
+++ b/docs/changes/2026-06-10-assignment-drafts-panel.md
@@ -1,0 +1,88 @@
+# AssignmentDraftsPanel — first consumer of /ai/assignment-drafts/ (ASA-6)
+
+**Date:** 2026-06-10
+**Classification:** New (batch anchor)
+**Initiative:** AI Surface Activation — ASA-6 (daily plan 2026-06-10 PR 5)
+
+## Summary
+
+`/ai/assignment-drafts/` was a fully built, fully tested teacher feature —
+generate → review rationale → approve into a real ProblemSet + Assignment —
+with zero frontend consumers. This PR wires it: a collapsible "AI Assignment
+Drafts" panel inside each subject-room's insights on the teacher dashboard.
+One click takes a teacher from "my class is weak on X" to a reviewable draft,
+and one more to a live assignment. 3 of the 4 dark `/ai/` endpoint groups are
+now lit; only ASA-7 (open-response grading) remains.
+
+## Legacy reference
+
+Legacy assignment creation (`core/`, `sphinx/`) had teachers pick an existing
+ProblemSet and a due date — no help choosing *what* to assign; the insight
+about which chapters are weak lived in a separate analytics page. ASA-6 fuses
+insight and action: the draft *is* the analytics conclusion, with rationale a
+teacher can read and overrule. Kept: teacher final say (approve/dismiss,
+title/due-date control). Improved: AI-targeted selection with provider
+transparency.
+
+## What changed
+
+- **`frontend_modern/src/features/teacher/useAssignmentDrafts.ts`** (new) —
+  `AssignmentDraft` type mirroring `AssignmentDraftSerializer`;
+  `useAssignmentDrafts(subjectRoomId, enabled)` list query (handles both
+  array and `{results}` shapes) with `refetchInterval` polling **only while a
+  draft is pending** (3 s, stops by itself); `useGenerateAssignmentDraft`,
+  `useApproveAssignmentDraft`, `useDismissAssignmentDraft` mutations, each
+  invalidating the room's list; `errorDetail()` helper for axios-shaped 409s.
+- **`frontend_modern/src/features/teacher/AssignmentDraftsPanel.tsx`** (new) —
+  structural copy of the sibling insight panels (collapsed by default, fetch
+  on expand, per-room):
+  - **pending** card: pulsing "Assembling a draft from your class's weak
+    spots…" (polling flips it to ready/failed).
+  - **ready** card: title, rationale, target-chapter chips with class
+    averages, question count + estimated minutes, `✨ AI-generated` vs
+    `Auto-drafted` + stub note from `model_used`; **Approve…** opens an
+    inline form (due date, default 7 days out, ISO on submit like
+    `CreateAssignmentPage`; optional title override); **Dismiss**.
+  - **approved** card: "Assigned" badge + react-router `Link` to
+    `/teacher/assignments/{approved_assignment}`.
+  - **failed** card: friendly line + `error_detail` + "Try again"
+    (re-generates with the same size/difficulty).
+  - 409 on approve surfaces the server's `detail` (e.g. no active questions →
+    regenerate hint).
+  - List-error → "Couldn't load drafts" + Retry (never the empty state, per
+    this batch's sweep); loading → 2 shape-matched skeletons; empty → an
+    explanatory card.
+  - Generate controls: question count (1–20, default 8) + difficulty (1–5,
+    default 2) + "Draft an assignment". Footer: "AI proposes, you decide."
+- **`frontend_modern/src/features/teacher/TeacherDashboard.tsx`** — panel
+  mounted in `RoomInsights` alongside `InterventionsPanel` /
+  `MisconceptionClustersPanel`. Mounting per subject-room (prop, not a room
+  select) matches how the sibling panels already work — the plan's SubjectRoom
+  dropdown became unnecessary.
+
+## Backend
+
+None — `AssignmentDraftViewSet` (views.py:1450) was already complete,
+permission-scoped (teacher's own rooms only) and tested; no serializer gaps
+surfaced.
+
+## Tests
+
+`AssignmentDraftsPanel.test.tsx` — 10 cases: collapsed-by-default +
+skeleton-not-empty while loading; explanatory empty state; ready-card render
+(rationale, chips, counts, provenance badge, actions); stub Auto-drafted
+path; generate → pending card; approve happy path (asserts the assignment
+link); approve 409 surfaces server detail; dismiss removes the card; failed
+card with error detail + retry; list-error + Retry recovery.
+
+Full gate: lint, `tsc --noEmit`, `vitest run` (290 passed / 48 files),
+`npm run build` — all green.
+
+## Next steps
+
+- ASA-7 (open-response grading UI) — last dark endpoint group, its own
+  batch-anchor run.
+- Continuous-improvement pool: shared `AIBadge`, `useAsyncGeneration` hook
+  (this panel re-implements the 202-then-poll pattern a third time).
+- Manual Docker-stack screenshot pending (stack not running in this session);
+  panel follows the proven sibling-panel layout.

--- a/frontend_modern/src/features/teacher/AssignmentDraftsPanel.test.tsx
+++ b/frontend_modern/src/features/teacher/AssignmentDraftsPanel.test.tsx
@@ -1,0 +1,270 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { AssignmentDraftsPanel } from './AssignmentDraftsPanel';
+import type { AssignmentDraft } from './useAssignmentDrafts';
+
+const { mockGet, mockPost } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPost: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    get: mockGet,
+    post: mockPost,
+  },
+}));
+
+const READY_DRAFT: AssignmentDraft = {
+  id: 11,
+  subject_room: 1,
+  subject_name: 'Mathematics',
+  classroom_label: 'Std 8 A',
+  status: 'ready',
+  title: 'Practice: Fractions',
+  rationale_text: 'The class averages 42% on Fractions; these 8 questions target that gap.',
+  target_difficulty: 2,
+  requested_size: 8,
+  target_chapters: [
+    { chapter_id: 1, chapter_name: 'Fractions', avg_score: 0.42, tick_count: 40 },
+    { chapter_id: 2, chapter_name: 'Decimals', avg_score: 0.55, tick_count: 22 },
+  ],
+  selected_questions: [
+    {
+      question_id: 5,
+      chapter_id: 1,
+      chapter_name: 'Fractions',
+      difficulty: 2,
+      question_type: 'mcq',
+      preview: 'What is 1/2 + 1/3?',
+      reason: 'targets Fractions (42% avg)',
+    },
+  ],
+  question_count: 8,
+  estimated_minutes: 24,
+  is_actionable: true,
+  approved_problem_set: null,
+  approved_assignment: null,
+  model_used: 'claude-sonnet-4-6',
+  error_detail: '',
+  created_at: '2026-06-10T08:00:00Z',
+  updated_at: '2026-06-10T08:00:05Z',
+};
+
+function renderPanel() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <AssignmentDraftsPanel subjectRoomId={1} />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+async function expandPanel(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: /ai assignment drafts/i }));
+}
+
+describe('AssignmentDraftsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is collapsed by default and shows skeletons — not the empty state — while loading', async () => {
+    const user = userEvent.setup();
+    let resolveGet!: (value: { data: { results: AssignmentDraft[] } }) => void;
+    mockGet.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveGet = resolve;
+        })
+    );
+
+    renderPanel();
+    expect(mockGet).not.toHaveBeenCalled();
+
+    await expandPanel(user);
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0);
+    expect(screen.queryByText(/no drafts yet/i)).toBeNull();
+
+    resolveGet({ data: { results: [READY_DRAFT] } });
+    await waitFor(() => expect(screen.getByText('Practice: Fractions')).toBeDefined());
+    expect(mockGet).toHaveBeenCalledWith('/ai/assignment-drafts/?subject_room=1');
+  });
+
+  it('explains what the feature does when there are no drafts', async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue({ data: [] });
+
+    renderPanel();
+    await expandPanel(user);
+
+    await waitFor(() => expect(screen.getByText(/no drafts yet/i)).toBeDefined());
+    expect(screen.getByRole('button', { name: /draft an assignment/i })).toBeDefined();
+  });
+
+  it('renders a ready draft: rationale, chapter chips, counts and provenance badge', async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue({ data: [READY_DRAFT] });
+
+    renderPanel();
+    await expandPanel(user);
+
+    await waitFor(() => expect(screen.getByText('Practice: Fractions')).toBeDefined());
+    expect(screen.getByText(/averages 42% on Fractions/)).toBeDefined();
+    expect(screen.getByText('Fractions')).toBeDefined();
+    expect(screen.getByText('Decimals')).toBeDefined();
+    expect(screen.getByText(/8 questions · ~24 min/)).toBeDefined();
+    expect(screen.getByText('✨ AI-generated')).toBeDefined();
+    expect(screen.getByRole('button', { name: /approve/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /dismiss/i })).toBeDefined();
+  });
+
+  it('labels a stub-built draft as Auto-drafted with a fallback note', async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue({ data: [{ ...READY_DRAFT, model_used: 'stub' }] });
+
+    renderPanel();
+    await expandPanel(user);
+
+    await waitFor(() => expect(screen.getByText('Auto-drafted')).toBeDefined());
+    expect(screen.getByText(/AI was unavailable/)).toBeDefined();
+    expect(screen.queryByText('✨ AI-generated')).toBeNull();
+  });
+
+  it('generate posts the request and shows the pending card while assembly runs', async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValueOnce({ data: [] });
+    mockPost.mockResolvedValue({ data: { ...READY_DRAFT, id: 12, status: 'pending' } });
+    mockGet.mockResolvedValue({ data: [{ ...READY_DRAFT, id: 12, status: 'pending' }] });
+
+    renderPanel();
+    await expandPanel(user);
+    await waitFor(() => expect(screen.getByText(/no drafts yet/i)).toBeDefined());
+
+    await user.click(screen.getByRole('button', { name: /draft an assignment/i }));
+
+    await waitFor(() =>
+      expect(mockPost).toHaveBeenCalledWith('/ai/assignment-drafts/generate/', {
+        subject_room_id: 1,
+        size: 8,
+        target_difficulty: 2,
+      })
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/assembling a draft from your class's weak spots/i)).toBeDefined()
+    );
+  });
+
+  it('approve happy path: posts due date and links to the created assignment', async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValueOnce({ data: [READY_DRAFT] });
+    const approved = {
+      ...READY_DRAFT,
+      status: 'approved' as const,
+      approved_problem_set: 31,
+      approved_assignment: 77,
+    };
+    mockPost.mockResolvedValue({ data: approved });
+    mockGet.mockResolvedValue({ data: [approved] });
+
+    renderPanel();
+    await expandPanel(user);
+    await waitFor(() => expect(screen.getByText('Practice: Fractions')).toBeDefined());
+
+    await user.click(screen.getByRole('button', { name: /approve/i }));
+    await user.click(screen.getByRole('button', { name: /assign to class/i }));
+
+    await waitFor(() =>
+      expect(mockPost).toHaveBeenCalledWith(
+        '/ai/assignment-drafts/11/approve/',
+        expect.objectContaining({ due_at: expect.stringMatching(/T/) })
+      )
+    );
+    await waitFor(() => expect(screen.getByText('Assigned')).toBeDefined());
+    const link = screen.getByRole('link', { name: /view the assignment/i });
+    expect(link.getAttribute('href')).toBe('/teacher/assignments/77');
+  });
+
+  it('approve conflict (409) surfaces the server detail instead of failing silently', async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue({ data: [READY_DRAFT] });
+    mockPost.mockRejectedValue({
+      response: {
+        status: 409,
+        data: { detail: "None of the draft's questions are still active. Regenerate the draft." },
+      },
+    });
+
+    renderPanel();
+    await expandPanel(user);
+    await waitFor(() => expect(screen.getByText('Practice: Fractions')).toBeDefined());
+
+    await user.click(screen.getByRole('button', { name: /approve/i }));
+    await user.click(screen.getByRole('button', { name: /assign to class/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/none of the draft's questions are still active/i)).toBeDefined()
+    );
+  });
+
+  it('dismiss posts and the card leaves the list', async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValueOnce({ data: [READY_DRAFT] });
+    const dismissed = { ...READY_DRAFT, status: 'dismissed' as const };
+    mockPost.mockResolvedValue({ data: dismissed });
+    mockGet.mockResolvedValue({ data: [dismissed] });
+
+    renderPanel();
+    await expandPanel(user);
+    await waitFor(() => expect(screen.getByText('Practice: Fractions')).toBeDefined());
+
+    await user.click(screen.getByRole('button', { name: /dismiss/i }));
+
+    await waitFor(() =>
+      expect(mockPost).toHaveBeenCalledWith('/ai/assignment-drafts/11/dismiss/', {})
+    );
+    await waitFor(() => expect(screen.queryByText('Practice: Fractions')).toBeNull());
+  });
+
+  it('renders a failed draft with its error detail and a retry action', async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue({
+      data: [
+        {
+          ...READY_DRAFT,
+          status: 'failed' as const,
+          error_detail: 'Not enough practice data in this room yet.',
+        },
+      ],
+    });
+
+    renderPanel();
+    await expandPanel(user);
+
+    await waitFor(() =>
+      expect(screen.getByText(/couldn't put this draft together/i)).toBeDefined()
+    );
+    expect(screen.getByText(/not enough practice data/i)).toBeDefined();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeDefined();
+  });
+
+  it('shows an error with retry — not the empty state — when the list fetch fails', async () => {
+    const user = userEvent.setup();
+    mockGet.mockRejectedValueOnce(new Error('network down'));
+    mockGet.mockResolvedValue({ data: [READY_DRAFT] });
+
+    renderPanel();
+    await expandPanel(user);
+
+    await waitFor(() => expect(screen.getByText(/couldn't load drafts just now/i)).toBeDefined());
+    expect(screen.queryByText(/no drafts yet/i)).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+    await waitFor(() => expect(screen.getByText('Practice: Fractions')).toBeDefined());
+  });
+});

--- a/frontend_modern/src/features/teacher/AssignmentDraftsPanel.tsx
+++ b/frontend_modern/src/features/teacher/AssignmentDraftsPanel.tsx
@@ -1,0 +1,376 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Badge, Button, Skeleton } from '@/shared/ui';
+import {
+  errorDetail,
+  useAssignmentDrafts,
+  useApproveAssignmentDraft,
+  useDismissAssignmentDraft,
+  useGenerateAssignmentDraft,
+  type AssignmentDraft,
+} from './useAssignmentDrafts';
+
+const pct = (v: number): string => `${Math.round(v * 100)}%`;
+
+/** Default due date for an approved draft: a week out, as a date-input value. */
+const defaultDueDate = (): string => {
+  const d = new Date();
+  d.setDate(d.getDate() + 7);
+  return d.toISOString().slice(0, 10);
+};
+
+interface ApproveFormProps {
+  draft: AssignmentDraft;
+  subjectRoomId: number;
+  onCancel: () => void;
+}
+
+const ApproveForm = ({ draft, subjectRoomId, onCancel }: ApproveFormProps) => {
+  const approve = useApproveAssignmentDraft(subjectRoomId);
+  const [dueDate, setDueDate] = useState(defaultDueDate());
+  const [title, setTitle] = useState('');
+
+  const conflictDetail = approve.isError ? errorDetail(approve.error) : null;
+
+  return (
+    <form
+      className="mt-3 rounded-lg border border-ink-100 bg-ink-50/60 p-3 space-y-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (!dueDate) return;
+        approve.mutate({
+          id: draft.id,
+          due_at: new Date(dueDate).toISOString(),
+          title: title.trim() || undefined,
+        });
+      }}
+    >
+      <label className="block text-xs text-ink-600">
+        Due date
+        <input
+          type="date"
+          required
+          value={dueDate}
+          min={new Date().toISOString().slice(0, 10)}
+          onChange={(e) => setDueDate(e.target.value)}
+          className="input-brand mt-1 block w-full max-w-[12rem] text-sm"
+        />
+      </label>
+      <label className="block text-xs text-ink-600">
+        Title <span className="text-ink-400">(optional — keeps the draft's title if blank)</span>
+        <input
+          type="text"
+          value={title}
+          maxLength={255}
+          placeholder={draft.title || 'Practice set'}
+          onChange={(e) => setTitle(e.target.value)}
+          className="input-brand mt-1 block w-full text-sm"
+        />
+      </label>
+
+      {approve.isError && (
+        <p className="text-xs text-rose-600">
+          {conflictDetail ?? "Couldn't approve the draft just now. Please try again in a moment."}
+          {conflictDetail?.includes('Regenerate') && ' Use "Try again" to build a fresh draft.'}
+        </p>
+      )}
+
+      <div className="flex gap-2 pt-1">
+        <Button type="submit" variant="brand" size="sm" disabled={approve.isPending || !dueDate}>
+          {approve.isPending ? 'Assigning…' : 'Assign to class'}
+        </Button>
+        <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+interface CardProps {
+  draft: AssignmentDraft;
+  subjectRoomId: number;
+}
+
+const DraftCard = ({ draft, subjectRoomId }: CardProps) => {
+  const dismiss = useDismissAssignmentDraft(subjectRoomId);
+  const regenerate = useGenerateAssignmentDraft(subjectRoomId);
+  const [approving, setApproving] = useState(false);
+  // Like the sibling panels: the deterministic fallback selection is still
+  // useful, but must never read as genuine AI output (provider transparency).
+  const isStub = draft.model_used === 'stub';
+
+  if (draft.status === 'pending') {
+    return (
+      <div className="rounded-xl border border-ink-100 bg-paper p-4">
+        <div className="flex items-center gap-2">
+          <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-brand-500" aria-hidden />
+          <p className="text-sm text-ink-700">
+            Assembling a draft from your class&apos;s weak spots…
+          </p>
+        </div>
+        <p className="mt-1 text-xs text-ink-400">This usually takes a few seconds.</p>
+      </div>
+    );
+  }
+
+  if (draft.status === 'failed') {
+    return (
+      <div className="rounded-xl border border-rose-100 bg-rose-50/50 p-4">
+        <p className="text-sm text-ink-700">Couldn&apos;t put this draft together.</p>
+        {draft.error_detail && <p className="mt-1 text-xs text-ink-500">{draft.error_detail}</p>}
+        <div className="mt-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={regenerate.isPending}
+            onClick={() =>
+              regenerate.mutate({
+                size: draft.requested_size,
+                target_difficulty: draft.target_difficulty,
+              })
+            }
+          >
+            {regenerate.isPending ? 'Retrying…' : 'Try again'}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (draft.status === 'approved') {
+    return (
+      <div className="rounded-xl border border-emerald-100 bg-emerald-50/50 p-4">
+        <div className="flex items-start justify-between gap-3">
+          <p className="font-display text-base text-ink-900 leading-tight min-w-0">
+            {draft.title || 'Practice set'}
+          </p>
+          <Badge tone="success">Assigned</Badge>
+        </div>
+        {draft.approved_assignment != null && (
+          <p className="mt-2 text-xs text-ink-600">
+            <Link
+              to={`/teacher/assignments/${draft.approved_assignment}`}
+              className="font-medium text-brand-700 hover:text-brand-800 underline"
+            >
+              View the assignment
+            </Link>{' '}
+            — your class can see it now.
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  // ready
+  return (
+    <div className="rounded-xl border border-ink-100 bg-paper p-4">
+      <div className="flex items-start justify-between gap-3">
+        <p className="font-display text-base text-ink-900 leading-tight min-w-0">
+          {draft.title || 'Practice set'}
+        </p>
+        <Badge tone={isStub ? 'neutral' : 'brand'} className="shrink-0">
+          {isStub ? 'Auto-drafted' : '✨ AI-generated'}
+        </Badge>
+      </div>
+
+      {draft.rationale_text && (
+        <p className="mt-2 text-sm text-ink-700 leading-relaxed">{draft.rationale_text}</p>
+      )}
+      {isStub && (
+        <p className="mt-1 text-xs text-ink-400">
+          AI was unavailable, so this draft was built directly from your class&apos;s practice data.
+        </p>
+      )}
+
+      {draft.target_chapters.length > 0 && (
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {draft.target_chapters.map((c) => (
+            <span
+              key={c.chapter_id}
+              className="inline-flex items-center gap-1 rounded-full bg-ink-100 px-2.5 py-0.5 text-xs text-ink-700"
+            >
+              {c.chapter_name}
+              <span className="text-ink-400">{pct(c.avg_score)}</span>
+            </span>
+          ))}
+        </div>
+      )}
+
+      <p className="mt-2 text-xs text-ink-500">
+        {draft.question_count} question{draft.question_count !== 1 ? 's' : ''}
+        {draft.estimated_minutes > 0 && ` · ~${draft.estimated_minutes} min`}
+      </p>
+
+      {dismiss.isError && (
+        <p className="mt-2 text-xs text-rose-600">
+          Couldn&apos;t dismiss the draft just now. Please try again in a moment.
+        </p>
+      )}
+
+      {approving ? (
+        <ApproveForm draft={draft} subjectRoomId={subjectRoomId} onCancel={() => setApproving(false)} />
+      ) : (
+        <div className="mt-3 flex items-center justify-end gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={dismiss.isPending}
+            onClick={() => dismiss.mutate({ id: draft.id })}
+          >
+            Dismiss
+          </Button>
+          <Button variant="brand" size="sm" onClick={() => setApproving(true)}>
+            Approve…
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// Mirrors the ready DraftCard layout so the list doesn't reflow when data lands.
+const DraftCardSkeleton = () => (
+  <div className="rounded-xl border border-ink-100 bg-paper p-4">
+    <div className="flex items-start justify-between gap-3">
+      <Skeleton w="w-1/2" h="h-5" />
+      <Skeleton w="w-24" h="h-5" rounded="rounded-full" />
+    </div>
+    <div className="mt-3 space-y-1.5">
+      <Skeleton w="w-full" h="h-3" />
+      <Skeleton w="w-5/6" h="h-3" />
+    </div>
+    <div className="mt-3 flex gap-1.5">
+      <Skeleton w="w-24" h="h-5" rounded="rounded-full" />
+      <Skeleton w="w-20" h="h-5" rounded="rounded-full" />
+    </div>
+  </div>
+);
+
+interface Props {
+  subjectRoomId: number;
+}
+
+/**
+ * AI assignment drafts — the first consumer of /ai/assignment-drafts/ (ASA-6).
+ * One click takes a teacher from "my class is weak on X" to a reviewable
+ * draft (selection + rationale) and, on approval, to a real ProblemSet +
+ * Assignment. The teacher always has final say: approve with a due date, or
+ * dismiss. Collapsed by default like its sibling insight panels; data only
+ * loads when a teacher opens it.
+ */
+export const AssignmentDraftsPanel = ({ subjectRoomId }: Props) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const {
+    data: drafts,
+    isLoading,
+    isError,
+    refetch,
+  } = useAssignmentDrafts(subjectRoomId, isExpanded);
+  const generate = useGenerateAssignmentDraft(subjectRoomId);
+  const [size, setSize] = useState(8);
+  const [difficulty, setDifficulty] = useState(2);
+
+  // Dismissed drafts stay queryable server-side but add only noise here.
+  const visible = (drafts ?? []).filter((d) => d.status !== 'dismissed');
+  const actionable = visible.filter((d) => d.status === 'ready' || d.status === 'pending');
+
+  return (
+    <div className="mt-3 border-t border-ink-100 pt-3">
+      <button
+        onClick={() => setIsExpanded((v) => !v)}
+        aria-expanded={isExpanded}
+        className="flex items-center gap-1.5 text-xs font-semibold text-ink-500 hover:text-ink-800 transition-colors w-full text-left"
+      >
+        <span>AI Assignment Drafts</span>
+        {actionable.length > 0 && <Badge tone="brand">{actionable.length}</Badge>}
+        <span className={`ml-auto transition-transform ${isExpanded ? 'rotate-180' : ''}`}>▾</span>
+      </button>
+
+      {isExpanded && (
+        <div className="mt-3 space-y-3">
+          {isLoading && (
+            <>
+              <DraftCardSkeleton />
+              <DraftCardSkeleton />
+            </>
+          )}
+
+          {/* A failed fetch must not masquerade as "no drafts yet" — that would
+              invite the teacher to generate a duplicate of a draft that may
+              already be waiting for review. */}
+          {!isLoading && isError && (
+            <p className="text-xs text-rose-600 py-2">
+              Couldn&apos;t load drafts just now.{' '}
+              <button
+                type="button"
+                onClick={() => void refetch()}
+                className="font-medium underline hover:text-rose-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 rounded"
+              >
+                Retry
+              </button>
+            </p>
+          )}
+
+          {!isLoading && !isError && visible.length === 0 && (
+            <div className="text-xs text-ink-500 py-2">
+              No drafts yet — let AI assemble a practice set from this class&apos;s weakest
+              chapters, then review and assign it.
+            </div>
+          )}
+
+          {!isLoading &&
+            !isError &&
+            visible.map((d) => <DraftCard key={d.id} draft={d} subjectRoomId={subjectRoomId} />)}
+
+          {generate.isError && (
+            <p className="text-xs text-rose-600 pt-1">
+              Couldn&apos;t start a draft just now. Please try again in a moment.
+            </p>
+          )}
+
+          <div className="flex flex-wrap items-end justify-between gap-2 pt-1">
+            <div className="flex items-end gap-2">
+              <label className="block text-xs text-ink-500">
+                Questions
+                <input
+                  type="number"
+                  min={1}
+                  max={20}
+                  value={size}
+                  onChange={(e) => setSize(Math.min(20, Math.max(1, Number(e.target.value) || 1)))}
+                  className="input-brand mt-1 block w-16 text-sm"
+                />
+              </label>
+              <label className="block text-xs text-ink-500">
+                Difficulty
+                <select
+                  value={difficulty}
+                  onChange={(e) => setDifficulty(Number(e.target.value))}
+                  className="input-brand mt-1 block w-20 text-sm"
+                >
+                  {[1, 2, 3, 4, 5].map((d) => (
+                    <option key={d} value={d}>
+                      {d}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={generate.isPending}
+              onClick={() => generate.mutate({ size, target_difficulty: difficulty })}
+            >
+              {generate.isPending ? 'Starting…' : 'Draft an assignment'}
+            </Button>
+          </div>
+          <p className="text-xs text-ink-400">
+            AI proposes, you decide — nothing reaches students until you approve it.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend_modern/src/features/teacher/TeacherDashboard.tsx
+++ b/frontend_modern/src/features/teacher/TeacherDashboard.tsx
@@ -7,6 +7,7 @@ import { ClassHealthPanel } from './ClassHealthPanel';
 import { WeeklyReportPanel } from './WeeklyReportPanel';
 import { InterventionsPanel } from './InterventionsPanel';
 import { MisconceptionClustersPanel } from './MisconceptionClustersPanel';
+import { AssignmentDraftsPanel } from './AssignmentDraftsPanel';
 import { QuestionQualityPanel } from './QuestionQualityPanel';
 import { ClassroomCodeWidget } from './ClassroomCodeWidget';
 import { NeedsAttentionPanel } from './NeedsAttentionPanel';
@@ -83,6 +84,7 @@ const RoomInsights = ({ subjectRoomId }: { subjectRoomId: number }) => {
           <WeeklyReportPanel subjectRoomId={subjectRoomId} />
           <InterventionsPanel subjectRoomId={subjectRoomId} />
           <MisconceptionClustersPanel subjectRoomId={subjectRoomId} />
+          <AssignmentDraftsPanel subjectRoomId={subjectRoomId} />
           <QuestionQualityPanel subjectRoomId={subjectRoomId} />
         </div>
       )}

--- a/frontend_modern/src/features/teacher/useAssignmentDrafts.ts
+++ b/frontend_modern/src/features/teacher/useAssignmentDrafts.ts
@@ -1,0 +1,134 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+
+export type AssignmentDraftStatus = 'pending' | 'ready' | 'approved' | 'dismissed' | 'failed';
+
+export interface DraftTargetChapter {
+  chapter_id: number;
+  chapter_name: string;
+  avg_score: number;
+  tick_count: number;
+}
+
+export interface DraftSelectedQuestion {
+  question_id: number;
+  chapter_id: number;
+  chapter_name: string;
+  difficulty: number;
+  question_type: string;
+  preview: string;
+  reason: string;
+}
+
+/** Mirrors AssignmentDraftSerializer (backend/openshiksha/apps/ai/serializers.py). */
+export interface AssignmentDraft {
+  id: number;
+  subject_room: number;
+  subject_name: string;
+  classroom_label: string;
+  status: AssignmentDraftStatus;
+  title: string;
+  rationale_text: string;
+  target_difficulty: number;
+  requested_size: number;
+  target_chapters: DraftTargetChapter[];
+  selected_questions: DraftSelectedQuestion[];
+  question_count: number;
+  estimated_minutes: number;
+  is_actionable: boolean;
+  approved_problem_set: number | null;
+  approved_assignment: number | null;
+  model_used: string;
+  error_detail: string;
+  created_at: string;
+  updated_at: string;
+}
+
+const draftsKey = (subjectRoomId: number) => ['ai', 'assignment-drafts', subjectRoomId];
+
+/**
+ * Draft assembly is async on the server (generate returns 202 with a pending
+ * row; a Celery task fills in the selection + rationale). While any draft is
+ * pending the list refetches on an interval so the card flips to ready/failed
+ * by itself — and the polling stops as soon as nothing is pending.
+ */
+export const useAssignmentDrafts = (
+  subjectRoomId: number,
+  enabled: boolean,
+  pollIntervalMs = 3000
+) =>
+  useQuery<AssignmentDraft[]>({
+    queryKey: draftsKey(subjectRoomId),
+    queryFn: async () => {
+      const { data } = await apiClient.get<AssignmentDraft[] | { results: AssignmentDraft[] }>(
+        `/ai/assignment-drafts/?subject_room=${subjectRoomId}`
+      );
+      return Array.isArray(data) ? data : (data.results ?? []);
+    },
+    enabled,
+    staleTime: 60 * 1000,
+    refetchInterval: (query) =>
+      (query.state.data ?? []).some((d) => d.status === 'pending') ? pollIntervalMs : false,
+  });
+
+export const useGenerateAssignmentDraft = (subjectRoomId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation<AssignmentDraft, Error, { size?: number; target_difficulty?: number }>({
+    mutationFn: async (opts) => {
+      const { data } = await apiClient.post<AssignmentDraft>('/ai/assignment-drafts/generate/', {
+        subject_room_id: subjectRoomId,
+        ...opts,
+      });
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: draftsKey(subjectRoomId) });
+    },
+  });
+};
+
+export const useApproveAssignmentDraft = (subjectRoomId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation<AssignmentDraft, Error, { id: number; due_at: string; title?: string }>({
+    mutationFn: async ({ id, due_at, title }) => {
+      const { data } = await apiClient.post<AssignmentDraft>(
+        `/ai/assignment-drafts/${id}/approve/`,
+        title ? { due_at, title } : { due_at }
+      );
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: draftsKey(subjectRoomId) });
+    },
+  });
+};
+
+export const useDismissAssignmentDraft = (subjectRoomId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation<AssignmentDraft, Error, { id: number }>({
+    mutationFn: async ({ id }) => {
+      const { data } = await apiClient.post<AssignmentDraft>(
+        `/ai/assignment-drafts/${id}/dismiss/`,
+        {}
+      );
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: draftsKey(subjectRoomId) });
+    },
+  });
+};
+
+/** Extract the server's `detail` message from an axios-shaped error (e.g. a 409). */
+export const errorDetail = (error: unknown): string | null => {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'response' in error &&
+    typeof (error as { response?: { data?: { detail?: unknown } } }).response?.data?.detail ===
+      'string'
+  ) {
+    return (error as { response: { data: { detail: string } } }).response.data.detail;
+  }
+  return null;
+};


### PR DESCRIPTION
## Classification
New — ASA-6, batch anchor of the 2026-06-10 daily plan (PR 5).

## What
`/ai/assignment-drafts/` was fully built and tested with **zero frontend consumers**. This wires it into the teacher dashboard as a collapsible **AI Assignment Drafts** panel per subject room (inside the existing room-insights disclosure, alongside `InterventionsPanel`/`MisconceptionClustersPanel`):

- **Generate**: question count (1–20, default 8) + difficulty (1–5, default 2) → `POST generate/` (202) → pending card ("Assembling a draft from your class's weak spots…"). The list polls every 3 s **only while a draft is pending** and stops by itself.
- **Ready card**: title, rationale, target-chapter chips with class averages, count + estimated minutes, `✨ AI-generated` vs `Auto-drafted` + stub note from `model_used`.
- **Approve…**: inline form (due date, default 7 days out; optional title) → `POST approve/` (201) → "Assigned" card with a router `Link` to `/teacher/assignments/{id}`. A 409 surfaces the server's `detail` (e.g. stale questions → regenerate hint).
- **Dismiss** / **failed card** with `error_detail` + "Try again".
- List-error → error + Retry (never the empty state — consistent with #293/#294); loading → shape-matched skeletons; explanatory empty state.

Per-room mounting (prop, not a SubjectRoom dropdown) matches how every sibling panel already works.

## Backend
None — `AssignmentDraftViewSet` was complete, teacher-scoped and tested. No serializer gaps surfaced.

## Legacy reference
Legacy (`core/`, `sphinx/`) teachers hand-picked ProblemSets with no guidance on *what* to assign. The draft fuses the analytics conclusion with the action; the teacher keeps final say.

## Tests
`AssignmentDraftsPanel.test.tsx` — 10 cases (skeleton-not-empty, empty state, ready render, stub badge, generate→pending, approve happy path + link, approve 409 detail, dismiss, failed+retry, list-error+Retry recovery).
Full gate: lint + tsc + **vitest 290/290 (48 files)** + `npm run build` all green.

## How to verify
Teacher dashboard → expand a room's insights → "AI Assignment Drafts" → Draft an assignment → pending → ready → Approve with a due date → follow the link to the live assignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)