### PR TITLE
infra(deps): Dependabot coverage for Docker base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,47 @@ updates:
           - "minor"
           - "patch"
 
+  # Backend Docker base images (Dockerfile + Dockerfile.prod: python:3.11-slim)
+  - package-ecosystem: "docker"
+    directory: "/backend"
+    schedule:
+      interval: "monthly"
+    target-branch: "modernization"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "backend"
+    commit-message:
+      prefix: "deps"
+    # Patch/digest bumps of the base image are routine; group them monthly.
+    # A major (python 3.11 → 3.x) is a runtime upgrade that needs its own
+    # review against CI and mypy, so majors stay individual PRs.
+    groups:
+      backend-docker-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Frontend Docker base images (node:20-alpine builder, nginx runtime)
+  - package-ecosystem: "docker"
+    directory: "/frontend_modern"
+    schedule:
+      interval: "monthly"
+    target-branch: "modernization"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "frontend"
+    commit-message:
+      prefix: "deps"
+    groups:
+      frontend-docker-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
   # GitHub Actions workflow dependencies
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/docs/changes/2026-06-11-dependabot-docker-ecosystem.md
+++ b/docs/changes/2026-06-11-dependabot-docker-ecosystem.md
@@ -30,10 +30,13 @@ images only picked up fixes when someone rebuilt for an unrelated reason.
 
 ## Dependabot alert triage (same run)
 
-All 3 open alerts (idna GHSA-65pc-fj4g-8rjx, urllib3 GHSA-qccp-gfcp-xxvc,
-pillow GHSA-wjx4-4jcj-g98j) point at the deleted legacy `pip-requirements.txt`,
-which still exists on the default branch `qa` (322 commits behind
-`modernization`). Per `docs/infra/dependabot-legacy-stack.md` they auto-resolve
-at the next `modernization → qa` promotion. The modern stack is clean: Pillow
-is pinned at the patched 12.2.0, and idna/urllib3 are unpinned transitives that
-resolve to patched versions (pip-audit in CI is green).
+All **74** open alerts point at the deleted legacy `pip-requirements.txt`
+(verified via paginated API query grouped by manifest path), which still
+exists on the default branch `qa` (322 commits behind `modernization`). Per
+`docs/infra/dependabot-legacy-stack.md` they auto-resolve at the next
+`modernization → qa` promotion. The three newest (idna GHSA-65pc-fj4g-8rjx,
+urllib3 GHSA-qccp-gfcp-xxvc, pillow GHSA-wjx4-4jcj-g98j) were spot-checked
+against the modern stack: Pillow is pinned at the patched 12.2.0, and
+idna/urllib3 are unpinned transitives that resolve to patched versions
+(pip-audit in CI is green). No open alert targets `backend/requirements.txt`,
+`frontend_modern/package.json`, or the workflows.

--- a/docs/changes/2026-06-11-dependabot-docker-ecosystem.md
+++ b/docs/changes/2026-06-11-dependabot-docker-ecosystem.md
@@ -1,0 +1,39 @@
+# Dependabot: cover Docker base images
+
+**Date:** 2026-06-11
+**Type:** infra
+**Branch:** `infra/2026-06-11-dependabot-docker`
+
+## What
+
+Added two `docker` ecosystem entries to `.github/dependabot.yml`:
+
+- `/backend` — `Dockerfile` + `Dockerfile.prod` (`python:3.11-slim`)
+- `/frontend_modern` — `Dockerfile` + `Dockerfile.prod` (`node:20-alpine`
+  builder stage, `nginx` runtime stage)
+
+Both run monthly, target `modernization`, and group minor/patch bumps into a
+single PR per directory. Majors (e.g. `python:3.11` → a new Python minor line,
+which Docker tags treat as a major-ish runtime change) stay as individual PRs
+because a base-runtime upgrade needs deliberate review against CI, mypy, and
+the deploy images. Security updates keep Dependabot's default
+one-PR-per-advisory behaviour.
+
+## Why
+
+Dependabot previously covered `pip`, `npm`, and `github-actions` — but the
+deploy pipeline ships two production Docker images
+(`backend/Dockerfile.prod`, `frontend_modern/Dockerfile.prod` → GHCR → k3s),
+and nothing watched their base images. Base-image patch releases are how OS-level
+CVE fixes (Debian slim, Alpine, nginx) reach the running pods; without this,
+images only picked up fixes when someone rebuilt for an unrelated reason.
+
+## Dependabot alert triage (same run)
+
+All 3 open alerts (idna GHSA-65pc-fj4g-8rjx, urllib3 GHSA-qccp-gfcp-xxvc,
+pillow GHSA-wjx4-4jcj-g98j) point at the deleted legacy `pip-requirements.txt`,
+which still exists on the default branch `qa` (322 commits behind
+`modernization`). Per `docs/infra/dependabot-legacy-stack.md` they auto-resolve
+at the next `modernization → qa` promotion. The modern stack is clean: Pillow
+is pinned at the patched 12.2.0, and idna/urllib3 are unpinned transitives that
+resolve to patched versions (pip-audit in CI is green).


### PR DESCRIPTION
## What

Adds two `docker` ecosystem entries to `.github/dependabot.yml`:

- `/backend` — `Dockerfile` + `Dockerfile.prod` (`python:3.11-slim`)
- `/frontend_modern` — `Dockerfile` + `Dockerfile.prod` (`node:20-alpine` builder, `nginx` runtime)

Monthly cadence, targeting `modernization`, minor/patch bumps grouped per directory, majors as individual PRs (a base-runtime upgrade deserves its own review), security updates one-PR-per-advisory as usual.

## Why

The deploy pipeline ships two production images to GHCR/k3s, but Dependabot only watched `pip`/`npm`/`github-actions` — nothing tracked the base images, which is how OS-level CVE fixes (Debian slim, Alpine, nginx) reach the running pods.

## Alert triage (this run)

All **74** open Dependabot alerts target the deleted legacy `pip-requirements.txt` (verified via paginated API query grouped by manifest path), which still exists on the default branch `qa` — 322 commits behind `modernization`. Per `docs/infra/dependabot-legacy-stack.md` they auto-resolve at the next `modernization → qa` promotion. The three newest (idna, urllib3, pillow) were spot-checked against the modern stack: Pillow pinned at patched 12.2.0; idna/urllib3 are unpinned transitives resolving to patched versions; pip-audit in CI is green. No open alert targets `backend/requirements.txt`, `frontend_modern/package.json`, or the workflows.

## Validation

- `yaml.safe_load` parses; 5 update entries (pip, npm, docker ×2, github-actions)
- Pre-commit hooks passed (yaml check, whitespace, EOF)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
