### PR TITLE
feat(ui): shared AIBadge provenance primitive, adopted on all AI surfaces

### DIFF
--- a/docs/changes/2026-06-11-shared-aibadge.md
+++ b/docs/changes/2026-06-11-shared-aibadge.md
@@ -1,0 +1,47 @@
+# Shared AIBadge primitive + adoption across all AI surfaces
+
+**Date:** 2026-06-11
+**Classification:** Improve (consolidation)
+**Initiative:** AI Surface Activation — continuous-improvement pool item 1
+
+## Summary
+
+The `✨ AI-generated` vs `Auto-…` provenance badge (initiative principle 3)
+was re-implemented as a hand-rolled ternary in five places — and
+`ExplanationPanel` used a bare uppercase span instead of the shared `Badge`
+(a known polish-backlog inconsistency). One shared primitive now owns the
+vocabulary.
+
+## What changed
+
+- **`frontend_modern/src/shared/ui/AIBadge.tsx`** (new) —
+  `<AIBadge modelUsed stubLabel? className?>`: brand-toned `✨ AI-generated`
+  for a real LLM, neutral surface-specific `Auto-…` label when
+  `model_used === 'stub'`.
+- **`frontend_modern/src/shared/ui/aiProvenance.ts`** (new) — `isAIStub()`
+  helper (separate file keeps the component file fast-refresh-clean); panels
+  use it for their contextual stub notes.
+- Exported from `ui/index.ts`; showcased on the `/design` route per the
+  design-system rule.
+- **Adopted in all five call sites** (labels unchanged, so every existing
+  badge test still passes as-is):
+  - `InterventionsPanel` — `Auto-strategy`
+  - `WeeklyReportPanel` — `Auto-summary`
+  - `parent/components/NarrativeCard` — `Auto-summary`
+  - `ExplanationPanel` — `Auto-explanation` (was a bare span → now the shared
+    Badge, closing the polish-backlog item)
+  - `AssignmentDraftsPanel` — `Auto-drafted`
+- The per-surface stub *notes* ("AI was unavailable, so this was built
+  from …") intentionally stay in the panels — they are contextual copy, not
+  badge vocabulary.
+
+## Tests
+
+New `AIBadge.test.tsx` (4 cases: LLM label, stub label, default label,
+`isAIStub` edge cases). All 5 adopting components' suites re-run green
+(38 tests across 6 files). Lint + tsc clean.
+
+## Notes
+
+Stacked on the #294 re-land (PR #299) because both touch
+`WeeklyReportPanel.tsx`.

--- a/frontend_modern/src/features/design/DesignSystemPage.tsx
+++ b/frontend_modern/src/features/design/DesignSystemPage.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   Card,
   Badge,
+  AIBadge,
   Skeleton,
   LoadingSpinner,
   Input,
@@ -143,6 +144,17 @@ export const DesignSystemPage = () => (
           <Badge tone="success">On track</Badge>
           <Badge tone="attention">Needs practice</Badge>
           <Badge tone="urgent">Sharp drop</Badge>
+        </Card>
+        <p className="mt-4 mb-3 text-sm text-ink-500">
+          AI provenance — <code>&lt;AIBadge /&gt;</code> labels every AI surface honestly:
+          brand for genuine LLM output, a neutral <em>Auto-…</em> label when the provider
+          cascade fell back to the deterministic stub.
+        </p>
+        <Card className="flex flex-wrap gap-2">
+          <AIBadge modelUsed="claude-sonnet-4-6" />
+          <AIBadge modelUsed="stub" stubLabel="Auto-summary" />
+          <AIBadge modelUsed="stub" stubLabel="Auto-strategy" />
+          <AIBadge modelUsed="stub" stubLabel="Auto-explanation" />
         </Card>
       </Section>
 

--- a/frontend_modern/src/features/parent/components/NarrativeCard.tsx
+++ b/frontend_modern/src/features/parent/components/NarrativeCard.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@/shared/ui';
+import { AIBadge, isAIStub } from '@/shared/ui';
 import type { ParentProgressSummary } from '../useParentSummary';
 
 interface Props {
@@ -22,10 +22,7 @@ const StatTile = ({ label, value }: { label: string; value: string }) => (
 
 export const NarrativeCard = ({ summary }: Props) => {
   const weekRange = `${formatDate(summary.week_start)} – ${formatDate(summary.week_end)}`;
-  // The provider cascade falls back to a deterministic, data-derived summary when
-  // no LLM key is configured. That narrative is still useful, but parents must not
-  // see it presented as genuine AI output (provider-cascade transparency).
-  const isStub = summary.model_used === 'stub';
+  const isStub = isAIStub(summary.model_used);
   const deltaPct = Math.round(summary.score_delta * 100);
   const deltaSign = summary.score_delta > 0 ? '+' : '';
   const deltaColor =
@@ -44,9 +41,7 @@ export const NarrativeCard = ({ summary }: Props) => {
           </p>
           <p className="text-sm text-ink-500 mt-1">{weekRange}</p>
         </div>
-        <Badge tone={isStub ? 'neutral' : 'brand'}>
-          {isStub ? 'Auto-summary' : '✨ AI-generated'}
-        </Badge>
+        <AIBadge modelUsed={summary.model_used} stubLabel="Auto-summary" />
       </div>
 
       <p className="mt-4 text-ink-800 leading-relaxed whitespace-pre-line">

--- a/frontend_modern/src/features/student/ExplanationPanel.tsx
+++ b/frontend_modern/src/features/student/ExplanationPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { RichContent } from '@/shared/ui/RichContent';
-import { Skeleton } from '@/shared/ui';
+import { AIBadge, Skeleton, isAIStub } from '@/shared/ui';
 import { useExplanationList, useGenerateExplanation } from './useExplanation';
 
 interface ExplanationPanelProps {
@@ -75,16 +75,14 @@ export const ExplanationPanel = ({
   }
 
   if (explanation) {
-    const isStub = explanation.model_used === 'stub';
+    const isStub = isAIStub(explanation.model_used);
     return (
       <div className="mt-3 rounded-lg border border-brand-100 bg-brand-50 p-3">
         <div className="flex items-center justify-between mb-1.5">
           <span className="text-xs font-medium text-brand-800">
             {isCorrect ? 'Why this answer is right' : 'Where this went wrong'}
           </span>
-          <span className="text-[10px] font-medium uppercase tracking-wide text-ink-400">
-            {isStub ? 'Auto-explanation' : '✨ AI-generated'}
-          </span>
+          <AIBadge modelUsed={explanation.model_used} stubLabel="Auto-explanation" />
         </div>
         <div className="text-sm text-ink-800 leading-relaxed">
           <RichContent text={explanation.explanation_text} variant="block" />

--- a/frontend_modern/src/features/teacher/AssignmentDraftsPanel.tsx
+++ b/frontend_modern/src/features/teacher/AssignmentDraftsPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Badge, Button, Skeleton } from '@/shared/ui';
+import { AIBadge, Badge, Button, Skeleton, isAIStub } from '@/shared/ui';
 import {
   errorDetail,
   useAssignmentDrafts,
@@ -96,9 +96,7 @@ const DraftCard = ({ draft, subjectRoomId }: CardProps) => {
   const dismiss = useDismissAssignmentDraft(subjectRoomId);
   const regenerate = useGenerateAssignmentDraft(subjectRoomId);
   const [approving, setApproving] = useState(false);
-  // Like the sibling panels: the deterministic fallback selection is still
-  // useful, but must never read as genuine AI output (provider transparency).
-  const isStub = draft.model_used === 'stub';
+  const isStub = isAIStub(draft.model_used);
 
   if (draft.status === 'pending') {
     return (
@@ -169,9 +167,7 @@ const DraftCard = ({ draft, subjectRoomId }: CardProps) => {
         <p className="font-display text-base text-ink-900 leading-tight min-w-0">
           {draft.title || 'Practice set'}
         </p>
-        <Badge tone={isStub ? 'neutral' : 'brand'} className="shrink-0">
-          {isStub ? 'Auto-drafted' : '✨ AI-generated'}
-        </Badge>
+        <AIBadge modelUsed={draft.model_used} stubLabel="Auto-drafted" className="shrink-0" />
       </div>
 
       {draft.rationale_text && (

--- a/frontend_modern/src/features/teacher/InterventionsPanel.tsx
+++ b/frontend_modern/src/features/teacher/InterventionsPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Badge, Button, Skeleton } from '@/shared/ui';
+import { AIBadge, Badge, Button, Skeleton, isAIStub } from '@/shared/ui';
 import {
   useGenerateInterventions,
   useInterventions,
@@ -27,10 +27,7 @@ interface CardProps {
 const SuggestionCard = ({ item, subjectRoomId }: CardProps) => {
   const setStatus = useSetInterventionStatus(subjectRoomId);
   const busy = setStatus.isPending;
-  // The provider cascade falls back to a deterministic, data-derived strategy when
-  // no LLM key is configured. That guidance is still useful, but teachers must not
-  // see it presented as genuine AI output (provider-cascade transparency).
-  const isStub = item.model_used === 'stub';
+  const isStub = isAIStub(item.model_used);
 
   return (
     <div className="rounded-xl border border-ink-100 bg-paper p-4">
@@ -45,9 +42,7 @@ const SuggestionCard = ({ item, subjectRoomId }: CardProps) => {
       </div>
 
       <div className="mt-3">
-        <Badge tone={isStub ? 'neutral' : 'brand'}>
-          {isStub ? 'Auto-strategy' : '✨ AI-generated'}
-        </Badge>
+        <AIBadge modelUsed={item.model_used} stubLabel="Auto-strategy" />
         <p className="mt-2 text-sm text-ink-700 leading-relaxed">{item.strategy_text}</p>
         {isStub && (
           <p className="mt-1 text-xs text-ink-400">

--- a/frontend_modern/src/features/teacher/WeeklyReportPanel.tsx
+++ b/frontend_modern/src/features/teacher/WeeklyReportPanel.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { apiClient } from '@/api/client';
 import { useWeeklyReport } from './useWeeklyReport';
-import { Badge, Button, Skeleton } from '@/shared/ui';
+import { AIBadge, Button, Skeleton, isAIStub } from '@/shared/ui';
 
 const triggerWeeklyReport = async (subjectRoomId: number): Promise<void> => {
   await apiClient.post('/ai/weekly-reports/generate/', { subject_room_id: subjectRoomId });
@@ -59,10 +59,7 @@ export const WeeklyReportPanel = ({ subjectRoomId }: Props) => {
     }
   };
 
-  // The provider cascade falls back to a deterministic, data-derived summary when
-  // no LLM key is configured. That text is still useful, but we must not present
-  // it as genuine AI output (provider-cascade transparency).
-  const isStub = report?.model_used === 'stub';
+  const isStub = isAIStub(report?.model_used);
 
   return (
     <div className="mt-3 border-t border-ink-100 pt-3">
@@ -126,9 +123,7 @@ export const WeeklyReportPanel = ({ subjectRoomId }: Props) => {
                 <p className="text-xs font-semibold text-brand-800">
                   Week of {formatDate(report.week_start)} – {formatDate(report.week_end)}
                 </p>
-                <Badge tone={isStub ? 'neutral' : 'brand'}>
-                  {isStub ? 'Auto-summary' : '✨ AI-generated'}
-                </Badge>
+                <AIBadge modelUsed={report.model_used} stubLabel="Auto-summary" />
               </div>
               <p className="mt-1.5 text-sm leading-relaxed text-ink-700">
                 {report.summary_text}

--- a/frontend_modern/src/shared/ui/AIBadge.test.tsx
+++ b/frontend_modern/src/shared/ui/AIBadge.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { AIBadge } from './AIBadge';
+import { isAIStub } from './aiProvenance';
+
+describe('AIBadge', () => {
+  it('labels genuine LLM output as AI-generated', () => {
+    render(<AIBadge modelUsed="claude-sonnet-4-6" stubLabel="Auto-summary" />);
+    expect(screen.getByText('✨ AI-generated')).toBeDefined();
+    expect(screen.queryByText('Auto-summary')).toBeNull();
+  });
+
+  it('labels the deterministic stub with the surface-specific Auto label', () => {
+    render(<AIBadge modelUsed="stub" stubLabel="Auto-strategy" />);
+    expect(screen.getByText('Auto-strategy')).toBeDefined();
+    expect(screen.queryByText('✨ AI-generated')).toBeNull();
+  });
+
+  it('falls back to a generic Auto label when none is given', () => {
+    render(<AIBadge modelUsed="stub" />);
+    expect(screen.getByText('Auto-generated')).toBeDefined();
+  });
+});
+
+describe('isAIStub', () => {
+  it('is true only for the stub sentinel', () => {
+    expect(isAIStub('stub')).toBe(true);
+    expect(isAIStub('claude-sonnet-4-6')).toBe(false);
+    expect(isAIStub('')).toBe(false);
+    expect(isAIStub(null)).toBe(false);
+    expect(isAIStub(undefined)).toBe(false);
+  });
+});

--- a/frontend_modern/src/shared/ui/AIBadge.tsx
+++ b/frontend_modern/src/shared/ui/AIBadge.tsx
@@ -1,0 +1,33 @@
+import { Badge } from './Badge';
+import { isAIStub } from './aiProvenance';
+
+interface AIBadgeProps {
+  /** The serializer's `model_used` field — `'stub'` means no LLM ran. */
+  modelUsed: string;
+  /**
+   * Label when the provider cascade fell back to the stub. Name what the
+   * fallback *is* on this surface: "Auto-summary", "Auto-strategy",
+   * "Auto-drafted", "Auto-explanation", …
+   */
+  stubLabel?: string;
+  className?: string;
+}
+
+/**
+ * Provider-transparency badge for every AI surface: brand-toned
+ * `✨ AI-generated` for genuine LLM output, neutral `Auto-…` when the cascade
+ * fell back to the deterministic stub. Deterministic output is still useful,
+ * but must never be presented as AI. One vocabulary across student, teacher
+ * and parent surfaces — pair with a short plain-language note on the stub
+ * path explaining where the content came from.
+ */
+export const AIBadge = ({ modelUsed, stubLabel = 'Auto-generated', className }: AIBadgeProps) =>
+  isAIStub(modelUsed) ? (
+    <Badge tone="neutral" className={className}>
+      {stubLabel}
+    </Badge>
+  ) : (
+    <Badge tone="brand" className={className}>
+      ✨ AI-generated
+    </Badge>
+  );

--- a/frontend_modern/src/shared/ui/aiProvenance.ts
+++ b/frontend_modern/src/shared/ui/aiProvenance.ts
@@ -1,0 +1,5 @@
+/**
+ * True when the LLM cascade fell back to the deterministic, data-derived stub.
+ * Every AI serializer carries `model_used`; `'stub'` is the no-LLM sentinel.
+ */
+export const isAIStub = (modelUsed: string | null | undefined): boolean => modelUsed === 'stub';

--- a/frontend_modern/src/shared/ui/index.ts
+++ b/frontend_modern/src/shared/ui/index.ts
@@ -14,6 +14,8 @@ export { Logo } from './Logo';
 export { Button } from './Button';
 export { Card } from './Card';
 export { Badge } from './Badge';
+export { AIBadge } from './AIBadge';
+export { isAIStub } from './aiProvenance';
 export { Skeleton } from './Skeleton';
 export { LoadingSpinner } from './LoadingSpinner';
 export { ErrorBoundary } from './ErrorBoundary';


### PR DESCRIPTION
## Classification
Improve (consolidation) — ASA continuous-improvement pool item 1. **Stacked on #299** (both touch `WeeklyReportPanel.tsx`) — merge #299 first, then **retarget this PR to `modernization`** before merging (don't merge into the stack branch; that's what orphaned #294).

## What
- New `<AIBadge modelUsed stubLabel?>` in `src/shared/ui`: brand `✨ AI-generated` for real LLM output, neutral surface-specific `Auto-…` when `model_used === 'stub'`. `isAIStub()` helper in `aiProvenance.ts` for the contextual stub notes.
- Adopted at all five call sites — `InterventionsPanel` (Auto-strategy), `WeeklyReportPanel` (Auto-summary), `NarrativeCard` (Auto-summary), `ExplanationPanel` (Auto-explanation — was a bare uppercase span, now the shared Badge, closing that polish-backlog item), `AssignmentDraftsPanel` (Auto-drafted).
- Exported from `ui/index.ts` + showcased on `/design` per the design-system rule.
- Labels unchanged → all existing badge tests pass untouched.

## Tests
New `AIBadge.test.tsx` (4 cases) + all 5 adopting suites green (38 tests / 6 files). Lint + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)