### PR TITLE
feat(teacher): ASA-7a — open-response AI grading queue (first /ai/open-grades/ consumer)

### DIFF
--- a/docs/changes/2026-06-11-open-response-grading-queue.md
+++ b/docs/changes/2026-06-11-open-response-grading-queue.md
@@ -1,0 +1,74 @@
+# Open-response grading queue — first consumer of /ai/open-grades/ (ASA-7a)
+
+**Date:** 2026-06-11
+**Classification:** New (ASA-7 batch anchor, part 1 of 2)
+**Initiative:** AI Surface Activation — ASA-7a
+
+## Summary
+
+`/ai/open-grades/` was the last fully-built, tested `/ai/` endpoint group with
+zero frontend consumers. This PR wires its review surface: a teacher
+`AI grading` page (`/teacher/grading`) where free-text answers get an
+AI-suggested score, plain-language feedback, and a per-criterion breakdown —
+and the teacher finalises every one (accept in one click or override with
+their own marks + comment). The AI never finalises anything. With this, **all
+4 dark endpoint groups are lit**; ASA-7b (rubric authoring + record-response)
+completes the loop in the next PR.
+
+## Legacy reference
+
+Legacy `grader/` auto-graded MCQ/numeric only; free-text questions had no
+grading path at all (modern core pipeline grades short answers to 0). This is
+a New capability with the teacher kept firmly in the loop.
+
+## What changed
+
+- **`frontend_modern/src/features/teacher/useOpenResponseGrading.ts`** (new) —
+  `OpenResponseGrade` type mirroring `OpenResponseGradeSerializer`;
+  `useOpenGrades({subjectRoomId?, status?})` list query (array/`{results}`
+  tolerant) polling every 3 s **only while a row is pending**;
+  `useReviewOpenGrade` / `useRegradeOpenGrade` mutations invalidating all
+  open-grades lists; `gradeErrorDetail()` for axios-shaped 400/409 details.
+- **`frontend_modern/src/features/teacher/OpenResponseGradingPage.tsx`** (new) —
+  - Filters: class select (`useSubjectRooms`) + status chips (All / Needs
+    review / AI grading / Finalised / Failed).
+  - **ai_graded card**: student, question, quoted response, "AI suggests
+    X/Y" + confidence + `AIBadge` (`Auto-graded` + extra-care note on the
+    stub path — the heuristic keyword match deserves a stronger caveat than
+    other stub surfaces), criterion rows, review form (score defaults to the
+    suggestion → "Accept suggestion" is one click; typing a different score
+    relabels to "Save final grade"), "Ask AI again" (regrade).
+  - **pending**: pulsing working state (polling flips it). **failed**:
+    `error_detail` + retry. **reviewed**: final grade, override note when the
+    teacher changed the AI's score, teacher comment.
+  - List-error → error + Retry (never the empty state); loading →
+    shape-matched skeletons; empty → explanatory `EmptyState` (separate copy
+    when filters are active).
+- **`frontend_modern/src/App.tsx`** — lazy route `/teacher/grading`.
+- **`frontend_modern/src/features/teacher/TeacherDashboard.tsx`** —
+  "✨ AI grading" ghost button in the dashboard header.
+
+## Backend
+
+None — `OpenResponseGradeViewSet` was complete, teacher-scoped and tested
+(`test_open_response_grading.py`, 20 tests).
+
+## Tests
+
+`OpenResponseGradingPage.test.tsx` — 10 cases: skeleton-not-empty; ai_graded
+card render (suggestion, confidence, criteria, provenance); accept-suggestion
+posts suggested score; override posts score + comment; pending + failed
+affordances; reviewed card with override note; stub Auto-graded + care note;
+status-chip re-query; list-error + Retry recovery; explanatory empty state.
+
+Full gate: lint, tsc, **vitest 313/313 (50 files)**, build — all green.
+
+## Notes
+
+Stacked on #300 (AIBadge) which is stacked on #299 — merge in order
+#299 → #300 → this, retargeting each to `modernization` before merging.
+
+## Next steps
+
+ASA-7b: rubric authoring (max marks, model answer, criteria) + the
+"record a response" entry point on this page.

--- a/frontend_modern/src/App.tsx
+++ b/frontend_modern/src/App.tsx
@@ -43,6 +43,7 @@ const ProblemSetPreviewPage = lazyNamed(() => import('./features/teacher/Problem
 const ProblemSetVersionsPage = lazyNamed(() => import('./features/teacher/ProblemSetVersionsPage'), 'ProblemSetVersionsPage');
 const TeacherAssignmentDetailPage = lazyNamed(() => import('./features/teacher/TeacherAssignmentDetailPage'), 'TeacherAssignmentDetailPage');
 const QuestionBankPage = lazyNamed(() => import('./features/teacher/QuestionBankPage'), 'QuestionBankPage');
+const OpenResponseGradingPage = lazyNamed(() => import('./features/teacher/OpenResponseGradingPage'), 'OpenResponseGradingPage');
 const ParentDashboard = lazyNamed(() => import('./features/parent/ParentDashboard'), 'ParentDashboard');
 const ParentInsightsPage = lazyNamed(() => import('./features/parent/ParentInsightsPage'), 'ParentInsightsPage');
 const ParentInsightsLandingPage = lazyNamed(() => import('./features/parent/ParentInsightsLandingPage'), 'ParentInsightsLandingPage');
@@ -260,6 +261,17 @@ function App() {
             <ProtectedRoute>
               <AppShell>
                 <QuestionBankPage />
+              </AppShell>
+            </ProtectedRoute>
+          }
+        />
+
+        <Route
+          path="/teacher/grading"
+          element={
+            <ProtectedRoute>
+              <AppShell>
+                <OpenResponseGradingPage />
               </AppShell>
             </ProtectedRoute>
           }

--- a/frontend_modern/src/features/teacher/OpenResponseGradingPage.test.tsx
+++ b/frontend_modern/src/features/teacher/OpenResponseGradingPage.test.tsx
@@ -1,0 +1,248 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { OpenResponseGradingPage } from './OpenResponseGradingPage';
+import type { OpenResponseGrade } from './useOpenResponseGrading';
+
+const { mockGet, mockPost } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPost: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    get: mockGet,
+    post: mockPost,
+  },
+}));
+
+const ROOM = {
+  id: 1,
+  classroom: 1,
+  classroom_display: 'Std 8 A',
+  subject: 2,
+  subject_name: 'Biology',
+  teacher: 9,
+  teacher_name: 'T',
+  is_active: true,
+  student_count: 30,
+};
+
+const GRADE: OpenResponseGrade = {
+  id: 21,
+  subpart: 301,
+  question_text: 'Explain why leaves look green.',
+  student: 42,
+  student_name: 'Asha Rao',
+  student_username: 'asha',
+  subject_room: 1,
+  subject_name: 'Biology',
+  assignment: null,
+  response_text: 'Chlorophyll absorbs red and blue light and reflects green.',
+  status: 'ai_graded',
+  max_marks: 5,
+  suggested_score: 4,
+  feedback: 'Correct mechanism; mention photosynthesis explicitly for full marks.',
+  criterion_scores: [
+    { label: 'Names chlorophyll', awarded: 2, max: 2, comment: 'Present.' },
+    { label: 'Links to photosynthesis', awarded: 2, max: 3, comment: 'Implied, not named.' },
+  ],
+  confidence: 0.85,
+  final_score: null,
+  teacher_comment: '',
+  reviewed_by: null,
+  reviewed_at: null,
+  effective_score: 4,
+  is_reviewed: false,
+  model_used: 'claude-sonnet-4-6',
+  error_detail: '',
+  created_at: '2026-06-11T08:00:00Z',
+  updated_at: '2026-06-11T08:00:05Z',
+};
+
+// The page fires two GETs (subject rooms + grades) — route by URL.
+function mockApi(grades: OpenResponseGrade[] | Promise<never>) {
+  mockGet.mockImplementation((url: string) => {
+    if (url.startsWith('/subject-rooms/')) {
+      return Promise.resolve({ data: { results: [ROOM] } });
+    }
+    if (grades instanceof Promise) return grades;
+    return Promise.resolve({ data: { results: grades } });
+  });
+}
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <OpenResponseGradingPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('OpenResponseGradingPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows skeletons — not the empty state — while the queue loads', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url.startsWith('/subject-rooms/')) {
+        return Promise.resolve({ data: { results: [ROOM] } });
+      }
+      return new Promise(() => {});
+    });
+    renderPage();
+
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0);
+    expect(screen.queryByText(/no responses to grade yet/i)).toBeNull();
+  });
+
+  it('renders an AI-graded card: response, suggestion, confidence, criteria, provenance', async () => {
+    mockApi([GRADE]);
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Asha Rao')).toBeDefined());
+    expect(screen.getByText(/chlorophyll absorbs red and blue light/i)).toBeDefined();
+    expect(screen.getByText('AI suggests 4/5')).toBeDefined();
+    expect(screen.getByText('85% confident')).toBeDefined();
+    expect(screen.getByText('✨ AI-generated')).toBeDefined();
+    expect(screen.getByText('Names chlorophyll')).toBeDefined();
+    expect(screen.getByText('Needs your review')).toBeDefined();
+  });
+
+  it('accepting the suggestion posts review with the suggested score', async () => {
+    const user = userEvent.setup();
+    mockApi([GRADE]);
+    mockPost.mockResolvedValue({
+      data: { ...GRADE, status: 'reviewed', final_score: 4, is_reviewed: true },
+    });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Asha Rao')).toBeDefined());
+    await user.click(screen.getByRole('button', { name: /accept suggestion/i }));
+
+    await waitFor(() =>
+      expect(mockPost).toHaveBeenCalledWith('/ai/open-grades/21/review/', { final_score: 4 })
+    );
+  });
+
+  it('overriding the score relabels the action and posts the override + comment', async () => {
+    const user = userEvent.setup();
+    mockApi([GRADE]);
+    mockPost.mockResolvedValue({
+      data: { ...GRADE, status: 'reviewed', final_score: 3, is_reviewed: true },
+    });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Asha Rao')).toBeDefined());
+
+    const scoreInput = screen.getByLabelText(/final marks/i);
+    await user.clear(scoreInput);
+    await user.type(scoreInput, '3');
+    await user.type(screen.getByLabelText(/comment for the student/i), 'Name the process.');
+    await user.click(screen.getByRole('button', { name: /save final grade/i }));
+
+    await waitFor(() =>
+      expect(mockPost).toHaveBeenCalledWith('/ai/open-grades/21/review/', {
+        final_score: 3,
+        teacher_comment: 'Name the process.',
+      })
+    );
+  });
+
+  it('renders pending and failed cards with their working/retry affordances', async () => {
+    mockApi([
+      { ...GRADE, id: 22, status: 'pending', suggested_score: null },
+      {
+        ...GRADE,
+        id: 23,
+        status: 'failed',
+        suggested_score: null,
+        error_detail: 'Provider timeout.',
+      },
+    ]);
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText(/AI is reading this response/i)).toBeDefined());
+    expect(screen.getByText(/couldn't grade this response/i)).toBeDefined();
+    expect(screen.getByText('Provider timeout.')).toBeDefined();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeDefined();
+  });
+
+  it('reviewed cards show the final grade and the override note', async () => {
+    mockApi([
+      {
+        ...GRADE,
+        status: 'reviewed',
+        final_score: 3,
+        teacher_comment: 'Name the process.',
+        is_reviewed: true,
+      },
+    ]);
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Final grade: 3/5')).toBeDefined());
+    expect(screen.getByText(/AI suggested 4\/5 — you overrode it/)).toBeDefined();
+    expect(screen.getByText(/name the process/i)).toBeDefined();
+  });
+
+  it('labels stub-graded suggestions as Auto-graded with a care note', async () => {
+    mockApi([{ ...GRADE, model_used: 'stub' }]);
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Auto-graded')).toBeDefined());
+    expect(screen.getByText(/review with extra care/i)).toBeDefined();
+    expect(screen.queryByText('✨ AI-generated')).toBeNull();
+  });
+
+  it('status filter chips re-query with the status param', async () => {
+    const user = userEvent.setup();
+    mockApi([GRADE]);
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Asha Rao')).toBeDefined());
+    await user.click(screen.getByRole('button', { name: 'Finalised' }));
+
+    await waitFor(() =>
+      expect(mockGet).toHaveBeenCalledWith('/ai/open-grades/?status=reviewed')
+    );
+  });
+
+  it('shows an error with retry — not the empty state — when the queue fetch fails', async () => {
+    const user = userEvent.setup();
+    let failed = false;
+    mockGet.mockImplementation((url: string) => {
+      if (url.startsWith('/subject-rooms/')) {
+        return Promise.resolve({ data: { results: [ROOM] } });
+      }
+      if (!failed) {
+        failed = true;
+        return Promise.reject(new Error('network down'));
+      }
+      return Promise.resolve({ data: { results: [GRADE] } });
+    });
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/couldn't load the grading queue just now/i)).toBeDefined()
+    );
+    // A failed fetch must not read as "queue is clear".
+    expect(screen.queryByText(/no responses to grade yet/i)).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+    await waitFor(() => expect(screen.getByText('Asha Rao')).toBeDefined());
+  });
+
+  it('explains the feature on a successful empty queue', async () => {
+    mockApi([]);
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText(/no responses to grade yet/i)).toBeDefined());
+    expect(screen.getByText(/AI will suggest a grade for your review/i)).toBeDefined();
+  });
+});

--- a/frontend_modern/src/features/teacher/OpenResponseGradingPage.tsx
+++ b/frontend_modern/src/features/teacher/OpenResponseGradingPage.tsx
@@ -1,0 +1,382 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AIBadge, Badge, Button, EmptyState, Skeleton, isAIStub } from '@/shared/ui';
+import { useSubjectRooms } from './useSubjectRooms';
+import {
+  gradeErrorDetail,
+  useOpenGrades,
+  useRegradeOpenGrade,
+  useReviewOpenGrade,
+  type OpenGradeStatus,
+  type OpenResponseGrade,
+} from './useOpenResponseGrading';
+
+const STATUS_LABEL: Record<OpenGradeStatus, string> = {
+  pending: 'AI grading…',
+  ai_graded: 'Needs your review',
+  reviewed: 'Finalised',
+  failed: 'Grading failed',
+};
+
+const STATUS_TONE: Record<OpenGradeStatus, 'attention' | 'brand' | 'success' | 'urgent'> = {
+  pending: 'attention',
+  ai_graded: 'brand',
+  reviewed: 'success',
+  failed: 'urgent',
+};
+
+const formatDate = (iso: string): string =>
+  new Date(iso).toLocaleDateString('en-IN', { day: 'numeric', month: 'short' });
+
+interface ReviewFormProps {
+  grade: OpenResponseGrade;
+}
+
+/**
+ * The human-in-the-loop step: the teacher accepts or overrides the AI's
+ * suggestion. Score defaults to the suggestion so accepting is one click.
+ */
+const ReviewForm = ({ grade }: ReviewFormProps) => {
+  const review = useReviewOpenGrade();
+  const [score, setScore] = useState(
+    grade.suggested_score != null ? String(grade.suggested_score) : ''
+  );
+  const [comment, setComment] = useState('');
+
+  const parsed = Number(score);
+  const valid = score !== '' && !Number.isNaN(parsed) && parsed >= 0 && parsed <= grade.max_marks;
+
+  return (
+    <form
+      className="mt-3 rounded-lg border border-ink-100 bg-ink-50/60 p-3 space-y-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (!valid) return;
+        review.mutate({
+          id: grade.id,
+          final_score: parsed,
+          teacher_comment: comment.trim() || undefined,
+        });
+      }}
+    >
+      <div className="flex flex-wrap items-end gap-3">
+        <label className="block text-xs text-ink-600">
+          Final marks (out of {grade.max_marks})
+          <input
+            type="number"
+            min={0}
+            max={grade.max_marks}
+            step={0.5}
+            value={score}
+            onChange={(e) => setScore(e.target.value)}
+            className="input-brand mt-1 block w-24 text-sm"
+          />
+        </label>
+        <label className="block flex-1 min-w-[12rem] text-xs text-ink-600">
+          Comment for the student <span className="text-ink-400">(optional)</span>
+          <input
+            type="text"
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            placeholder="e.g. Good reasoning — name the process next time."
+            className="input-brand mt-1 block w-full text-sm"
+          />
+        </label>
+      </div>
+
+      {review.isError && (
+        <p className="text-xs text-rose-600">
+          {gradeErrorDetail(review.error) ??
+            "Couldn't save the grade just now. Please try again in a moment."}
+        </p>
+      )}
+
+      <div className="flex items-center gap-2 pt-1">
+        <Button type="submit" variant="brand" size="sm" disabled={!valid || review.isPending}>
+          {review.isPending
+            ? 'Saving…'
+            : grade.suggested_score != null && parsed === grade.suggested_score
+              ? 'Accept suggestion'
+              : 'Save final grade'}
+        </Button>
+        <p className="text-xs text-ink-400">Finalising locks this grade.</p>
+      </div>
+    </form>
+  );
+};
+
+const GradeCard = ({ grade }: { grade: OpenResponseGrade }) => {
+  const regrade = useRegradeOpenGrade();
+  const isStub = isAIStub(grade.model_used);
+
+  return (
+    <div className="os-card p-4 sm:p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="font-display text-lg text-ink-900 leading-tight">{grade.student_name}</p>
+          <p className="mt-0.5 text-xs text-ink-500">
+            {grade.subject_name} · submitted {formatDate(grade.created_at)}
+          </p>
+        </div>
+        <Badge tone={STATUS_TONE[grade.status]} className="shrink-0">
+          {STATUS_LABEL[grade.status]}
+        </Badge>
+      </div>
+
+      <p className="mt-3 text-xs text-ink-500">
+        <span className="font-semibold">Question:</span> {grade.question_text}
+      </p>
+      <blockquote className="mt-2 rounded-lg border border-ink-100 bg-ink-50/60 p-3 text-sm text-ink-800 leading-relaxed whitespace-pre-line">
+        {grade.response_text}
+      </blockquote>
+
+      {grade.status === 'pending' && (
+        <div className="mt-3 flex items-center gap-2">
+          <span
+            className="inline-block h-2 w-2 animate-pulse rounded-full bg-brand-500"
+            aria-hidden
+          />
+          <p className="text-sm text-ink-600">AI is reading this response…</p>
+        </div>
+      )}
+
+      {grade.status === 'failed' && (
+        <div className="mt-3">
+          <p className="text-sm text-rose-700">Couldn&apos;t grade this response.</p>
+          {grade.error_detail && <p className="mt-1 text-xs text-ink-500">{grade.error_detail}</p>}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="mt-2"
+            disabled={regrade.isPending}
+            onClick={() => regrade.mutate({ id: grade.id })}
+          >
+            {regrade.isPending ? 'Retrying…' : 'Try again'}
+          </Button>
+        </div>
+      )}
+
+      {grade.status === 'ai_graded' && (
+        <div className="mt-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="text-sm font-semibold text-ink-900">
+              AI suggests {grade.suggested_score}/{grade.max_marks}
+            </p>
+            {grade.confidence != null && (
+              <span className="text-xs text-ink-400">
+                {Math.round(grade.confidence * 100)}% confident
+              </span>
+            )}
+            <AIBadge modelUsed={grade.model_used} stubLabel="Auto-graded" />
+          </div>
+          {grade.feedback && (
+            <p className="mt-1.5 text-sm text-ink-700 leading-relaxed">{grade.feedback}</p>
+          )}
+          {isStub && (
+            <p className="mt-1 text-xs text-ink-400">
+              AI was unavailable, so this suggestion came from a keyword match against the model
+              answer — please review with extra care.
+            </p>
+          )}
+
+          {grade.criterion_scores.length > 0 && (
+            <ul className="mt-2 space-y-1">
+              {grade.criterion_scores.map((c) => (
+                <li key={c.label} className="flex items-start gap-2 text-xs text-ink-600">
+                  <span className="shrink-0 rounded-full bg-ink-100 px-2 py-0.5 font-medium text-ink-700">
+                    {c.awarded}/{c.max}
+                  </span>
+                  <span>
+                    <span className="font-semibold">{c.label}</span>
+                    {c.comment && <> — {c.comment}</>}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <ReviewForm grade={grade} />
+
+          <div className="mt-2 flex justify-end">
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={regrade.isPending}
+              onClick={() => regrade.mutate({ id: grade.id })}
+            >
+              {regrade.isPending ? 'Re-grading…' : 'Ask AI again'}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {grade.status === 'reviewed' && (
+        <div className="mt-3">
+          <p className="text-sm font-semibold text-ink-900">
+            Final grade: {grade.final_score}/{grade.max_marks}
+          </p>
+          {grade.suggested_score != null && grade.final_score !== grade.suggested_score && (
+            <p className="mt-0.5 text-xs text-ink-400">
+              AI suggested {grade.suggested_score}/{grade.max_marks} — you overrode it.
+            </p>
+          )}
+          {grade.teacher_comment && (
+            <p className="mt-1.5 text-sm text-ink-700">
+              <span className="font-semibold">Your comment:</span> {grade.teacher_comment}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// Mirrors the GradeCard layout so the list doesn't reflow when data lands.
+const GradeCardSkeleton = () => (
+  <div className="os-card p-4 sm:p-5">
+    <div className="flex items-start justify-between gap-3">
+      <div className="min-w-0 flex-1 space-y-1.5">
+        <Skeleton w="w-1/3" h="h-5" />
+        <Skeleton w="w-1/4" h="h-3" />
+      </div>
+      <Skeleton w="w-28" h="h-5" rounded="rounded-full" />
+    </div>
+    <Skeleton w="w-2/3" h="h-3" className="mt-3" />
+    <Skeleton w="w-full" h="h-16" rounded="rounded-lg" className="mt-2" />
+    <div className="mt-3 space-y-1.5">
+      <Skeleton w="w-1/2" h="h-4" />
+      <Skeleton w="w-5/6" h="h-3" />
+    </div>
+  </div>
+);
+
+type StatusFilter = OpenGradeStatus | 'all';
+
+const FILTER_CHIPS: Array<{ value: StatusFilter; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'ai_graded', label: 'Needs review' },
+  { value: 'pending', label: 'AI grading' },
+  { value: 'reviewed', label: 'Finalised' },
+  { value: 'failed', label: 'Failed' },
+];
+
+/**
+ * Open-response grading queue — the first consumer of /ai/open-grades/
+ * (ASA-7a). Free-text answers can't self-grade like MCQ/numeric, so the AI
+ * proposes a score, feedback, and a per-criterion breakdown, and the teacher
+ * reviews each one: accept in one click or override with their own marks and
+ * comment. The AI never finalises anything (human firmly in the loop).
+ */
+export const OpenResponseGradingPage = () => {
+  const navigate = useNavigate();
+  const [roomFilter, setRoomFilter] = useState<number | 'all'>('all');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+
+  const { data: rooms } = useSubjectRooms();
+  const {
+    data: grades,
+    isLoading,
+    isError,
+    refetch,
+  } = useOpenGrades({
+    subjectRoomId: roomFilter === 'all' ? undefined : roomFilter,
+    status: statusFilter === 'all' ? undefined : statusFilter,
+  });
+
+  const items = grades ?? [];
+  const isFiltered = roomFilter !== 'all' || statusFilter !== 'all';
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 px-4 py-8">
+      <div>
+        <button
+          type="button"
+          onClick={() => navigate('/teacher')}
+          className="text-sm text-brand-700 font-medium hover:underline mb-3 inline-flex items-center gap-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded"
+        >
+          ← Dashboard
+        </button>
+        <h1 className="font-display text-3xl font-semibold text-ink-900">AI grading</h1>
+        <p className="mt-1 text-sm text-ink-500">
+          Open-ended answers, graded by AI, finalised by you. Nothing counts until you review it.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <select
+          aria-label="Filter by class"
+          value={roomFilter === 'all' ? 'all' : String(roomFilter)}
+          onChange={(e) =>
+            setRoomFilter(e.target.value === 'all' ? 'all' : Number(e.target.value))
+          }
+          className="input-brand w-auto text-sm"
+        >
+          <option value="all">All my classes</option>
+          {(rooms ?? []).map((r) => (
+            <option key={r.id} value={r.id}>
+              {r.subject_name} · {r.classroom_display}
+            </option>
+          ))}
+        </select>
+        <div className="flex flex-wrap gap-1.5">
+          {FILTER_CHIPS.map((chip) => (
+            <button
+              key={chip.value}
+              type="button"
+              onClick={() => setStatusFilter(chip.value)}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                statusFilter === chip.value
+                  ? 'bg-brand-600 text-white shadow-soft'
+                  : 'bg-ink-50 text-ink-700 hover:bg-ink-100'
+              }`}
+            >
+              {chip.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {isLoading && (
+        <div className="space-y-4">
+          <GradeCardSkeleton />
+          <GradeCardSkeleton />
+        </div>
+      )}
+
+      {/* A failed fetch must not masquerade as "queue is clear" — that would
+          tell the teacher there is nothing to review when we just couldn't
+          reach the server. */}
+      {!isLoading && isError && (
+        <p className="text-sm text-rose-600">
+          Couldn&apos;t load the grading queue just now.{' '}
+          <button
+            type="button"
+            onClick={() => void refetch()}
+            className="font-medium underline hover:text-rose-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 rounded"
+          >
+            Retry
+          </button>
+        </p>
+      )}
+
+      {!isLoading && !isError && items.length === 0 && (
+        <EmptyState
+          title={isFiltered ? 'Nothing matches these filters' : 'No responses to grade yet'}
+          description={
+            isFiltered
+              ? 'Try a different class or status.'
+              : 'Record a student’s open-ended answer and AI will suggest a grade for your review.'
+          }
+        />
+      )}
+
+      {!isLoading && !isError && (
+        <div className="space-y-4">
+          {items.map((g) => (
+            <GradeCard key={g.id} grade={g} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend_modern/src/features/teacher/TeacherDashboard.tsx
+++ b/frontend_modern/src/features/teacher/TeacherDashboard.tsx
@@ -121,6 +121,9 @@ export const TeacherDashboard = () => {
           </p>
         </div>
         <div className="flex flex-wrap justify-end gap-2">
+          <Button variant="ghost" size="sm" onClick={() => navigate('/teacher/grading')}>
+            ✨ AI grading
+          </Button>
           <Button variant="ghost" size="sm" onClick={() => navigate('/teacher/questions/new')}>
             + Question
           </Button>

--- a/frontend_modern/src/features/teacher/useOpenResponseGrading.ts
+++ b/frontend_modern/src/features/teacher/useOpenResponseGrading.ts
@@ -1,0 +1,128 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+
+export type OpenGradeStatus = 'pending' | 'ai_graded' | 'reviewed' | 'failed';
+
+export interface CriterionScore {
+  label: string;
+  awarded: number;
+  max: number;
+  comment: string;
+}
+
+/** Mirrors OpenResponseGradeSerializer (backend/openshiksha/apps/ai/serializers.py). */
+export interface OpenResponseGrade {
+  id: number;
+  subpart: number;
+  question_text: string;
+  student: number;
+  student_name: string;
+  student_username: string;
+  subject_room: number;
+  subject_name: string;
+  assignment: number | null;
+  response_text: string;
+  status: OpenGradeStatus;
+  max_marks: number;
+  suggested_score: number | null;
+  feedback: string;
+  criterion_scores: CriterionScore[];
+  confidence: number | null;
+  final_score: number | null;
+  teacher_comment: string;
+  reviewed_by: number | null;
+  reviewed_at: string | null;
+  effective_score: number | null;
+  is_reviewed: boolean;
+  model_used: string;
+  error_detail: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface OpenGradeFilters {
+  subjectRoomId?: number;
+  status?: OpenGradeStatus;
+}
+
+const gradesKey = (filters: OpenGradeFilters) => [
+  'ai',
+  'open-grades',
+  filters.subjectRoomId ?? 'all',
+  filters.status ?? 'all',
+];
+
+/**
+ * AI grading runs async (submit returns 202 with a pending row; a Celery task
+ * fills in the suggestion). While any visible row is pending the list
+ * refetches on an interval so cards flip to ai_graded/failed by themselves —
+ * and polling stops as soon as nothing is pending.
+ */
+export const useOpenGrades = (filters: OpenGradeFilters, enabled = true, pollIntervalMs = 3000) =>
+  useQuery<OpenResponseGrade[]>({
+    queryKey: gradesKey(filters),
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (filters.subjectRoomId != null) params.set('subject_room', String(filters.subjectRoomId));
+      if (filters.status) params.set('status', filters.status);
+      const qs = params.toString();
+      const { data } = await apiClient.get<OpenResponseGrade[] | { results: OpenResponseGrade[] }>(
+        `/ai/open-grades/${qs ? `?${qs}` : ''}`
+      );
+      return Array.isArray(data) ? data : (data.results ?? []);
+    },
+    enabled,
+    staleTime: 30 * 1000,
+    refetchInterval: (query) =>
+      (query.state.data ?? []).some((g) => g.status === 'pending') ? pollIntervalMs : false,
+  });
+
+/** Invalidate every open-grades list (all filter combinations). */
+const invalidateGrades = (queryClient: ReturnType<typeof useQueryClient>) =>
+  queryClient.invalidateQueries({ queryKey: ['ai', 'open-grades'] });
+
+export const useReviewOpenGrade = () => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    OpenResponseGrade,
+    Error,
+    { id: number; final_score: number; teacher_comment?: string }
+  >({
+    mutationFn: async ({ id, final_score, teacher_comment }) => {
+      const { data } = await apiClient.post<OpenResponseGrade>(`/ai/open-grades/${id}/review/`, {
+        final_score,
+        ...(teacher_comment ? { teacher_comment } : {}),
+      });
+      return data;
+    },
+    onSuccess: () => invalidateGrades(queryClient),
+  });
+};
+
+export const useRegradeOpenGrade = () => {
+  const queryClient = useQueryClient();
+  return useMutation<OpenResponseGrade, Error, { id: number }>({
+    mutationFn: async ({ id }) => {
+      const { data } = await apiClient.post<OpenResponseGrade>(
+        `/ai/open-grades/${id}/regrade/`,
+        {}
+      );
+      return data;
+    },
+    onSuccess: () => invalidateGrades(queryClient),
+  });
+};
+
+/** Extract the server's `detail` message from an axios-shaped error (e.g. a 400/409). */
+export const gradeErrorDetail = (error: unknown): string | null => {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'response' in error &&
+    typeof (error as { response?: { data?: { detail?: unknown } } }).response?.data?.detail ===
+      'string'
+  ) {
+    return (error as { response: { data: { detail: string } } }).response.data.detail;
+  }
+  return null;
+};


### PR DESCRIPTION
## Classification
New — ASA-7a (review queue), part 1 of the ASA-7 batch anchor. **Stacked on #300 → #299.** Merge order: #299 → #300 → this, **retargeting each PR to `modernization` before merging** (do not merge into the stack branch — that's what orphaned #294).

## What
`/ai/open-grades/` was the **last dark `/ai/` endpoint group**. New teacher page **`/teacher/grading`** ("✨ AI grading" button on the dashboard header):
- Class select + status chips (All / Needs review / AI grading / Finalised / Failed).
- **Needs-review card**: quoted student response, "AI suggests X/Y" + confidence + `AIBadge` (stub path says `Auto-graded` with an extra-care note — keyword heuristic), per-criterion breakdown, review form where the score **defaults to the suggestion** (one-click "Accept suggestion"; typing another score relabels to "Save final grade"), "Ask AI again" regrade.
- **Pending** cards pulse and the list polls every 3 s only while something is pending; **failed** cards show `error_detail` + retry; **reviewed** cards show the final grade + an override note when the teacher changed the AI's score.
- List-error → error + Retry (never the empty state); shape-matched skeletons; explanatory empty state.
- The AI never finalises anything — `review` is the only path to a final grade.

## Backend
None — `OpenResponseGradeViewSet` complete and tested (20 backend tests).

## Tests
`OpenResponseGradingPage.test.tsx` — 10 cases (render, accept, override, pending/failed, reviewed+override note, stub care note, filter re-query, error+Retry recovery, empty state). Full gate: lint + tsc + **vitest 313/313 (50 files)** + build.

## How to verify
Teacher dashboard → ✨ AI grading → review queue. With seeded data: accept a suggestion in one click; override another with a comment; watch a pending row flip to graded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)