### PR TITLE
docs(initiatives): ASA batch 2 shipped — ledger rows + status headline

### DIFF
--- a/docs/initiatives/STATUS.md
+++ b/docs/initiatives/STATUS.md
@@ -4,12 +4,21 @@
 > task advances the **top active initiative** here. See [`README.md`](README.md)
 > for how. Keep this file short - one row per initiative.
 
-**Last updated:** 2026-06-10 — **ASA batch 2 planned**
-([2026-06-10-plan.md](../daily-plans/2026-06-10-plan.md)): ASA-6 assignment-draft
-builder (anchor — lights the 3rd dark endpoint group), ASA-8 drill explanations,
-ASA-9 SRS server-side repeat guard, plus the last two error-as-empty-state
-panels (`InterventionsPanel`, `WeeklyReportPanel`). #291 (misconception-panel
-error/skeleton polish) merged this morning.
+**Last updated:** 2026-06-10 — **ASA batch 2 shipped:
+[#293](https://github.com/openshiksha/openshiksha/pull/293)–[#297](https://github.com/openshiksha/openshiksha/pull/297)**
+(per [2026-06-10-plan.md](../daily-plans/2026-06-10-plan.md)). Teachers can now
+generate, review and approve **AI-drafted assignments** straight from the
+dashboard (#297 — first `/ai/assignment-drafts/` consumer; **3 of 4 dark
+endpoint groups lit**); SRS drill result screens offer per-subpart AI
+explanations (#296); the server now guarantees one SM-2 update per entry per
+day (#295); and the error-as-empty-state sweep is **complete** across all
+teacher AI panels (#293 `InterventionsPanel`, #294 `WeeklyReportPanel`).
+Remaining: ASA-7 (open-response grading UI — last dark group, its own
+batch-anchor run), then the continuous-improvement pool (shared `AIBadge`,
+`useAsyncGeneration`) and the initiative DoD audit.
+
+Earlier same day — ASA batch 2 planned; #291 (misconception-panel
+error/skeleton polish) merged in the morning.
 
 Earlier (2026-06-09 evening) — **ASA first batch shipped: ASA-1..5
 across [#285](https://github.com/openshiksha/openshiksha/pull/285)–[#289](https://github.com/openshiksha/openshiksha/pull/289).**

--- a/docs/initiatives/ai-surface-activation.md
+++ b/docs/initiatives/ai-surface-activation.md
@@ -67,10 +67,10 @@ the platform earns trust by always labelling what is AI vs. data-derived.
 | ASA-3 | SRS drill repeat-review guard: second pass in one sitting is practice-only, never a second SM-2 update | ✅ [#287](https://github.com/openshiksha/openshiksha/pull/287) |
 | ASA-4 | Wire `/ai/explanations/` into post-submit assignment feedback (per-subpart "Explain" → generate → poll → labelled explanation) | ✅ [#288](https://github.com/openshiksha/openshiksha/pull/288) |
 | ASA-5 | Teacher `MisconceptionClustersPanel` on dashboard (list + refresh + AI labels) | ✅ [#289](https://github.com/openshiksha/openshiksha/pull/289) |
-| ASA-6 | Assignment draft builder UI (`/ai/assignment-drafts/`): generate → review rationale → approve into a real Assignment / dismiss | ☐ |
+| ASA-6 | Assignment draft builder UI (`/ai/assignment-drafts/`): generate → review rationale → approve into a real Assignment / dismiss | ✅ [#297](https://github.com/openshiksha/openshiksha/pull/297) |
 | ASA-7 | Open-response grading UI (`/ai/open-rubrics/` + `/ai/open-grades/`) — teacher review surface | ☐ |
-| ASA-8 | Explanations on the SRS drill result screen (reuse ASA-4's hook/panel) | ☐ |
-| ASA-9 | Backend idempotency guard for repeat SRS review in one day (defence-in-depth behind ASA-3) | ☐ |
+| ASA-8 | Explanations on the SRS drill result screen (reuse ASA-4's hook/panel) | ✅ [#296](https://github.com/openshiksha/openshiksha/pull/296) |
+| ASA-9 | Backend idempotency guard for repeat SRS review in one day (defence-in-depth behind ASA-3) | ✅ [#295](https://github.com/openshiksha/openshiksha/pull/295) |
 
 ## Definition of Done (per increment)
 
@@ -104,3 +104,8 @@ frontend consumer; every AI surface passes the checklist audit; recommendations
 | 2026-06-09 | ASA-3 — SRS repeat-review guard | [#287](https://github.com/openshiksha/openshiksha/pull/287) | Plan's "grade locally" assumption was wrong (no client-side correctness); practice rounds are unscored — the guard (one SM-2 update per sitting) is what matters. ASA-9 stays for defence-in-depth. |
 | 2026-06-09 | ASA-4 — post-submit answer explanations | [#288](https://github.com/openshiksha/openshiksha/pull/288) | Serializer lacked `model_used` (1-line fix). Per-subpart correctness doesn't exist in the API — derived conservatively from overall score; per-subpart grade breakdown is a backlog candidate. |
 | 2026-06-09 | ASA-5 — teacher misconception clusters panel | [#289](https://github.com/openshiksha/openshiksha/pull/289) | Cluster serializer has no `model_used` (aggregation, not generation) — no badge needed. InterventionsPanel pattern copied wholesale; 2 of 4 dark endpoint groups now lit. |
+| 2026-06-10 | Polish — `InterventionsPanel` list-error + skeletons | [#293](https://github.com/openshiksha/openshiksha/pull/293) | Pure pattern copy of #291; `useQuery` already exposed `isError`/`refetch`. |
+| 2026-06-10 | Polish — `WeeklyReportPanel` list-error + skeletons | [#294](https://github.com/openshiksha/openshiksha/pull/294) | Stacked on #293 (shared polish-backlog doc). Error-as-empty-state sweep now **complete** across all teacher AI panels. Hook's 404→null mapping meant only real failures hit the error path. |
+| 2026-06-10 | ASA-9 — server-side same-day SM-2 guard | [#295](https://github.com/openshiksha/openshiksha/pull/295) | "Grade, don't schedule": guarded calls still grade answers but skip schedule/ticks/streak. Additive `already_reviewed_today` flag; no migration needed. |
+| 2026-06-10 | ASA-8 — explanations on drill result screens | [#296](https://github.com/openshiksha/openshiksha/pull/296) | Zero new hooks — rendering the answered questions read-only via `QuestionCard` unlocked ASA-4's ExplanationPanel *and* worked-solution reveal for free. Practice rounds pass `null` score (ungraded client-side). |
+| 2026-06-10 | ASA-6 — assignment drafts panel (batch anchor) | [#297](https://github.com/openshiksha/openshiksha/pull/297) | 3 of 4 dark endpoint groups lit; only ASA-7 remains. Per-room mounting beat the planned room-dropdown (siblings set the convention). Third re-implementation of 202-then-poll — `useAsyncGeneration` extraction is now clearly worth it. |


### PR DESCRIPTION
## Classification
Docs — batch ledger update for the 2026-06-10 run (same split as #290 for batch 1).

## What
- `ai-surface-activation.md`: ASA-6/8/9 marked ✅ in the backlog table; 6 progress-ledger rows for [#293](https://github.com/openshiksha/openshiksha/pull/293) [#294](https://github.com/openshiksha/openshiksha/pull/294) [#295](https://github.com/openshiksha/openshiksha/pull/295) [#296](https://github.com/openshiksha/openshiksha/pull/296) [#297](https://github.com/openshiksha/openshiksha/pull/297) with learnings (incl. the now-overdue `useAsyncGeneration` extraction).
- `STATUS.md`: headline updated — batch 2 shipped, 3 of 4 dark endpoint groups lit, ASA-7 is the remaining batch-anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)