### PR TITLE
polish(ai): difficulty calibration — list-error state, skeleton loading, refresh feedback

### DIFF
--- a/docs/ai-features/polish-backlog.md
+++ b/docs/ai-features/polish-backlog.md
@@ -250,20 +250,67 @@ While loading → a pulsing report-card skeleton.
 
 ---
 
+## 2026-06-11 — Difficulty calibration: list-error state + skeleton loading + refresh feedback
+
+**Surface:** Difficulty calibration (teacher dashboard `QuestionQualityPanel`).
+First audit of this surface — it predates the error-as-empty-state sweep and
+was missed by it.
+
+**Gaps (checklist #1 error states, #2 loading states, #8 tests):**
+1. The list query's `isError` was never read, so a **failed fetch rendered the
+   empty state** — "No questions flagged yet" — telling the teacher their
+   question bank looks healthy when the server was simply unreachable. Same
+   anti-pattern already fixed in `MisconceptionClustersPanel`,
+   `InterventionsPanel`, and `WeeklyReportPanel`.
+2. Loading was a bare "Loading question analysis…" text line instead of a
+   shape-matched skeleton, so the expanded section reflowed when data landed.
+3. The refresh mutation **silently swallowed errors** (`refresh.isError` never
+   read) and gave no confirmation on success — after the button flicked back
+   from "Refreshing…" nothing told the teacher a recompute was underway.
+4. The panel had **no test file at all** — the only teacher AI panel without one.
+5. Minor: the collapse toggle lacked `aria-expanded` (all siblings have it).
+
+**Fix:**
+- Destructured `isError`/`refetch` from `useFlaggedCalibrations`; a failed
+  fetch now shows "Couldn't load the question analysis just now." with an
+  inline **Retry** button. The empty state only renders on a *successful*
+  empty response.
+- Added `CalibrationCardSkeleton` (mirrors the `CalibrationCard` layout:
+  title + meta lines, flag pill, hint line, three stat chips) shown twice
+  while loading.
+- `refresh.isError` → inline rose error; `refresh.isSuccess` → "Recalibrating
+  from recent answers — updated verdicts appear here shortly." status line
+  (same recipe as `MisconceptionClustersPanel`).
+- Added `aria-expanded` to the toggle.
+- New test file `QuestionQualityPanel.test.tsx` (7 tests): lazy fetch +
+  skeletons, card details + summary line, empty state, list-error + Retry
+  (not the empty state), retry recovery, refresh queue + status, refresh
+  failure (checklist #8).
+
+**Verify:** Teacher dashboard → expand "Question Quality" with the API
+unreachable → red "Couldn't load…" line with Retry, not the empty state.
+While loading → two pulsing card skeletons. Click Refresh → status line
+confirms the recompute; a failing refresh shows the inline error.
+
+---
+
 ## Remaining gaps (audit notes — updated 2026-06-11, ASA closed)
 
 - ✅ **Error-as-empty-state sweep complete** — `MisconceptionClustersPanel`
-  (#291), `InterventionsPanel` and `WeeklyReportPanel` (both 2026-06-10) now
+  (#291), `InterventionsPanel` and `WeeklyReportPanel` (both 2026-06-10), and
+  `QuestionQualityPanel` (2026-06-11, the one panel the sweep missed) now
   all distinguish a failed fetch from a genuinely empty response and use
-  shape-matched skeletons while loading.
+  shape-matched skeletons while loading. `AssignmentDraftsPanel` shipped with
+  the pattern built in (#297).
 - **Misconception cluster cards lack AI provenance** — `sample_diagnosis` /
   `sample_remediation_tip` are copied from LLM-generated `StudentMisconception`
   rows but `ClassMisconceptionCluster` carries no `model_used`, so the cards
   can't show the `✨ AI-generated` vs stub badge used everywhere else. Needs a
   model field + migration → guardrailed out of polish runs; note for ASA.
 - **Refresh confirmation lingers** — `MisconceptionClustersPanel`'s
-  "Recomputing from recent submissions…" status stays visible after the
-  delayed refetch lands; could clear once new data arrives. Minor.
+  "Recomputing from recent submissions…" status (and now
+  `QuestionQualityPanel`'s matching "Recalibrating…" line) stays visible
+  after the delayed refetch lands; could clear once new data arrives. Minor.
 - **Hint system** — solid: loading ("Thinking of a good hint…"), error, and
   exhausted states all present. Low priority.
 - ✅ **Unwired backend surfaces — all four groups lit.**

--- a/frontend_modern/src/features/teacher/QuestionQualityPanel.test.tsx
+++ b/frontend_modern/src/features/teacher/QuestionQualityPanel.test.tsx
@@ -1,0 +1,197 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { QuestionQualityPanel } from './QuestionQualityPanel';
+import type { CalibrationSummary, DifficultyCalibration } from './useDifficultyCalibration';
+
+const { mockGet, mockPost } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPost: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    get: mockGet,
+    post: mockPost,
+  },
+}));
+
+const CALIBRATION: DifficultyCalibration = {
+  id: 7,
+  subject_room: 1,
+  subject_name: 'Mathematics',
+  question_subpart: 42,
+  question_id: 42,
+  subpart_index: 0,
+  chapter_name: 'Fractions',
+  question_preview: 'Add 1/2 and 1/3 and simplify the result.',
+  sample_size: 18,
+  attempt_count: 21,
+  facility_index: 0.17,
+  discrimination_index: 0.05,
+  empirical_difficulty: 5,
+  declared_difficulty: 2,
+  difficulty_delta: 3,
+  flag: 'too_hard',
+  flag_display: 'Too hard',
+  needs_review: true,
+  computed_at: '2026-06-10T06:00:00Z',
+};
+
+const SUMMARY: CalibrationSummary = {
+  subject_room: 1,
+  total_calibrated: 12,
+  flagged: 1,
+  by_flag: { ok: 11, mislabeled: 0, too_easy: 0, too_hard: 1, low_discrimination: 0 },
+};
+
+/** Serve the list and summary endpoints; the panel queries both when opened. */
+const serveList = (listResponse: () => Promise<{ data: { results: DifficultyCalibration[] } }>) => {
+  mockGet.mockImplementation((url: string) =>
+    url.includes('/summary/') ? Promise.resolve({ data: SUMMARY }) : listResponse()
+  );
+};
+
+function renderPanel() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <QuestionQualityPanel subjectRoomId={1} />
+    </QueryClientProvider>
+  );
+}
+
+describe('QuestionQualityPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is collapsed by default and shows shape-matched skeletons while loading', async () => {
+    const user = userEvent.setup();
+    let resolveList!: (value: { data: { results: DifficultyCalibration[] } }) => void;
+    serveList(
+      () =>
+        new Promise((resolve) => {
+          resolveList = resolve;
+        })
+    );
+
+    renderPanel();
+    expect(mockGet).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: /question quality/i }));
+    // Shape-matched skeleton cards, not bare text, while the list loads.
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0);
+    expect(screen.queryByText(/no questions flagged yet/i)).toBeNull();
+
+    resolveList({ data: { results: [CALIBRATION] } });
+    await waitFor(() =>
+      expect(screen.getByText('Add 1/2 and 1/3 and simplify the result.')).toBeDefined()
+    );
+    expect(mockGet).toHaveBeenCalledWith(
+      '/ai/difficulty-calibrations/?subject_room=1&needs_review=true'
+    );
+  });
+
+  it('renders the flag verdict, teacher hint, and authored-vs-observed chips', async () => {
+    const user = userEvent.setup();
+    serveList(() => Promise.resolve({ data: { results: [CALIBRATION] } }));
+
+    renderPanel();
+    await user.click(screen.getByRole('button', { name: /question quality/i }));
+
+    await waitFor(() => expect(screen.getByText('Too hard')).toBeDefined());
+    expect(screen.getByText(/almost no one got this right/i)).toBeDefined();
+    expect(screen.getByText('Authored difficulty')).toBeDefined();
+    expect(screen.getByText('Observed difficulty')).toBeDefined();
+    expect(screen.getByText(/1 of 12 calibrated questions need a look/i)).toBeDefined();
+  });
+
+  it('explains what unlocks calibration when nothing is flagged', async () => {
+    const user = userEvent.setup();
+    serveList(() => Promise.resolve({ data: { results: [] } }));
+
+    renderPanel();
+    await user.click(screen.getByRole('button', { name: /question quality/i }));
+
+    await waitFor(() => expect(screen.getByText(/no questions flagged yet/i)).toBeDefined());
+  });
+
+  it('shows an error with retry — not the empty state — when the list fetch fails', async () => {
+    const user = userEvent.setup();
+    serveList(() => Promise.reject(new Error('network down')));
+
+    renderPanel();
+    await user.click(screen.getByRole('button', { name: /question quality/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/couldn't load the question analysis/i)).toBeDefined()
+    );
+    // A failed fetch must not read as "your question bank is healthy".
+    expect(screen.queryByText(/no questions flagged yet/i)).toBeNull();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeDefined();
+  });
+
+  it('recovers when retry succeeds after a failed list fetch', async () => {
+    const user = userEvent.setup();
+    let failNext = true;
+    serveList(() => {
+      if (failNext) {
+        failNext = false;
+        return Promise.reject(new Error('network down'));
+      }
+      return Promise.resolve({ data: { results: [CALIBRATION] } });
+    });
+
+    renderPanel();
+    await user.click(screen.getByRole('button', { name: /question quality/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/couldn't load the question analysis/i)).toBeDefined()
+    );
+
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText('Add 1/2 and 1/3 and simplify the result.')).toBeDefined()
+    );
+    expect(screen.queryByText(/couldn't load the question analysis/i)).toBeNull();
+  });
+
+  it('queues a recalibration and confirms the recompute is underway', async () => {
+    const user = userEvent.setup();
+    serveList(() => Promise.resolve({ data: { results: [CALIBRATION] } }));
+    mockPost.mockResolvedValue({ data: { detail: 'queued' } });
+
+    renderPanel();
+    await user.click(screen.getByRole('button', { name: /question quality/i }));
+    await waitFor(() => expect(screen.getByText('Too hard')).toBeDefined());
+
+    await user.click(screen.getByRole('button', { name: /refresh/i }));
+
+    await waitFor(() =>
+      expect(mockPost).toHaveBeenCalledWith('/ai/difficulty-calibrations/refresh/', {
+        subject_room_id: 1,
+      })
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/recalibrating from recent answers/i)).toBeDefined()
+    );
+  });
+
+  it('shows an inline error when the recalibration fails to start', async () => {
+    const user = userEvent.setup();
+    serveList(() => Promise.resolve({ data: { results: [CALIBRATION] } }));
+    mockPost.mockRejectedValue(new Error('boom'));
+
+    renderPanel();
+    await user.click(screen.getByRole('button', { name: /question quality/i }));
+    await waitFor(() => expect(screen.getByText('Too hard')).toBeDefined());
+
+    await user.click(screen.getByRole('button', { name: /refresh/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/couldn't start the recalibration/i)).toBeDefined()
+    );
+  });
+});

--- a/frontend_modern/src/features/teacher/QuestionQualityPanel.tsx
+++ b/frontend_modern/src/features/teacher/QuestionQualityPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Badge, Button } from '@/shared/ui';
+import { Badge, Button, Skeleton } from '@/shared/ui';
 import {
   useCalibrationSummary,
   useFlaggedCalibrations,
@@ -78,6 +78,25 @@ const CalibrationCard = ({ item }: CardProps) => {
   );
 };
 
+// Mirrors the CalibrationCard layout so the list doesn't reflow when data lands.
+const CalibrationCardSkeleton = () => (
+  <div className="rounded-xl border border-ink-100 bg-paper p-4">
+    <div className="flex items-start justify-between gap-3">
+      <div className="min-w-0 flex-1 space-y-1.5">
+        <Skeleton w="w-2/3" h="h-5" />
+        <Skeleton w="w-1/2" h="h-3" />
+      </div>
+      <Skeleton w="w-20" h="h-5" rounded="rounded-full" />
+    </div>
+    <Skeleton w="w-5/6" h="h-3" className="mt-3" />
+    <div className="mt-3 flex gap-1.5">
+      <Skeleton w="w-28" h="h-5" rounded="rounded-full" />
+      <Skeleton w="w-28" h="h-5" rounded="rounded-full" />
+      <Skeleton w="w-24" h="h-5" rounded="rounded-full" />
+    </div>
+  </div>
+);
+
 interface Props {
   subjectRoomId: number;
 }
@@ -93,7 +112,12 @@ interface Props {
  */
 export const QuestionQualityPanel = ({ subjectRoomId }: Props) => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const { data: flagged, isLoading } = useFlaggedCalibrations(subjectRoomId, isExpanded);
+  const {
+    data: flagged,
+    isLoading,
+    isError,
+    refetch,
+  } = useFlaggedCalibrations(subjectRoomId, isExpanded);
   const { data: summary } = useCalibrationSummary(subjectRoomId, isExpanded);
   const refresh = useRefreshCalibrations(subjectRoomId);
 
@@ -103,6 +127,7 @@ export const QuestionQualityPanel = ({ subjectRoomId }: Props) => {
     <div className="mt-3 border-t border-ink-100 pt-3">
       <button
         onClick={() => setIsExpanded((v) => !v)}
+        aria-expanded={isExpanded}
         className="flex items-center gap-1.5 text-xs font-semibold text-ink-500 hover:text-ink-800 transition-colors w-full text-left"
       >
         <span>Question Quality</span>
@@ -119,16 +144,51 @@ export const QuestionQualityPanel = ({ subjectRoomId }: Props) => {
             </p>
           )}
 
-          {isLoading && <p className="text-xs text-ink-400 py-2">Loading question analysis…</p>}
+          {isLoading && (
+            <>
+              <CalibrationCardSkeleton />
+              <CalibrationCardSkeleton />
+            </>
+          )}
 
-          {!isLoading && items.length === 0 && (
+          {/* A failed fetch must not masquerade as "no questions flagged" —
+              that would tell the teacher their question bank is healthy when
+              we just couldn't reach the server. */}
+          {!isLoading && isError && (
+            <p className="text-xs text-rose-600 py-2">
+              Couldn&apos;t load the question analysis just now.{' '}
+              <button
+                type="button"
+                onClick={() => void refetch()}
+                className="font-medium underline hover:text-rose-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 rounded"
+              >
+                Retry
+              </button>
+            </p>
+          )}
+
+          {!isLoading && !isError && items.length === 0 && (
             <div className="text-xs text-ink-500 py-2">
               No questions flagged yet. Calibration needs a handful of student attempts per
               question — refresh once your class has practised.
             </div>
           )}
 
-          {!isLoading && items.map((item) => <CalibrationCard key={item.id} item={item} />)}
+          {!isLoading &&
+            !isError &&
+            items.map((item) => <CalibrationCard key={item.id} item={item} />)}
+
+          {refresh.isError && (
+            <p className="text-xs text-rose-600 pt-1">
+              Couldn&apos;t start the recalibration just now. Please try again in a moment.
+            </p>
+          )}
+
+          {refresh.isSuccess && (
+            <p className="text-xs text-ink-400 pt-1" role="status">
+              Recalibrating from recent answers — updated verdicts appear here shortly.
+            </p>
+          )}
 
           <div className="flex items-center justify-between pt-1">
             <p className="text-xs text-ink-400">


### PR DESCRIPTION
## What gap was fixed

`QuestionQualityPanel` (the difficulty-calibration surface on the teacher dashboard) predates the error-as-empty-state sweep (#291, #295/#296-era fixes) and was the **one teacher AI panel it missed**. First audit of this surface against the 8-point polish checklist found:

1. **Error masquerading as all-clear (checklist #1):** the list query's `isError` was never read, so a failed fetch rendered the empty state — *"No questions flagged yet"* — telling the teacher their question bank looks healthy when the server was simply unreachable.
2. **Bare-text loading (checklist #2):** *"Loading question analysis…"* instead of a shape-matched skeleton, so the expanded section reflowed when data landed.
3. **Silent refresh failures:** `refresh.isError` was never read — a failed recalibration POST gave no feedback at all. A successful one gave no confirmation either, even though the recompute is async and results land ~2.5 s later.
4. **Zero test coverage (checklist #8):** the only teacher AI panel with no test file.
5. Minor: the collapse toggle lacked `aria-expanded` (all siblings have it).

## Before / after

| | Before | After |
|---|---|---|
| Failed list fetch | "No questions flagged yet" (false all-clear) | "Couldn't load the question analysis just now." + inline **Retry** |
| Loading | bare text line, reflow on land | 2× `CalibrationCardSkeleton` mirroring the card layout |
| Failed refresh | nothing | inline rose error |
| Successful refresh | nothing | "Recalibrating from recent answers — updated verdicts appear here shortly." status |

Same recipes as `MisconceptionClustersPanel` / `InterventionsPanel` / `WeeklyReportPanel`, so all five collapsible teacher AI panels now behave identically.

## How to verify

- Teacher dashboard → expand **Question Quality** with the API unreachable → red "Couldn't load…" line with Retry, **not** the empty state.
- While loading → two pulsing card skeletons, no reflow.
- Click **Refresh** → status line confirms the recompute; kill the endpoint → inline error.
- `npx vitest run src/features/teacher/QuestionQualityPanel.test.tsx` → 7 tests. Full suite: 327 passed. `tsc --noEmit` and `eslint --max-warnings 0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)