### PR TITLE
fix(infra): migrate on backend container start; quiet django.template debug noise

### DIFF
--- a/backend/openshiksha/settings/development.py
+++ b/backend/openshiksha/settings/development.py
@@ -33,6 +33,15 @@ CORS_ALLOW_ALL_ORIGINS = True
 # Logging - More verbose in development
 LOGGING["root"]["level"] = "DEBUG"  # noqa: F405  # type: ignore[index]
 LOGGING["loggers"]["django"]["level"] = "DEBUG"  # noqa: F405  # type: ignore[index]
+# django.template at DEBUG floods the console with internal VariableDoesNotExist
+# tracebacks every time Django renders its own technical 404/500 pages — pages
+# whose templates probe optional context keys by design. The flood buries the
+# *real* exception several screens up, so keep this one logger at INFO.
+LOGGING["loggers"]["django.template"] = {  # noqa: F405  # type: ignore[index]
+    "handlers": ["console"],
+    "level": "INFO",
+    "propagate": False,
+}
 
 # Email - Console backend for development
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,10 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     container_name: openshiksha-backend
-    command: python manage.py runserver 0.0.0.0:8000
+    # Migrate before serving — otherwise the DB silently drifts behind new
+    # migrations and requests blow up mid-flight (e.g. "relation
+    # problem_set_versions does not exist" when publishing an assignment).
+    command: sh -c "python manage.py migrate --noinput && python manage.py runserver 0.0.0.0:8000"
     volumes:
       - ./backend:/app
       - backend_static:/app/staticfiles

--- a/docs/changes/2026-06-11-docker-migrate-on-start.md
+++ b/docs/changes/2026-06-11-docker-migrate-on-start.md
@@ -1,0 +1,46 @@
+# Fix assignment-publish 500: migrate on container start + readable dev logs
+
+**Date:** 2026-06-11
+**Classification:** Fix (infra + dev ergonomics)
+
+## Summary
+
+Publishing an assignment against the Docker stack failed with a 500. The
+backend log was a wall of `django.template VariableDoesNotExist` tracebacks
+(`Failed lookup for key [name] in <URLResolver …>`), which is **not** the
+bug — it's Django's own technical 404/500 debug pages probing optional
+template variables, logged because dev settings run the `django` logger at
+DEBUG. Buried beneath the noise was the real exception:
+
+```
+django.db.utils.ProgrammingError: relation "problem_set_versions" does not exist
+```
+
+The dockerized Postgres had never been migrated for AIV-7's
+`ProblemSetVersion` table (migrations 0025/0026), so the version-pinning
+query in `AssignmentSerializer.create` exploded. The compose backend service
+ran bare `runserver` — nothing ever applied migrations, so the container DB
+silently drifts every time new migrations land.
+
+## What changed
+
+- **`docker-compose.yml`** — backend command is now
+  `sh -c "python manage.py migrate --noinput && python manage.py runserver 0.0.0.0:8000"`,
+  so the schema always matches the code on container start.
+- **`backend/openshiksha/settings/development.py`** — `django.template`
+  logger pinned to INFO (console only, no propagate). The DEBUG-level
+  VariableDoesNotExist flood from Django's internal debug pages buried the
+  actual error several screens up; real template errors still surface (they
+  raise, they don't log-and-continue).
+
+No application code change — `AssignmentSerializer.create` was correct; the
+schema was missing.
+
+## Verification
+
+- Live DB migrated (incl. previously missed `django_celery_results`
+  migrations applied on the new container boot).
+- End-to-end smoke test inside the container: teacher POST
+  `/api/v1/assignments/` → **201**, `problem_set_version` pinned — twice
+  (before and after recreating the container with the new command).
+- `manage.py check` clean; `docker compose config` valid.


### PR DESCRIPTION
## Classification
Fix (infra + dev ergonomics) — resolves the backend error on assignment publish.

## Root cause
The scary `VariableDoesNotExist: Failed lookup for key [name] in <URLResolver …>` wall is **noise**: Django's own technical 404/500 pages probe optional template variables, and dev settings log `django` at DEBUG. The real exception underneath:
```
django.db.utils.ProgrammingError: relation "problem_set_versions" does not exist
```
The dockerized Postgres was never migrated for AIV-7 (`0025/0026`) — the compose backend service ran bare `runserver`, so the container DB silently drifts whenever new migrations land. Assignment creation pins a `ProblemSetVersion` (`AssignmentSerializer.create`) → 500.

## What
- `docker-compose.yml`: backend command → `migrate --noinput && runserver` (schema always matches code on boot).
- `development.py`: `django.template` logger pinned to INFO so the next real error isn't buried under internal debug-page noise (real template errors raise, they don't log-and-continue).

No application-code change — the serializer was correct.

## Verification
- Live stack already healed (migrations applied; new container boot also picked up missed `django_celery_results` migrations).
- In-container smoke test: teacher `POST /api/v1/assignments/` → **201** with `problem_set_version` pinned — before *and* after recreating the container with the new command.
- `manage.py check` clean; `docker compose config` valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)