### PR TITLE
feat(teacher): ASA-7b — rubric authoring + record-response (completes ASA-7)

### DIFF
--- a/backend/openshiksha/apps/api/tests/test_core_api.py
+++ b/backend/openshiksha/apps/api/tests/test_core_api.py
@@ -325,6 +325,32 @@ class TestSubjectRoomVisibility:
         assert subject_room.pk not in ids
 
 
+class TestSubjectRoomStudentsAction:
+    """GET /api/subject-rooms/{id}/students/ — roster for teacher pickers (ASA-7b)."""
+
+    def test_teacher_lists_own_room_roster(self, api_client, teacher, student, subject_room):
+        api_client.force_authenticate(user=teacher)
+        url = reverse("subjectroom-students", kwargs={"pk": subject_room.pk})
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        rows = response.data["results"]
+        assert {"id", "full_name", "username"} <= set(rows[0].keys())
+        assert student.pk in [r["id"] for r in rows]
+
+    def test_other_teacher_cannot_see_roster(self, api_client, other_teacher, subject_room):
+        api_client.force_authenticate(user=other_teacher)
+        url = reverse("subjectroom-students", kwargs={"pk": subject_room.pk})
+        response = api_client.get(url)
+        # get_queryset scopes to the teacher's own rooms → 404, not a leak
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_student_cannot_enumerate_classmates(self, api_client, student, subject_room):
+        api_client.force_authenticate(user=student)
+        url = reverse("subjectroom-students", kwargs={"pk": subject_room.pk})
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
 class TestSubjectRoomPermissions:
     def test_teacher_can_create_subject_room(self, api_client, teacher, classroom, subject):
         api_client.force_authenticate(user=teacher)

--- a/backend/openshiksha/apps/api/views/core.py
+++ b/backend/openshiksha/apps/api/views/core.py
@@ -645,6 +645,20 @@ class SubjectRoomViewSet(viewsets.ModelViewSet):
             {"unenrolled": [s.id for s in students], "invalid_ids": invalid_ids, "student_count": room.students.count()}
         )
 
+    @action(detail=True, methods=["get"], url_path="students")
+    def students(self, request, pk=None):
+        """
+        GET /api/v1/subject-rooms/{id}/students/ — the room's roster, for
+        teacher pickers (e.g. recording an open response for AI grading).
+        Students can see their own rooms via get_queryset but must not be able
+        to enumerate classmates, so the action is teacher/admin-only.
+        """
+        if request.user.role not in (UserRole.TEACHER, UserRole.ADMIN):
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+        room = self.get_object()  # get_queryset already scopes to own/school rooms
+        roster = room.students.order_by("first_name", "last_name", "username")
+        return Response({"results": [{"id": s.id, "full_name": s.full_name, "username": s.username} for s in roster]})
+
 
 class ProblemSetViewSet(viewsets.ModelViewSet):
     """

--- a/docs/changes/2026-06-11-rubric-authoring-record-response.md
+++ b/docs/changes/2026-06-11-rubric-authoring-record-response.md
@@ -1,0 +1,73 @@
+# Rubric authoring + record-response flow (ASA-7b)
+
+**Date:** 2026-06-11
+**Classification:** New (ASA-7 batch anchor, part 2 of 2 — completes ASA-7)
+**Initiative:** AI Surface Activation — ASA-7b
+
+## Summary
+
+ASA-7a (#301) shipped the review queue; this PR ships the **input side** of
+open-response grading, completing ASA-7 and the last initiative backlog item:
+
+- **Record a response**: the teacher picks a class → student → one of their
+  short-answer questions, pastes the student's free-text answer, and the
+  server queues AI grading (202 → pending row appears in the queue below).
+- **Rubric authoring**: the one rubric a short-answer subpart carries
+  (max marks, model answer, optional per-point marking criteria) is created
+  and edited inline, right where the teacher records responses — with a nudge
+  when a picked question has no rubric ("AI falls back to a rough keyword
+  match — add one for fair, transparent marks") and a warning when marking
+  points don't sum to the maximum.
+
+First consumer of `/ai/open-rubrics/`. With this, **every `/ai/` endpoint
+group has a frontend consumer** — the initiative's North-Star condition.
+
+## Legacy reference
+
+None — legacy had no grading path for free-text answers at all.
+
+## What changed
+
+### Backend (small, justified by a genuinely missing surface)
+
+- `backend/openshiksha/apps/api/views/core.py` — new
+  `GET /api/v1/subject-rooms/{id}/students/` action: the room roster
+  (`id`, `full_name`, `username`) for teacher pickers. Teacher/admin-only and
+  scoped by `get_queryset` (other teachers 404); **students get 404** so they
+  cannot enumerate classmates even for rooms they're enrolled in.
+- `backend/openshiksha/apps/api/tests/test_core_api.py` — 3 tests
+  (`TestSubjectRoomStudentsAction`): teacher sees roster; other teacher 404;
+  student 404. No model change, no migration.
+
+### Frontend
+
+- **`useOpenRubrics.ts`** (new) — `OpenResponseRubric`/`RubricCriterion`
+  types; `useRubricForSubpart` (resolves the OneToOne to rubric-or-null);
+  `useSaveRubric` (POST when none exists, PATCH otherwise);
+  `useRoomStudents`; `useShortAnswerSubparts` (teacher's
+  `?question_type=short_answer` questions flattened to subpart options);
+  `useSubmitOpenResponse` (invalidates all grading-queue views so the
+  pending row appears immediately).
+- **`RecordResponsePanel.tsx`** (new) — collapsible card mounted at the top
+  of `/teacher/grading`: class/student/question selects (student select
+  disabled until a class is picked; explanatory copy when the teacher has no
+  short-answer questions yet), inline `RubricSection` (summary + Edit, or the
+  no-rubric nudge + Add), `RubricForm` (max marks, model answer, add/remove
+  marking points, sum-mismatch warning), response textarea, submit → success
+  note pointing at the queue. Submit errors surface inline.
+- **`OpenResponseGradingPage.tsx`** — mounts the panel above the queue.
+
+## Tests
+
+`RecordResponsePanel.test.tsx` — 7 cases: collapsed-by-default (no fetches);
+full record flow posts the submit payload + success note; no-rubric nudge;
+rubric create POST; rubric edit PATCH (existing summary shown first);
+marking-point sum warning; submit-failure surfaced inline.
+
+Full gates: frontend lint + tsc + **vitest 320/320 (51 files)** + build;
+backend **pytest 926 passed, 93.77% coverage**.
+
+## Next steps
+
+ASA backlog is now empty (ASA-1..9 all shipped). Remaining: endpoint-to-
+consumer map + DoD audit + initiative close (docs PR).

--- a/frontend_modern/src/features/teacher/OpenResponseGradingPage.tsx
+++ b/frontend_modern/src/features/teacher/OpenResponseGradingPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AIBadge, Badge, Button, EmptyState, Skeleton, isAIStub } from '@/shared/ui';
 import { useSubjectRooms } from './useSubjectRooms';
+import { RecordResponsePanel } from './RecordResponsePanel';
 import {
   gradeErrorDetail,
   useOpenGrades,
@@ -301,6 +302,8 @@ export const OpenResponseGradingPage = () => {
           Open-ended answers, graded by AI, finalised by you. Nothing counts until you review it.
         </p>
       </div>
+
+      <RecordResponsePanel />
 
       <div className="flex flex-wrap items-center gap-2">
         <select

--- a/frontend_modern/src/features/teacher/RecordResponsePanel.test.tsx
+++ b/frontend_modern/src/features/teacher/RecordResponsePanel.test.tsx
@@ -1,0 +1,214 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { RecordResponsePanel } from './RecordResponsePanel';
+import type { OpenResponseRubric } from './useOpenRubrics';
+
+const { mockGet, mockPost, mockPatch } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPost: vi.fn(),
+  mockPatch: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    get: mockGet,
+    post: mockPost,
+    patch: mockPatch,
+  },
+}));
+
+const ROOM = {
+  id: 1,
+  classroom: 1,
+  classroom_display: 'Std 8 A',
+  subject: 2,
+  subject_name: 'Biology',
+  teacher: 9,
+  teacher_name: 'T',
+  is_active: true,
+  student_count: 30,
+};
+
+const RUBRIC: OpenResponseRubric = {
+  id: 5,
+  subpart: 301,
+  question_text: 'Explain why leaves look green.',
+  max_marks: 5,
+  model_answer: 'Chlorophyll absorbs red and blue light and reflects green.',
+  criteria: [{ label: 'Names chlorophyll', marks: 2 }],
+  created_by: 9,
+  created_at: '2026-06-11T08:00:00Z',
+  updated_at: '2026-06-11T08:00:00Z',
+};
+
+function mockApi({ rubrics = [] as OpenResponseRubric[] } = {}) {
+  mockGet.mockImplementation((url: string) => {
+    if (url.startsWith('/subject-rooms/1/students/')) {
+      return Promise.resolve({
+        data: { results: [{ id: 42, full_name: 'Asha Rao', username: 'asha' }] },
+      });
+    }
+    if (url.startsWith('/subject-rooms/')) {
+      return Promise.resolve({ data: { results: [ROOM] } });
+    }
+    if (url.startsWith('/questions/')) {
+      return Promise.resolve({
+        data: {
+          results: [
+            { id: 7, subparts: [{ id: 301, question_text: 'Explain why leaves look green.' }] },
+          ],
+        },
+      });
+    }
+    if (url.startsWith('/ai/open-rubrics/')) {
+      return Promise.resolve({ data: { results: rubrics } });
+    }
+    return Promise.reject(new Error(`unexpected GET ${url}`));
+  });
+}
+
+function renderPanel() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RecordResponsePanel />
+    </QueryClientProvider>
+  );
+}
+
+async function fillSelections(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByText(/record a response for ai grading/i));
+  await waitFor(() => expect(screen.getByText(/Biology · Std 8 A/)).toBeDefined());
+  await user.selectOptions(screen.getByRole('combobox', { name: 'Class' }), '1');
+  await waitFor(() => expect(screen.getByText('Asha Rao')).toBeDefined());
+  await user.selectOptions(screen.getByRole('combobox', { name: 'Student' }), '42');
+  await user.selectOptions(
+    screen.getByRole('combobox', { name: 'Short-answer question' }),
+    '301'
+  );
+}
+
+describe('RecordResponsePanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is collapsed by default and fetches nothing until opened', () => {
+    mockApi();
+    renderPanel();
+    // useSubjectRooms fires on mount (shared with the page); nothing else should.
+    expect(mockGet).not.toHaveBeenCalledWith(expect.stringContaining('/questions/'));
+    expect(screen.queryByLabelText(/student's answer/i)).toBeNull();
+  });
+
+  it('submits a response: room → student → subpart → answer → 202 + success note', async () => {
+    const user = userEvent.setup();
+    mockApi({ rubrics: [RUBRIC] });
+    mockPost.mockResolvedValue({ data: { id: 99, status: 'pending' } });
+    renderPanel();
+
+    await fillSelections(user);
+    await user.type(screen.getByLabelText(/student's answer/i), 'Because of chlorophyll.');
+    await user.click(screen.getByRole('button', { name: /send to ai grading/i }));
+
+    await waitFor(() =>
+      expect(mockPost).toHaveBeenCalledWith('/ai/open-grades/submit/', {
+        subject_room_id: 1,
+        student_id: 42,
+        subpart_id: 301,
+        response_text: 'Because of chlorophyll.',
+      })
+    );
+    await waitFor(() => expect(screen.getByText(/queued — it appears below/i)).toBeDefined());
+  });
+
+  it('nudges to add a rubric when the picked subpart has none', async () => {
+    const user = userEvent.setup();
+    mockApi({ rubrics: [] });
+    renderPanel();
+
+    await fillSelections(user);
+
+    await waitFor(() => expect(screen.getByText(/no rubric yet/i)).toBeDefined());
+    expect(screen.getByRole('button', { name: /add rubric/i })).toBeDefined();
+  });
+
+  it('creates a rubric with model answer and marking points', async () => {
+    const user = userEvent.setup();
+    mockApi({ rubrics: [] });
+    mockPost.mockResolvedValue({ data: RUBRIC });
+    renderPanel();
+
+    await fillSelections(user);
+    await waitFor(() => expect(screen.getByText(/no rubric yet/i)).toBeDefined());
+    await user.click(screen.getByRole('button', { name: /add rubric/i }));
+
+    await user.type(screen.getByLabelText(/model answer/i), 'Chlorophyll reflects green.');
+    await user.click(screen.getByRole('button', { name: /\+ marking point/i }));
+    await user.type(screen.getByLabelText('Criterion 1 label'), 'Names chlorophyll');
+    await user.click(screen.getByRole('button', { name: /save rubric/i }));
+
+    await waitFor(() =>
+      expect(mockPost).toHaveBeenCalledWith('/ai/open-rubrics/', {
+        subpart: 301,
+        max_marks: 5,
+        model_answer: 'Chlorophyll reflects green.',
+        criteria: [{ label: 'Names chlorophyll', marks: 1 }],
+      })
+    );
+  });
+
+  it('shows the existing rubric summary and PATCHes on edit', async () => {
+    const user = userEvent.setup();
+    mockApi({ rubrics: [RUBRIC] });
+    mockPatch.mockResolvedValue({ data: { ...RUBRIC, max_marks: 6 } });
+    renderPanel();
+
+    await fillSelections(user);
+    await waitFor(() => expect(screen.getByText(/rubric:/i)).toBeDefined());
+    expect(screen.getByText(/5 marks · 1 marking point/)).toBeDefined();
+
+    await user.click(screen.getByRole('button', { name: /edit/i }));
+    const marks = screen.getByLabelText(/maximum marks/i);
+    await user.clear(marks);
+    await user.type(marks, '6');
+    await user.click(screen.getByRole('button', { name: /update rubric/i }));
+
+    await waitFor(() =>
+      expect(mockPatch).toHaveBeenCalledWith(
+        '/ai/open-rubrics/5/',
+        expect.objectContaining({ max_marks: 6 })
+      )
+    );
+  });
+
+  it('warns when marking points do not sum to the maximum marks', async () => {
+    const user = userEvent.setup();
+    mockApi({ rubrics: [RUBRIC] });
+    renderPanel();
+
+    await fillSelections(user);
+    await waitFor(() => expect(screen.getByText(/rubric:/i)).toBeDefined());
+    await user.click(screen.getByRole('button', { name: /edit/i }));
+
+    // Existing criterion is 2 marks against a 5-mark maximum.
+    expect(screen.getByText(/add up to 2, not 5/i)).toBeDefined();
+  });
+
+  it('surfaces a submit failure instead of silently dropping the response', async () => {
+    const user = userEvent.setup();
+    mockApi({ rubrics: [RUBRIC] });
+    mockPost.mockRejectedValue(new Error('boom'));
+    renderPanel();
+
+    await fillSelections(user);
+    await user.type(screen.getByLabelText(/student's answer/i), 'Because of chlorophyll.');
+    await user.click(screen.getByRole('button', { name: /send to ai grading/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/couldn't queue this response just now/i)).toBeDefined()
+    );
+  });
+});

--- a/frontend_modern/src/features/teacher/RecordResponsePanel.tsx
+++ b/frontend_modern/src/features/teacher/RecordResponsePanel.tsx
@@ -1,0 +1,350 @@
+import { useState } from 'react';
+import { Button, Skeleton } from '@/shared/ui';
+import { useSubjectRooms } from './useSubjectRooms';
+import {
+  useRoomStudents,
+  useRubricForSubpart,
+  useSaveRubric,
+  useShortAnswerSubparts,
+  useSubmitOpenResponse,
+  type OpenResponseRubric,
+  type RubricCriterion,
+} from './useOpenRubrics';
+
+interface RubricFormProps {
+  subpartId: number;
+  existing: OpenResponseRubric | null;
+  onDone: () => void;
+}
+
+/**
+ * Create or edit the one rubric a short-answer subpart carries: max marks,
+ * the model answer the AI compares against, and optional per-point criteria
+ * so partial credit is transparent.
+ */
+const RubricForm = ({ subpartId, existing, onDone }: RubricFormProps) => {
+  const save = useSaveRubric();
+  const [maxMarks, setMaxMarks] = useState(existing?.max_marks ?? 5);
+  const [modelAnswer, setModelAnswer] = useState(existing?.model_answer ?? '');
+  const [criteria, setCriteria] = useState<RubricCriterion[]>(existing?.criteria ?? []);
+
+  const criteriaSum = criteria.reduce((sum, c) => sum + (c.marks || 0), 0);
+  const sumMismatch = criteria.length > 0 && criteriaSum !== maxMarks;
+
+  const updateCriterion = (i: number, patch: Partial<RubricCriterion>) =>
+    setCriteria((rows) => rows.map((row, idx) => (idx === i ? { ...row, ...patch } : row)));
+
+  return (
+    <form
+      className="mt-2 rounded-lg border border-ink-100 bg-ink-50/60 p-3 space-y-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        save.mutate(
+          {
+            existingId: existing?.id ?? null,
+            subpart: subpartId,
+            max_marks: maxMarks,
+            model_answer: modelAnswer,
+            criteria: criteria.filter((c) => c.label.trim()),
+          },
+          { onSuccess: onDone }
+        );
+      }}
+    >
+      <label className="block text-xs text-ink-600">
+        Maximum marks
+        <input
+          type="number"
+          min={1}
+          max={100}
+          value={maxMarks === 0 ? '' : maxMarks}
+          onChange={(e) => {
+            // Allow a transient empty field while retyping; clamp real values.
+            const raw = e.target.value;
+            setMaxMarks(raw === '' ? 0 : Math.min(100, Math.max(1, Number(raw) || 1)));
+          }}
+          className="input-brand mt-1 block w-24 text-sm"
+        />
+      </label>
+      <label className="block text-xs text-ink-600">
+        Model answer <span className="text-ink-400">(what a full-marks answer says)</span>
+        <textarea
+          value={modelAnswer}
+          onChange={(e) => setModelAnswer(e.target.value)}
+          rows={3}
+          className="input-brand mt-1 block w-full text-sm"
+          placeholder="e.g. Chlorophyll absorbs red and blue light for photosynthesis and reflects green."
+        />
+      </label>
+
+      <div>
+        <p className="text-xs text-ink-600 font-medium">
+          Marking points <span className="text-ink-400 font-normal">(optional — enables per-point partial credit)</span>
+        </p>
+        {criteria.map((c, i) => (
+          <div key={i} className="mt-1.5 flex items-center gap-2">
+            <input
+              type="text"
+              aria-label={`Criterion ${i + 1} label`}
+              value={c.label}
+              onChange={(e) => updateCriterion(i, { label: e.target.value })}
+              placeholder="e.g. Names chlorophyll"
+              className="input-brand flex-1 text-sm"
+            />
+            <input
+              type="number"
+              aria-label={`Criterion ${i + 1} marks`}
+              min={0}
+              max={100}
+              value={c.marks}
+              onChange={(e) => updateCriterion(i, { marks: Number(e.target.value) || 0 })}
+              className="input-brand w-20 text-sm"
+            />
+            <button
+              type="button"
+              aria-label={`Remove criterion ${i + 1}`}
+              onClick={() => setCriteria((rows) => rows.filter((_, idx) => idx !== i))}
+              className="text-ink-400 hover:text-rose-600 text-sm px-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 rounded"
+            >
+              ✕
+            </button>
+          </div>
+        ))}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="mt-1.5"
+          onClick={() => setCriteria((rows) => [...rows, { label: '', marks: 1 }])}
+        >
+          + Marking point
+        </Button>
+        {sumMismatch && (
+          <p className="mt-1 text-xs text-amber-700">
+            Marking points add up to {criteriaSum}, not {maxMarks} — the AI grades per point, so
+            consider matching the total.
+          </p>
+        )}
+      </div>
+
+      {save.isError && (
+        <p className="text-xs text-rose-600">
+          Couldn&apos;t save the rubric just now. Please try again in a moment.
+        </p>
+      )}
+
+      <div className="flex gap-2 pt-1">
+        <Button type="submit" variant="brand" size="sm" disabled={save.isPending || maxMarks < 1}>
+          {save.isPending ? 'Saving…' : existing ? 'Update rubric' : 'Save rubric'}
+        </Button>
+        <Button type="button" variant="ghost" size="sm" onClick={onDone}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+const RubricSection = ({ subpartId }: { subpartId: number }) => {
+  const { data: rubric, isLoading } = useRubricForSubpart(subpartId);
+  const [editing, setEditing] = useState(false);
+
+  if (isLoading) return <Skeleton w="w-2/3" h="h-4" className="mt-2" />;
+
+  if (editing) {
+    return (
+      <RubricForm subpartId={subpartId} existing={rubric ?? null} onDone={() => setEditing(false)} />
+    );
+  }
+
+  if (!rubric) {
+    return (
+      <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-amber-700">
+        <span>
+          No rubric yet — without one the AI falls back to a rough keyword match. Add one for
+          fair, transparent marks.
+        </span>
+        <Button type="button" variant="ghost" size="sm" onClick={() => setEditing(true)}>
+          Add rubric
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-2 rounded-lg border border-ink-100 bg-paper p-3">
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-xs text-ink-600">
+          <span className="font-semibold">Rubric:</span> {rubric.max_marks} marks
+          {rubric.criteria.length > 0 &&
+            ` · ${rubric.criteria.length} marking point${rubric.criteria.length !== 1 ? 's' : ''}`}
+        </p>
+        <Button type="button" variant="ghost" size="sm" onClick={() => setEditing(true)}>
+          Edit
+        </Button>
+      </div>
+      {rubric.model_answer && (
+        <p className="mt-1 text-xs text-ink-500 line-clamp-2">
+          <span className="font-semibold">Model answer:</span> {rubric.model_answer}
+        </p>
+      )}
+    </div>
+  );
+};
+
+/**
+ * "Record a response" — the entry point that feeds the AI grading queue
+ * (ASA-7b). The teacher picks a class, a student and one of their
+ * short-answer questions, pastes the student's free-text answer, and the
+ * server queues AI grading (202 → pending row in the queue below). Rubric
+ * authoring lives right here because the rubric is what makes the AI's
+ * suggestion fair — the form nudges the teacher to add one before grading.
+ */
+export const RecordResponsePanel = () => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [roomId, setRoomId] = useState<number | null>(null);
+  const [studentId, setStudentId] = useState<number | null>(null);
+  const [subpartId, setSubpartId] = useState<number | null>(null);
+  const [responseText, setResponseText] = useState('');
+
+  const { data: rooms } = useSubjectRooms();
+  const { data: students, isLoading: studentsLoading } = useRoomStudents(roomId);
+  const { data: subparts, isLoading: subpartsLoading } = useShortAnswerSubparts(isExpanded);
+  const submit = useSubmitOpenResponse();
+
+  const canSubmit =
+    roomId != null && studentId != null && subpartId != null && responseText.trim().length > 0;
+
+  return (
+    <div className="os-card p-4 sm:p-5">
+      <button
+        type="button"
+        onClick={() => setIsExpanded((v) => !v)}
+        aria-expanded={isExpanded}
+        className="flex w-full items-center gap-1.5 text-left text-sm font-semibold text-ink-700 hover:text-ink-900 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded"
+      >
+        <span>Record a response for AI grading</span>
+        <span className={`ml-auto transition-transform ${isExpanded ? 'rotate-180' : ''}`}>▾</span>
+      </button>
+
+      {isExpanded && (
+        <form
+          className="mt-3 space-y-3"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (!canSubmit) return;
+            submit.mutate(
+              {
+                subject_room_id: roomId,
+                student_id: studentId,
+                subpart_id: subpartId,
+                response_text: responseText.trim(),
+              },
+              { onSuccess: () => setResponseText('') }
+            );
+          }}
+        >
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="block text-xs text-ink-600">
+              Class
+              <select
+                value={roomId == null ? '' : String(roomId)}
+                onChange={(e) => {
+                  setRoomId(e.target.value ? Number(e.target.value) : null);
+                  setStudentId(null);
+                }}
+                className="input-brand mt-1 block w-full text-sm"
+              >
+                <option value="">Pick a class…</option>
+                {(rooms ?? []).map((r) => (
+                  <option key={r.id} value={r.id}>
+                    {r.subject_name} · {r.classroom_display}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block text-xs text-ink-600">
+              Student
+              <select
+                value={studentId == null ? '' : String(studentId)}
+                onChange={(e) => setStudentId(e.target.value ? Number(e.target.value) : null)}
+                disabled={roomId == null || studentsLoading}
+                className="input-brand mt-1 block w-full text-sm disabled:opacity-60"
+              >
+                <option value="">
+                  {roomId == null
+                    ? 'Pick a class first'
+                    : studentsLoading
+                      ? 'Loading students…'
+                      : 'Pick a student…'}
+                </option>
+                {(students ?? []).map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.full_name || s.username}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <label className="block text-xs text-ink-600">
+            Short-answer question
+            <select
+              value={subpartId == null ? '' : String(subpartId)}
+              onChange={(e) => setSubpartId(e.target.value ? Number(e.target.value) : null)}
+              disabled={subpartsLoading}
+              className="input-brand mt-1 block w-full text-sm disabled:opacity-60"
+            >
+              <option value="">
+                {subpartsLoading ? 'Loading questions…' : 'Pick a question…'}
+              </option>
+              {(subparts ?? []).map((sp) => (
+                <option key={sp.subpartId} value={sp.subpartId}>
+                  {sp.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          {!subpartsLoading && (subparts ?? []).length === 0 && (
+            <p className="text-xs text-ink-500">
+              No short-answer questions yet — create one in the question bank first; only
+              short-answer questions can be AI-graded here.
+            </p>
+          )}
+
+          {subpartId != null && <RubricSection subpartId={subpartId} />}
+
+          <label className="block text-xs text-ink-600">
+            Student&apos;s answer
+            <textarea
+              value={responseText}
+              onChange={(e) => setResponseText(e.target.value)}
+              rows={3}
+              className="input-brand mt-1 block w-full text-sm"
+              placeholder="Paste or type the student's written answer…"
+            />
+          </label>
+
+          {submit.isError && (
+            <p className="text-xs text-rose-600">
+              Couldn&apos;t queue this response just now. Please try again in a moment.
+            </p>
+          )}
+          {submit.isSuccess && (
+            <p className="text-xs text-emerald-700" role="status">
+              Queued — it appears below as “AI grading…” and flips to a suggestion in a few
+              seconds.
+            </p>
+          )}
+
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-xs text-ink-400">AI suggests, you finalise — always.</p>
+            <Button type="submit" variant="brand" size="sm" disabled={!canSubmit || submit.isPending}>
+              {submit.isPending ? 'Queuing…' : 'Send to AI grading'}
+            </Button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+};

--- a/frontend_modern/src/features/teacher/useOpenRubrics.ts
+++ b/frontend_modern/src/features/teacher/useOpenRubrics.ts
@@ -1,0 +1,135 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+
+export interface RubricCriterion {
+  label: string;
+  description?: string;
+  marks: number;
+}
+
+/** Mirrors OpenResponseRubricSerializer (backend/openshiksha/apps/ai/serializers.py). */
+export interface OpenResponseRubric {
+  id: number;
+  subpart: number;
+  question_text: string;
+  max_marks: number;
+  model_answer: string;
+  criteria: RubricCriterion[];
+  created_by: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+const rubricKey = (subpartId: number) => ['ai', 'open-rubrics', subpartId];
+
+/** One rubric per subpart (OneToOne server-side) — resolve to it or null. */
+export const useRubricForSubpart = (subpartId: number | null) =>
+  useQuery<OpenResponseRubric | null>({
+    queryKey: rubricKey(subpartId ?? 0),
+    queryFn: async () => {
+      const { data } = await apiClient.get<
+        OpenResponseRubric[] | { results: OpenResponseRubric[] }
+      >(`/ai/open-rubrics/?subpart=${subpartId}`);
+      const rows = Array.isArray(data) ? data : (data.results ?? []);
+      return rows[0] ?? null;
+    },
+    enabled: subpartId != null,
+    staleTime: 60 * 1000,
+  });
+
+export interface RubricPayload {
+  subpart: number;
+  max_marks: number;
+  model_answer: string;
+  criteria: RubricCriterion[];
+}
+
+/** Create when the subpart has no rubric yet, PATCH the existing one otherwise. */
+export const useSaveRubric = () => {
+  const queryClient = useQueryClient();
+  return useMutation<OpenResponseRubric, Error, { existingId: number | null } & RubricPayload>({
+    mutationFn: async ({ existingId, ...payload }) => {
+      const { data } = existingId
+        ? await apiClient.patch<OpenResponseRubric>(`/ai/open-rubrics/${existingId}/`, payload)
+        : await apiClient.post<OpenResponseRubric>('/ai/open-rubrics/', payload);
+      return data;
+    },
+    onSuccess: (rubric) => {
+      queryClient.invalidateQueries({ queryKey: rubricKey(rubric.subpart) });
+    },
+  });
+};
+
+export interface RoomStudent {
+  id: number;
+  full_name: string;
+  username: string;
+}
+
+/** Roster of a subject room — teacher-only picker data. */
+export const useRoomStudents = (roomId: number | null) =>
+  useQuery<RoomStudent[]>({
+    queryKey: ['subject-rooms', roomId, 'students'],
+    queryFn: async () => {
+      const { data } = await apiClient.get<{ results: RoomStudent[] }>(
+        `/subject-rooms/${roomId}/students/`
+      );
+      return data.results;
+    },
+    enabled: roomId != null,
+    staleTime: 5 * 60 * 1000,
+  });
+
+export interface ShortAnswerSubpartOption {
+  subpartId: number;
+  questionId: number;
+  label: string;
+}
+
+interface QuestionRow {
+  id: number;
+  subparts: Array<{ id: number; question_text: string }>;
+}
+
+/**
+ * The teacher's short-answer subparts, flattened for a picker. Only
+ * short-answer questions can carry a rubric / be AI-graded as open responses.
+ */
+export const useShortAnswerSubparts = (enabled = true) =>
+  useQuery<ShortAnswerSubpartOption[]>({
+    queryKey: ['questions', 'short-answer-subparts'],
+    queryFn: async () => {
+      const { data } = await apiClient.get<QuestionRow[] | { results: QuestionRow[] }>(
+        '/questions/?question_type=short_answer'
+      );
+      const rows = Array.isArray(data) ? data : (data.results ?? []);
+      return rows.flatMap((q) =>
+        q.subparts.map((sp) => ({
+          subpartId: sp.id,
+          questionId: q.id,
+          label:
+            sp.question_text.length > 90 ? `${sp.question_text.slice(0, 90)}…` : sp.question_text,
+        }))
+      );
+    },
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  });
+
+export const useSubmitOpenResponse = () => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    unknown,
+    Error,
+    { subpart_id: number; student_id: number; subject_room_id: number; response_text: string }
+  >({
+    mutationFn: async (payload) => {
+      const { data } = await apiClient.post('/ai/open-grades/submit/', payload);
+      return data;
+    },
+    onSuccess: () => {
+      // The new pending row should appear in every grading-queue view.
+      queryClient.invalidateQueries({ queryKey: ['ai', 'open-grades'] });
+    },
+  });
+};


### PR DESCRIPTION
## Classification
New — ASA-7b, part 2 of the ASA-7 anchor. Based on latest `modernization` (includes merged #299–#301). **Completes the ASA backlog (ASA-1..9 all shipped).**

## What
The input side of open-response grading, on `/teacher/grading` above the queue from #301:
- **Record a response**: class → student → short-answer question → paste the answer → `POST /ai/open-grades/submit/` (202) → pending row appears in the queue and flips to a suggestion via the existing polling.
- **Rubric authoring** (first `/ai/open-rubrics/` consumer): inline per-subpart rubric — max marks, model answer, optional marking points with a sum-mismatch warning. A picked question with no rubric gets a nudge ("AI falls back to a rough keyword match — add one for fair, transparent marks"). Create POSTs, edit PATCHes the OneToOne rubric.
- With this, **every `/ai/` endpoint group has a frontend consumer** — the initiative's North-Star condition.

## Backend (small, justified)
New teacher/admin-only `GET /api/v1/subject-rooms/{id}/students/` roster action for the pickers — no such endpoint existed. Other teachers 404 via queryset scoping; **students get 404** so they can't enumerate classmates. 3 new tests. No model change, no migration.

## Legacy reference
None — legacy had no grading path for free-text answers.

## Tests
`RecordResponsePanel.test.tsx` — 7 cases (collapsed default, record flow + success note, no-rubric nudge, rubric create, rubric edit PATCH, sum warning, submit-failure inline). Gates: frontend lint + tsc + **vitest 320/320 (51 files)** + build; backend **pytest 926 passed, 93.77% coverage**.

## How to verify
Teacher → ✨ AI grading → "Record a response for AI grading" → pick class/student/question → add a rubric → paste an answer → Send → watch the pending row below flip to an AI suggestion → review it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)