### PR TITLE
feat(i18n): LA-3 — student core-loop chrome in Hindi

### DIFF
--- a/docs/changes/2026-06-11-la3-student-chrome-hindi.md
+++ b/docs/changes/2026-06-11-la3-student-chrome-hindi.md
@@ -1,0 +1,58 @@
+# LA-3 — student core-loop chrome in Hindi
+
+**Date:** 2026-06-11
+**Classification:** Improve
+**Initiative:** [Language Access — i18n en/हिंदी](../initiatives/2026-language-access.md) (LA-3)
+
+## Summary
+
+The entire student core loop now renders in Hindi when the locale is `hi`:
+dashboard (greeting, panels, empty/error states), assignment list (sections,
+card status labels, CTAs), assignment detail (progress line, score banner,
+submit flow + confirm dialog), Due-for-Review panel, Recommendations panel,
+and the streak badge. Chrome only — authored content (question text, titles,
+chapter/subject names) renders as authored, per initiative principle 1.
+
+## Legacy files referenced
+
+None — legacy was English-only.
+
+## What changed and why
+
+- **~60 new keys** in `locales/en.ts` / `locales/hi.ts` across namespaces
+  `dashboard.*`, `assignments.*`, `assignment.*`, `assignmentDetail.*`,
+  `dueReview.*`, `recommendations.*`, `streak.*`, plus `common.cancel/practice/
+  topics*`. Key parity remains tsc-enforced (`LocaleDict`).
+- **Components migrated to `t()`** (string extraction only, zero behavior
+  change): `StudentDashboard`, `AssignmentList`, `AssignmentCard`,
+  `AssignmentDetailPage`, `DueForReviewPanel`, `RecommendationsPanel`,
+  `StreakBadge`.
+- **Relative dates localize too**: new `shared/i18n/dateFnsLocale.ts` maps the
+  active locale to date-fns's `hi` locale, so "due in 3 days" renders as
+  "3 दिन में" rather than mixed-script English. Deliberately *not* exported
+  from the i18n barrel — the barrel is in the entry chunk; the date locale
+  ships only inside the lazy student chunks that format dates.
+- Plurals kept dependency-free with explicit one/many keys (`common.topicsOne`
+  / `common.topicsMany`) — Hindi count nouns don't inflect here, English does.
+- Server-provided display strings (`priority_display`, `reason_display`)
+  intentionally untouched — server-side localization is LA-7 territory.
+
+## Tests
+
+- One renders-in-Hindi case per surface: `AssignmentList.test.tsx` (section +
+  CTA + authored-content-stays), `DueForReviewPanel.test.tsx` (title, urgency
+  label, practice link), `RecommendationsPanel.test.tsx` (title, score label,
+  practice link). Existing rich suites (skeleton/error/empty) untouched and
+  green.
+- Full suite 54 files / 345 tests green; lint + tsc clean; build + budget
+  green (entry 100.45 kB of 160 kB — growth is the English dictionary; Hindi
+  stays in its lazy chunk).
+
+## Migration notes
+
+None (frontend only).
+
+## Next steps
+
+LA-4 (AI content language), LA-5 (parity guard + parent/registration/home
+chrome — home page added to LA-5 scope per user request).

--- a/frontend_modern/src/features/student/AssignmentCard.tsx
+++ b/frontend_modern/src/features/student/AssignmentCard.tsx
@@ -1,6 +1,8 @@
 import { formatDistanceToNow, isPast, parseISO } from 'date-fns';
 import { useNavigate } from 'react-router-dom';
 import { Badge, Button } from '@/shared/ui';
+import { useI18n } from '@/shared/i18n';
+import { dateFnsLocaleFor } from '@/shared/i18n/dateFnsLocale';
 import type { Assignment } from '@/types/index';
 
 interface AssignmentCardProps {
@@ -9,6 +11,8 @@ interface AssignmentCardProps {
 
 export const AssignmentCard = ({ assignment }: AssignmentCardProps) => {
   const navigate = useNavigate();
+  const { t, locale } = useI18n();
+  const dateLocale = dateFnsLocaleFor(locale);
   const { problem_set, due_at, my_submission } = assignment;
   const dueDate = parseISO(due_at);
   const isOverdue = isPast(dueDate);
@@ -17,18 +21,29 @@ export const AssignmentCard = ({ assignment }: AssignmentCardProps) => {
   const score = my_submission?.score;
 
   const dueDateLabel = isOverdue
-    ? `Overdue by ${formatDistanceToNow(dueDate)}`
-    : `Due ${formatDistanceToNow(dueDate, { addSuffix: true })}`;
+    ? t('assignment.overdueBy', { distance: formatDistanceToNow(dueDate, { locale: dateLocale }) })
+    : t('assignment.dueIn', {
+        distance: formatDistanceToNow(dueDate, { addSuffix: true, locale: dateLocale }),
+      });
 
   // Submitted assignments surface *when* they were submitted instead of the
   // due date — once you've turned it in, the due date is irrelevant and the
   // student wants to know "did I do this recently?" at a glance.
   const submittedLabel =
     isSubmitted && my_submission?.submitted_at
-      ? `Submitted ${formatDistanceToNow(parseISO(my_submission.submitted_at), { addSuffix: true })}`
-      : 'Submitted';
+      ? t('assignment.submittedAgo', {
+          distance: formatDistanceToNow(parseISO(my_submission.submitted_at), {
+            addSuffix: true,
+            locale: dateLocale,
+          }),
+        })
+      : t('assignment.submitted');
 
-  const cta = isSubmitted ? 'Review' : completion > 0 ? 'Continue' : 'Start';
+  const cta = isSubmitted
+    ? t('assignment.ctaReview')
+    : completion > 0
+      ? t('assignment.ctaContinue')
+      : t('assignment.ctaStart');
 
   return (
     <div
@@ -47,7 +62,7 @@ export const AssignmentCard = ({ assignment }: AssignmentCardProps) => {
               {problem_set.subject.name}
             </p>
             {problem_set.is_remedial && (
-              <Badge tone="attention">Remedial Practice</Badge>
+              <Badge tone="attention">{t('assignment.remedialBadge')}</Badge>
             )}
           </div>
           <h3 className="font-display font-semibold text-ink-900 truncate">
@@ -72,7 +87,7 @@ export const AssignmentCard = ({ assignment }: AssignmentCardProps) => {
       {!isSubmitted && completion > 0 && (
         <div className="mt-3">
           <div className="flex items-center justify-between text-xs text-ink-500 mb-1">
-            <span>Progress</span>
+            <span>{t('assignment.progress')}</span>
             <span>{Math.round(completion * 100)}%</span>
           </div>
           <div className="h-1.5 bg-ink-100 rounded-full overflow-hidden">

--- a/frontend_modern/src/features/student/AssignmentDetailPage.tsx
+++ b/frontend_modern/src/features/student/AssignmentDetailPage.tsx
@@ -5,6 +5,7 @@ import { useSubmission, useCreateSubmission, usePatchSubmission } from './useSub
 import { QuestionCard } from './QuestionCard';
 import { VideosPanel } from './VideosPanel';
 import { Button, EmptyState, LoadingSpinner } from '@/shared/ui';
+import { useT } from '@/shared/i18n';
 import type { Question } from '@/types/index';
 
 function countSubparts(questions: Question[]): number {
@@ -23,6 +24,7 @@ export const AssignmentDetailPage = () => {
   const { id } = useParams<{ id: string }>();
   const assignmentId = Number(id);
   const navigate = useNavigate();
+  const t = useT();
 
   const { data: assignment, isLoading: assignmentLoading, error: assignmentError } =
     useAssignmentDetail(assignmentId);
@@ -131,11 +133,11 @@ export const AssignmentDetailPage = () => {
     return (
       <div className="max-w-2xl mx-auto px-4 py-16">
         <EmptyState
-          title="Assignment not found"
-          description="It may have been removed or you don't have access."
+          title={t('assignmentDetail.notFoundTitle')}
+          description={t('assignmentDetail.notFoundDescription')}
           action={
             <Button variant="ghost" size="sm" onClick={() => navigate('/student')}>
-              Back to dashboard
+              {t('assignmentDetail.backToDashboard')}
             </Button>
           }
         />
@@ -161,7 +163,7 @@ export const AssignmentDetailPage = () => {
           onClick={() => navigate('/student')}
           className="text-sm text-brand-700 font-medium hover:underline mb-3 flex items-center gap-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded"
         >
-          <span>&#8592;</span> Back to assignments
+          <span>&#8592;</span> {t('assignmentDetail.back')}
         </button>
         <p className="text-xs font-semibold text-brand-700 uppercase tracking-wide">
           {assignment.problem_set.subject.name}
@@ -175,9 +177,7 @@ export const AssignmentDetailPage = () => {
       {!isSubmitted && total > 0 && (
         <div className="mb-6">
           <div className="flex justify-between text-xs text-ink-500 mb-1">
-            <span>
-              {answered} of {total} answered
-            </span>
+            <span>{t('assignmentDetail.answeredCount', { answered, total })}</span>
             <span>{Math.round((answered / total) * 100)}%</span>
           </div>
           <div className="h-1.5 bg-ink-100 rounded-full overflow-hidden">
@@ -196,19 +196,21 @@ export const AssignmentDetailPage = () => {
               <p className="text-2xl font-display font-semibold text-ink-900">
                 {Math.round(submitScore * 100)}%
               </p>
-              <p className="text-sm text-ink-700 mt-0.5">Assignment submitted — nice work!</p>
+              <p className="text-sm text-ink-700 mt-0.5">{t('assignmentDetail.submittedNice')}</p>
             </>
           ) : (
             <>
-              <p className="font-display font-semibold text-brand-800">Submitted</p>
-              <p className="text-sm text-brand-700 mt-0.5">Grading in progress…</p>
+              <p className="font-display font-semibold text-brand-800">
+                {t('assignmentDetail.submittedTitle')}
+              </p>
+              <p className="text-sm text-brand-700 mt-0.5">{t('assignmentDetail.grading')}</p>
             </>
           )}
         </div>
       )}
 
       {questions.length === 0 ? (
-        <EmptyState title="No questions in this assignment" />
+        <EmptyState title={t('assignmentDetail.noQuestions')} />
       ) : (
         <div className="space-y-4">
           {questions.map((question: Question, idx: number) => (
@@ -237,7 +239,7 @@ export const AssignmentDetailPage = () => {
             onClick={() => setShowConfirm(true)}
             disabled={answered === 0}
           >
-            Submit assignment
+            {t('assignmentDetail.submit')}
           </Button>
         </div>
       )}
@@ -245,17 +247,20 @@ export const AssignmentDetailPage = () => {
       {showConfirm && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-ink-900/40 p-4">
           <div className="os-card p-6 max-w-sm w-full shadow-xl">
-            <h3 className="text-lg font-display font-semibold text-ink-900">Submit assignment?</h3>
+            <h3 className="text-lg font-display font-semibold text-ink-900">
+              {t('assignmentDetail.confirmTitle')}
+            </h3>
             <p className="text-sm text-ink-500 mt-1">
-              You have answered {answered} of {total} questions. You cannot change your answers
-              after submitting.
+              {t('assignmentDetail.confirmBody', { answered, total })}
             </p>
             <div className="flex gap-3 mt-5 justify-end">
               <Button variant="ghost" size="sm" onClick={() => setShowConfirm(false)}>
-                Cancel
+                {t('common.cancel')}
               </Button>
               <Button size="sm" onClick={handleSubmit} disabled={patchSubmission.isPending}>
-                {patchSubmission.isPending ? 'Submitting…' : 'Submit'}
+                {patchSubmission.isPending
+                  ? t('assignmentDetail.submitting')
+                  : t('assignmentDetail.confirmSubmit')}
               </Button>
             </div>
           </div>

--- a/frontend_modern/src/features/student/AssignmentList.test.tsx
+++ b/frontend_modern/src/features/student/AssignmentList.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect } from 'vitest';
+import { I18nProvider } from '@/shared/i18n';
 import { AssignmentList } from './AssignmentList';
 import type { Assignment } from '@/types/index';
 import { addDays, subDays, formatISO } from 'date-fns';
@@ -81,6 +82,23 @@ describe('AssignmentList', () => {
     const assignment = makeAssignment({ due_at: formatISO(addDays(new Date(), 2)) });
     renderWithRouter(<AssignmentList assignments={[assignment]} />);
     expect(screen.getByText(/due soon/i)).toBeDefined();
+  });
+
+  it('renders sections, card labels, and the CTA in Hindi when the locale is hi', async () => {
+    const assignment = makeAssignment({ due_at: formatISO(addDays(new Date(), 7)) });
+    render(
+      <I18nProvider initialLocale="hi">
+        <MemoryRouter>
+          <AssignmentList assignments={[assignment]} />
+        </MemoryRouter>
+      </I18nProvider>,
+    );
+
+    // Hindi dictionary loads via dynamic import — wait for the swap.
+    await waitFor(() => expect(screen.getByText('आने वाले')).toBeDefined());
+    expect(screen.getByRole('button', { name: 'शुरू करें' })).toBeDefined();
+    // Authored content (titles, chapter/subject names) stays as authored.
+    expect(screen.getByText('Chapter 3 Practice Set')).toBeDefined();
   });
 
   it('correctly categorizes multiple assignments into separate sections', () => {

--- a/frontend_modern/src/features/student/AssignmentList.tsx
+++ b/frontend_modern/src/features/student/AssignmentList.tsx
@@ -1,5 +1,6 @@
 import { isPast, parseISO, differenceInDays } from 'date-fns';
 import { EmptyState } from '@/shared/ui';
+import { useT } from '@/shared/i18n';
 import type { Assignment } from '@/types/index';
 import { AssignmentCard } from './AssignmentCard';
 
@@ -38,13 +39,14 @@ function groupAssignments(assignments: Assignment[]): GroupedAssignments {
 }
 
 export const AssignmentList = ({ assignments }: AssignmentListProps) => {
+  const t = useT();
   const groups = groupAssignments(assignments);
 
   if (assignments.length === 0) {
     return (
       <EmptyState
-        title="No assignments yet"
-        description="Your teacher will assign some soon. Check back later!"
+        title={t('assignments.emptyTitle')}
+        description={t('assignments.emptyDescription')}
       />
     );
   }
@@ -52,7 +54,11 @@ export const AssignmentList = ({ assignments }: AssignmentListProps) => {
   return (
     <div className="space-y-8">
       {groups.overdue.length > 0 && (
-        <Section title="Overdue" count={groups.overdue.length} accent="urgent">
+        <Section
+          title={t('assignments.sectionOverdue')}
+          count={groups.overdue.length}
+          accent="urgent"
+        >
           {groups.overdue.map((a) => (
             <AssignmentCard key={a.id} assignment={a} />
           ))}
@@ -60,7 +66,11 @@ export const AssignmentList = ({ assignments }: AssignmentListProps) => {
       )}
 
       {groups.dueSoon.length > 0 && (
-        <Section title="Due Soon" count={groups.dueSoon.length} accent="attention">
+        <Section
+          title={t('assignments.sectionDueSoon')}
+          count={groups.dueSoon.length}
+          accent="attention"
+        >
           {groups.dueSoon.map((a) => (
             <AssignmentCard key={a.id} assignment={a} />
           ))}
@@ -68,7 +78,11 @@ export const AssignmentList = ({ assignments }: AssignmentListProps) => {
       )}
 
       {groups.upcoming.length > 0 && (
-        <Section title="Upcoming" count={groups.upcoming.length} accent="brand">
+        <Section
+          title={t('assignments.sectionUpcoming')}
+          count={groups.upcoming.length}
+          accent="brand"
+        >
           {groups.upcoming.map((a) => (
             <AssignmentCard key={a.id} assignment={a} />
           ))}
@@ -76,7 +90,11 @@ export const AssignmentList = ({ assignments }: AssignmentListProps) => {
       )}
 
       {groups.completed.length > 0 && (
-        <Section title="Completed" count={groups.completed.length} accent="success">
+        <Section
+          title={t('assignments.sectionCompleted')}
+          count={groups.completed.length}
+          accent="success"
+        >
           {groups.completed.map((a) => (
             <AssignmentCard key={a.id} assignment={a} />
           ))}

--- a/frontend_modern/src/features/student/DueForReviewPanel.test.tsx
+++ b/frontend_modern/src/features/student/DueForReviewPanel.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { I18nProvider, type Locale } from '@/shared/i18n';
 import { DueForReviewPanel } from './DueForReviewPanel';
 import type { SRSEntry } from './useSpacedRepetitionDue';
 
@@ -45,13 +46,15 @@ function mockDueEntries(entries: SRSEntry[] | Error) {
   });
 }
 
-function renderPanel() {
+function renderPanel(locale: Locale = 'en') {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter>
-        <DueForReviewPanel />
-      </MemoryRouter>
+      <I18nProvider initialLocale={locale}>
+        <MemoryRouter>
+          <DueForReviewPanel />
+        </MemoryRouter>
+      </I18nProvider>
     </QueryClientProvider>
   );
 }
@@ -93,6 +96,18 @@ describe('DueForReviewPanel', () => {
       expect(screen.getByText(/finish a few assignments/i)).toBeDefined()
     );
     expect(screen.getByText('Due for Review')).toBeDefined();
+  });
+
+  it('renders the panel chrome in Hindi when the locale is hi', async () => {
+    mockDueEntries([ENTRY]);
+    renderPanel('hi');
+
+    // Hindi dictionary loads via dynamic import — wait for the swap.
+    await waitFor(() => expect(screen.getByText('दोहराव के लिए तैयार')).toBeDefined());
+    expect(screen.getByText('आज करना है')).toBeDefined();
+    expect(screen.getByRole('link', { name: 'अभ्यास' })).toBeDefined();
+    // Authored content stays as authored (initiative principle 1).
+    expect(screen.getByText('Polynomials')).toBeDefined();
   });
 
   it('hides the panel entirely when the fetch fails', async () => {

--- a/frontend_modern/src/features/student/DueForReviewPanel.tsx
+++ b/frontend_modern/src/features/student/DueForReviewPanel.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { Skeleton } from '@/shared/ui';
+import { useT, type Translate } from '@/shared/i18n';
 import { useSpacedRepetitionDue } from './useSpacedRepetitionDue';
 import type { SRSEntry } from './useSpacedRepetitionDue';
 
@@ -14,21 +15,24 @@ const getUrgency = (nextReviewDate: string): Urgency => {
   return 'soon';
 };
 
-const URGENCY_STYLES: Record<Urgency, { dot: string; text: string; label: string; bg: string }> = {
-  overdue: { dot: 'bg-rose-500', text: 'text-rose-700', label: 'Overdue', bg: 'bg-rose-50' },
-  today: { dot: 'bg-amber-500', text: 'text-amber-800', label: 'Due today', bg: 'bg-amber-50' },
-  soon: { dot: 'bg-brand-400', text: 'text-brand-700', label: 'Coming up', bg: '' },
+const URGENCY_STYLES: Record<Urgency, { dot: string; text: string; bg: string }> = {
+  overdue: { dot: 'bg-rose-500', text: 'text-rose-700', bg: 'bg-rose-50' },
+  today: { dot: 'bg-amber-500', text: 'text-amber-800', bg: 'bg-amber-50' },
+  soon: { dot: 'bg-brand-400', text: 'text-brand-700', bg: '' },
 };
 
+const dueLabelFor = (t: Translate, urgency: Urgency, nextReviewDate: string): string =>
+  urgency === 'overdue'
+    ? t('dueReview.overdueSince', { date: nextReviewDate })
+    : urgency === 'today'
+      ? t('dueReview.statusToday')
+      : t('dueReview.dueOn', { date: nextReviewDate });
+
 const SRSRow = ({ entry }: { entry: SRSEntry }) => {
+  const t = useT();
   const urgency = getUrgency(entry.next_review_date);
   const style = URGENCY_STYLES[urgency];
-  const dueLabel =
-    urgency === 'overdue'
-      ? `Overdue since ${entry.next_review_date}`
-      : urgency === 'today'
-        ? 'Due today'
-        : `Due ${entry.next_review_date}`;
+  const dueLabel = dueLabelFor(t, urgency, entry.next_review_date);
 
   return (
     <div className={`flex items-center justify-between py-2.5 px-3 rounded-lg ${style.bg}`}>
@@ -41,14 +45,18 @@ const SRSRow = ({ entry }: { entry: SRSEntry }) => {
       </div>
       <div className="flex items-center gap-3 shrink-0 ml-3">
         <div className="text-right hidden sm:block">
-          <p className="text-xs text-ink-500">every {entry.interval_days}d</p>
-          <p className="text-xs text-ink-400">{entry.repetitions}× reviewed</p>
+          <p className="text-xs text-ink-500">
+            {t('dueReview.interval', { days: entry.interval_days })}
+          </p>
+          <p className="text-xs text-ink-400">
+            {t('dueReview.reviewedTimes', { count: entry.repetitions })}
+          </p>
         </div>
         <Link
           to={`/student/srs-drill/${entry.id}`}
           className="text-xs font-semibold text-brand-700 hover:text-white border border-brand-200 rounded-full px-3 py-1 hover:bg-brand-600 hover:border-brand-600 transition-colors motion-reduce:transition-none focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2"
         >
-          Practice
+          {t('common.practice')}
         </Link>
       </div>
     </div>
@@ -56,6 +64,7 @@ const SRSRow = ({ entry }: { entry: SRSEntry }) => {
 };
 
 export const DueForReviewPanel = () => {
+  const t = useT();
   const { data: entries, isLoading, isError } = useSpacedRepetitionDue();
 
   // On a failed fetch the panel steps aside rather than stacking another error
@@ -88,10 +97,10 @@ export const DueForReviewPanel = () => {
   if (!entries || entries.length === 0) {
     return (
       <div className="os-card p-5 mt-6">
-        <h2 className="text-base font-display font-semibold text-ink-900">Due for Review</h2>
-        <p className="text-sm text-ink-500 mt-1">
-          Nothing due yet — finish a few assignments and your review schedule will appear here.
-        </p>
+        <h2 className="text-base font-display font-semibold text-ink-900">
+          {t('dueReview.title')}
+        </h2>
+        <p className="text-sm text-ink-500 mt-1">{t('dueReview.emptyDescription')}</p>
       </div>
     );
   }
@@ -105,15 +114,17 @@ export const DueForReviewPanel = () => {
     <div className="os-card border-amber-200 p-5 mt-6">
       <div className="flex items-center justify-between mb-3">
         <h2 className="text-base font-display font-semibold text-ink-900">
-          Due for Review
+          {t('dueReview.title')}
           {overdueCount > 0 && (
             <span className="ml-2 text-xs font-semibold bg-rose-100 text-rose-800 px-2 py-0.5 rounded-full">
-              {overdueCount} overdue
+              {t('dueReview.overdueCount', { count: overdueCount })}
             </span>
           )}
         </h2>
         <span className="text-xs text-ink-400">
-          {entries.length} topic{entries.length !== 1 ? 's' : ''}
+          {t(entries.length === 1 ? 'common.topicsOne' : 'common.topicsMany', {
+            count: entries.length,
+          })}
         </span>
       </div>
       <div className="space-y-1.5">
@@ -122,12 +133,12 @@ export const DueForReviewPanel = () => {
         ))}
         {entries.length > 5 && (
           <p className="text-xs text-center text-ink-400 pt-1">
-            +{entries.length - 5} more topics
+            {t('dueReview.moreTopics', { count: entries.length - 5 })}
           </p>
         )}
       </div>
       <p className="text-xs text-ink-400 mt-3 pt-2 border-t border-ink-100">
-        Practice your assignments to push review dates forward.
+        {t('dueReview.footer')}
       </p>
     </div>
   );

--- a/frontend_modern/src/features/student/RecommendationsPanel.test.tsx
+++ b/frontend_modern/src/features/student/RecommendationsPanel.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { I18nProvider, type Locale } from '@/shared/i18n';
 import { RecommendationsPanel } from './RecommendationsPanel';
 import type { ContentRecommendation } from './useRecommendations';
 import type { PracticePlan } from './usePracticePlan';
@@ -67,13 +68,15 @@ function mockEndpoints({
   });
 }
 
-function renderPanel() {
+function renderPanel(locale: Locale = 'en') {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter>
-        <RecommendationsPanel />
-      </MemoryRouter>
+      <I18nProvider initialLocale={locale}>
+        <MemoryRouter>
+          <RecommendationsPanel />
+        </MemoryRouter>
+      </I18nProvider>
     </QueryClientProvider>
   );
 }
@@ -131,6 +134,18 @@ describe('RecommendationsPanel', () => {
       expect(screen.getByText(/answer a few assignment questions/i)).toBeDefined()
     );
     expect(screen.getByText('What to Practice Next')).toBeDefined();
+  });
+
+  it('renders the panel chrome in Hindi when the locale is hi', async () => {
+    mockEndpoints({ recommendations: [REC], plan: PLAN });
+    renderPanel('hi');
+
+    // Hindi dictionary loads via dynamic import — wait for the swap.
+    await waitFor(() => expect(screen.getByText('आगे किसका अभ्यास करें')).toBeDefined());
+    expect(screen.getByText('आपका स्कोर')).toBeDefined();
+    expect(screen.getByRole('link', { name: 'अभ्यास' })).toBeDefined();
+    // Authored content (chapter names) stays as authored.
+    expect(screen.getByText('Fractions')).toBeDefined();
   });
 
   it('hides the panel entirely when the fetch fails', async () => {

--- a/frontend_modern/src/features/student/RecommendationsPanel.tsx
+++ b/frontend_modern/src/features/student/RecommendationsPanel.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { Badge, Skeleton } from '@/shared/ui';
+import { useT } from '@/shared/i18n';
 import { useRecommendations } from './useRecommendations';
 import { usePracticePlan } from './usePracticePlan';
 
@@ -12,6 +13,7 @@ const PRIORITY_TONE: Record<number, 'urgent' | 'attention' | 'brand' | 'neutral'
 };
 
 export const RecommendationsPanel = () => {
+  const t = useT();
   const { data: recommendations, isLoading, isError } = useRecommendations();
   const { data: plan } = usePracticePlan();
 
@@ -46,12 +48,9 @@ export const RecommendationsPanel = () => {
     return (
       <div className="os-card p-5">
         <h2 className="text-base font-display font-semibold text-ink-900">
-          What to Practice Next
+          {t('recommendations.title')}
         </h2>
-        <p className="text-sm text-ink-500 mt-1">
-          No suggestions yet — answer a few assignment questions and we&apos;ll point you to the
-          chapters worth revisiting.
-        </p>
+        <p className="text-sm text-ink-500 mt-1">{t('recommendations.emptyDescription')}</p>
       </div>
     );
   }
@@ -59,10 +58,12 @@ export const RecommendationsPanel = () => {
   return (
     <div className="os-card border-brand-200 p-5">
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-base font-display font-semibold text-ink-900">What to Practice Next</h2>
+        <h2 className="text-base font-display font-semibold text-ink-900">
+          {t('recommendations.title')}
+        </h2>
         {plan && (
           <span className="text-xs text-ink-500">
-            Today&apos;s plan: ~{plan.estimated_minutes} min
+            {t('recommendations.todaysPlan', { minutes: plan.estimated_minutes })}
           </span>
         )}
       </div>
@@ -87,13 +88,13 @@ export const RecommendationsPanel = () => {
                 <p className="text-sm font-semibold text-ink-700">
                   {Math.round(rec.score_snapshot * 100)}%
                 </p>
-                <p className="text-xs text-ink-400">your score</p>
+                <p className="text-xs text-ink-400">{t('recommendations.yourScore')}</p>
               </div>
               <Link
                 to={`/student/browse/chapter/${rec.chapter}`}
                 className="text-xs font-semibold text-brand-700 hover:text-white border border-brand-200 rounded-full px-3 py-1 hover:bg-brand-600 hover:border-brand-600 transition-colors motion-reduce:transition-none focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2"
               >
-                Practice
+                {t('common.practice')}
               </Link>
             </div>
           </div>
@@ -103,21 +104,25 @@ export const RecommendationsPanel = () => {
       {plan && (
         <div className="mt-4 pt-3 border-t border-ink-100 flex items-center justify-between">
           <span className="text-xs text-ink-500">
-            {plan.recommendations.length} topic{plan.recommendations.length !== 1 ? 's' : ''} in
-            today&apos;s plan
+            {t(
+              plan.recommendations.length === 1
+                ? 'recommendations.planTopicsOne'
+                : 'recommendations.planTopicsMany',
+              { count: plan.recommendations.length },
+            )}
           </span>
           <div className="flex items-center gap-3">
             <Link
               to="/student/proficiency"
               className="text-xs font-medium text-brand-700 hover:text-brand-800 focus:outline-none focus-visible:underline"
             >
-              View progress →
+              {t('recommendations.viewProgress')}
             </Link>
             <Link
               to="/student/learning-path"
               className="text-xs font-medium text-brand-700 hover:text-brand-800 focus:outline-none focus-visible:underline"
             >
-              View learning path →
+              {t('recommendations.viewLearningPath')}
             </Link>
           </div>
         </div>

--- a/frontend_modern/src/features/student/StreakBadge.tsx
+++ b/frontend_modern/src/features/student/StreakBadge.tsx
@@ -1,8 +1,10 @@
+import { useT } from '@/shared/i18n';
+import type { LocaleKey } from '@/shared/i18n';
 import type { MilestoneTier } from './useStreak';
 
 interface TierConfig {
   icon: string;
-  label: string;
+  labelKey: LocaleKey;
   bgColor: string;
   borderColor: string;
   textColor: string;
@@ -12,28 +14,28 @@ interface TierConfig {
 const TIER_CONFIG: Record<Exclude<MilestoneTier, 'none'>, TierConfig> = {
   starter: {
     icon: '🔥',
-    label: 'On Fire',
+    labelKey: 'streak.tierStarter',
     bgColor: 'bg-brand-50',
     borderColor: 'border-brand-200',
     textColor: 'text-brand-700',
   },
   week: {
     icon: '⚡',
-    label: 'Week Warrior',
+    labelKey: 'streak.tierWeek',
     bgColor: 'bg-amber-50',
     borderColor: 'border-amber-200',
     textColor: 'text-amber-800',
   },
   month: {
     icon: '🌟',
-    label: 'Month Master',
+    labelKey: 'streak.tierMonth',
     bgColor: 'bg-amber-100',
     borderColor: 'border-amber-300',
     textColor: 'text-amber-900',
   },
   champion: {
     icon: '👑',
-    label: 'Champion',
+    labelKey: 'streak.tierChampion',
     bgColor: 'bg-brand-100',
     borderColor: 'border-brand-300',
     textColor: 'text-brand-800',
@@ -48,11 +50,13 @@ interface StreakBadgeProps {
 }
 
 export const StreakBadge = ({ streak, tier, longestStreak, graceUsed }: StreakBadgeProps) => {
+  const t = useT();
+
   if (streak === 0 || tier === 'none') {
     return (
       <div className="inline-flex items-center gap-1.5 bg-ink-50 border border-ink-200 text-ink-500 text-xs font-semibold px-3 py-1 rounded-full mt-2">
         <span>🔥</span>
-        <span>{streak}-day streak</span>
+        <span>{t('streak.days', { count: streak })}</span>
       </div>
     );
   }
@@ -64,17 +68,14 @@ export const StreakBadge = ({ streak, tier, longestStreak, graceUsed }: StreakBa
       className={`inline-flex items-center gap-1.5 ${config.bgColor} border ${config.borderColor} ${config.textColor} text-xs font-semibold px-3 py-1 rounded-full mt-2`}
     >
       <span>{config.icon}</span>
-      <span>{streak}-day streak</span>
-      <span className="font-normal opacity-70">· {config.label}</span>
+      <span>{t('streak.days', { count: streak })}</span>
+      <span className="font-normal opacity-70">· {t(config.labelKey)}</span>
       {longestStreak > streak && (
-        <span className="font-normal opacity-60">· best: {longestStreak}</span>
+        <span className="font-normal opacity-60">· {t('streak.best', { count: longestStreak })}</span>
       )}
       {graceUsed && (
-        <span
-          className="font-normal opacity-60"
-          title="Grace day used — streak preserved through one missed day"
-        >
-          · grace ✓
+        <span className="font-normal opacity-60" title={t('streak.graceTitle')}>
+          · {t('streak.grace')}
         </span>
       )}
     </div>

--- a/frontend_modern/src/features/student/StudentDashboard.tsx
+++ b/frontend_modern/src/features/student/StudentDashboard.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { Button, EmptyState } from '@/shared/ui';
+import { useT } from '@/shared/i18n';
 import { AssignmentList } from './AssignmentList';
 import { useAssignments } from './useAssignments';
 import { useStreak } from './useStreak';
@@ -14,10 +15,13 @@ import { UserRole } from '@/types/index';
 export const StudentDashboard = () => {
   const navigate = useNavigate();
   const { user } = useAuth();
+  const t = useT();
   const { data: assignments, isLoading, isError } = useAssignments();
   const { data: streak } = useStreak();
 
-  const greeting = user?.first_name ? `Hi, ${user.first_name}!` : 'Your dashboard';
+  const greeting = user?.first_name
+    ? t('dashboard.greeting', { name: user.first_name })
+    : t('dashboard.title');
 
   return (
     <div>
@@ -35,14 +39,14 @@ export const StudentDashboard = () => {
               />
             </div>
           ) : (
-            <p className="mt-1 text-sm text-ink-500 sm:text-base">Here are your assignments.</p>
+            <p className="mt-1 text-sm text-ink-500 sm:text-base">{t('dashboard.subtitle')}</p>
           )}
         </div>
         <button
           onClick={() => navigate('/student/proficiency')}
           className="shrink-0 whitespace-nowrap text-sm font-semibold text-brand-700 hover:text-brand-800"
         >
-          My progress →
+          {t('dashboard.myProgress')}
         </button>
       </div>
 
@@ -61,16 +65,18 @@ export const StudentDashboard = () => {
           className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700"
           role="alert"
         >
-          Failed to load assignments. Please refresh the page.
+          {t('dashboard.loadError')}
         </div>
       )}
 
       {assignments && assignments.length === 0 && user?.role === UserRole.OPEN_STUDENT && (
         <EmptyState
-          title="You're not enrolled in a classroom yet"
-          description="Browse the shared question bank to start practising on your own."
+          title={t('dashboard.openEmptyTitle')}
+          description={t('dashboard.openEmptyDescription')}
           action={
-            <Button onClick={() => navigate('/student/browse')}>Browse subjects →</Button>
+            <Button onClick={() => navigate('/student/browse')}>
+              {t('dashboard.browseSubjects')}
+            </Button>
           }
         />
       )}

--- a/frontend_modern/src/shared/i18n/dateFnsLocale.ts
+++ b/frontend_modern/src/shared/i18n/dateFnsLocale.ts
@@ -1,0 +1,15 @@
+import { hi as hiDateLocale } from 'date-fns/locale';
+import type { Locale as DateFnsLocale } from 'date-fns';
+import type { Locale } from './i18nContext';
+
+/**
+ * date-fns locale for relative-time strings ("3 दिन में" instead of
+ * "in 3 days") when the UI is in Hindi. `undefined` keeps date-fns's
+ * built-in English default.
+ *
+ * Deliberately NOT re-exported from the i18n barrel: the barrel is imported
+ * by App (the entry chunk) and the Hindi date locale should only ship inside
+ * the lazy page chunks that format dates. Import this module directly.
+ */
+export const dateFnsLocaleFor = (locale: Locale): DateFnsLocale | undefined =>
+  locale === 'hi' ? hiDateLocale : undefined;

--- a/frontend_modern/src/shared/i18n/locales/en.ts
+++ b/frontend_modern/src/shared/i18n/locales/en.ts
@@ -12,6 +12,10 @@ export const en = {
   // ── Common / switcher ────────────────────────────────────────────────
   'common.language': 'Language',
   'common.languageSwitchTo': 'Switch language to {language}',
+  'common.cancel': 'Cancel',
+  'common.practice': 'Practice',
+  'common.topicsOne': '{count} topic',
+  'common.topicsMany': '{count} topics',
 
   // ── Auth hero (chalkboard panel, shared by login + register) ─────────
   'auth.heroHeadline': 'Unlock learning, one question at a time.',
@@ -33,6 +37,89 @@ export const en = {
   'login.registerLink': 'Register',
   'login.schoolQuestion': 'Are you a school?',
   'login.enquireLink': 'Enquire about OpenShiksha',
+
+  // ── Student dashboard ────────────────────────────────────────────────
+  'dashboard.greeting': 'Hi, {name}!',
+  'dashboard.title': 'Your dashboard',
+  'dashboard.subtitle': 'Here are your assignments.',
+  'dashboard.myProgress': 'My progress →',
+  'dashboard.loadError': 'Failed to load assignments. Please refresh the page.',
+  'dashboard.openEmptyTitle': "You're not enrolled in a classroom yet",
+  'dashboard.openEmptyDescription':
+    'Browse the shared question bank to start practising on your own.',
+  'dashboard.browseSubjects': 'Browse subjects →',
+
+  // ── Assignment list (sections + empty state) ─────────────────────────
+  'assignments.emptyTitle': 'No assignments yet',
+  'assignments.emptyDescription': 'Your teacher will assign some soon. Check back later!',
+  'assignments.sectionOverdue': 'Overdue',
+  'assignments.sectionDueSoon': 'Due Soon',
+  'assignments.sectionUpcoming': 'Upcoming',
+  'assignments.sectionCompleted': 'Completed',
+
+  // ── Assignment card ──────────────────────────────────────────────────
+  'assignment.overdueBy': 'Overdue by {distance}',
+  'assignment.dueIn': 'Due {distance}',
+  'assignment.submittedAgo': 'Submitted {distance}',
+  'assignment.submitted': 'Submitted',
+  'assignment.remedialBadge': 'Remedial Practice',
+  'assignment.progress': 'Progress',
+  'assignment.ctaReview': 'Review',
+  'assignment.ctaContinue': 'Continue',
+  'assignment.ctaStart': 'Start',
+
+  // ── Assignment detail (work + submit flow) ───────────────────────────
+  'assignmentDetail.back': 'Back to assignments',
+  'assignmentDetail.answeredCount': '{answered} of {total} answered',
+  'assignmentDetail.submittedNice': 'Assignment submitted — nice work!',
+  'assignmentDetail.submittedTitle': 'Submitted',
+  'assignmentDetail.grading': 'Grading in progress…',
+  'assignmentDetail.notFoundTitle': 'Assignment not found',
+  'assignmentDetail.notFoundDescription': "It may have been removed or you don't have access.",
+  'assignmentDetail.backToDashboard': 'Back to dashboard',
+  'assignmentDetail.noQuestions': 'No questions in this assignment',
+  'assignmentDetail.submit': 'Submit assignment',
+  'assignmentDetail.confirmTitle': 'Submit assignment?',
+  'assignmentDetail.confirmBody':
+    'You have answered {answered} of {total} questions. You cannot change your answers after submitting.',
+  'assignmentDetail.confirmSubmit': 'Submit',
+  'assignmentDetail.submitting': 'Submitting…',
+
+  // ── Due for Review panel (SRS) ───────────────────────────────────────
+  'dueReview.title': 'Due for Review',
+  'dueReview.overdueCount': '{count} overdue',
+  'dueReview.statusOverdue': 'Overdue',
+  'dueReview.statusToday': 'Due today',
+  'dueReview.statusSoon': 'Coming up',
+  'dueReview.overdueSince': 'Overdue since {date}',
+  'dueReview.dueOn': 'Due {date}',
+  'dueReview.interval': 'every {days}d',
+  'dueReview.reviewedTimes': '{count}× reviewed',
+  'dueReview.moreTopics': '+{count} more topics',
+  'dueReview.emptyDescription':
+    'Nothing due yet — finish a few assignments and your review schedule will appear here.',
+  'dueReview.footer': 'Practice your assignments to push review dates forward.',
+
+  // ── Recommendations panel ────────────────────────────────────────────
+  'recommendations.title': 'What to Practice Next',
+  'recommendations.todaysPlan': "Today's plan: ~{minutes} min",
+  'recommendations.yourScore': 'your score',
+  'recommendations.planTopicsOne': '{count} topic in today’s plan',
+  'recommendations.planTopicsMany': '{count} topics in today’s plan',
+  'recommendations.viewProgress': 'View progress →',
+  'recommendations.viewLearningPath': 'View learning path →',
+  'recommendations.emptyDescription':
+    "No suggestions yet — answer a few assignment questions and we'll point you to the chapters worth revisiting.",
+
+  // ── Streak badge ─────────────────────────────────────────────────────
+  'streak.days': '{count}-day streak',
+  'streak.tierStarter': 'On Fire',
+  'streak.tierWeek': 'Week Warrior',
+  'streak.tierMonth': 'Month Master',
+  'streak.tierChampion': 'Champion',
+  'streak.best': 'best: {count}',
+  'streak.grace': 'grace ✓',
+  'streak.graceTitle': 'Grace day used — streak preserved through one missed day',
 } as const;
 
 /** Every valid i18n key. Derived from the English dictionary. */

--- a/frontend_modern/src/shared/i18n/locales/hi.ts
+++ b/frontend_modern/src/shared/i18n/locales/hi.ts
@@ -14,6 +14,10 @@ export const hi: LocaleDict = {
   // ── Common / switcher ────────────────────────────────────────────────
   'common.language': 'भाषा',
   'common.languageSwitchTo': 'भाषा बदलें: {language}',
+  'common.cancel': 'रद्द करें',
+  'common.practice': 'अभ्यास',
+  'common.topicsOne': '{count} विषय',
+  'common.topicsMany': '{count} विषय',
 
   // ── Auth hero (chalkboard panel, shared by login + register) ─────────
   'auth.heroHeadline': 'सीखने की कुंजी, एक-एक सवाल से।',
@@ -35,4 +39,87 @@ export const hi: LocaleDict = {
   'login.registerLink': 'रजिस्टर करें',
   'login.schoolQuestion': 'क्या आप एक स्कूल हैं?',
   'login.enquireLink': 'OpenShiksha के बारे में पूछें',
+
+  // ── Student dashboard ────────────────────────────────────────────────
+  'dashboard.greeting': 'नमस्ते, {name}!',
+  'dashboard.title': 'आपका डैशबोर्ड',
+  'dashboard.subtitle': 'ये रहे आपके असाइनमेंट।',
+  'dashboard.myProgress': 'मेरी प्रगति →',
+  'dashboard.loadError': 'असाइनमेंट लोड नहीं हो पाए। कृपया पेज रीफ़्रेश करें।',
+  'dashboard.openEmptyTitle': 'आप अभी किसी क्लासरूम में नहीं हैं',
+  'dashboard.openEmptyDescription': 'अपने आप अभ्यास शुरू करने के लिए साझा प्रश्न बैंक देखें।',
+  'dashboard.browseSubjects': 'विषय देखें →',
+
+  // ── Assignment list (sections + empty state) ─────────────────────────
+  'assignments.emptyTitle': 'अभी कोई असाइनमेंट नहीं',
+  'assignments.emptyDescription': 'आपके शिक्षक जल्द ही असाइनमेंट देंगे। बाद में फिर देखें!',
+  'assignments.sectionOverdue': 'समय निकल गया',
+  'assignments.sectionDueSoon': 'जल्द जमा करें',
+  'assignments.sectionUpcoming': 'आने वाले',
+  'assignments.sectionCompleted': 'पूरे हो गए',
+
+  // ── Assignment card ──────────────────────────────────────────────────
+  'assignment.overdueBy': '{distance} देर हो चुकी',
+  'assignment.dueIn': 'अंतिम तिथि: {distance}',
+  'assignment.submittedAgo': '{distance} जमा किया',
+  'assignment.submitted': 'जमा हो गया',
+  'assignment.remedialBadge': 'सुधार अभ्यास',
+  'assignment.progress': 'प्रगति',
+  'assignment.ctaReview': 'देखें',
+  'assignment.ctaContinue': 'जारी रखें',
+  'assignment.ctaStart': 'शुरू करें',
+
+  // ── Assignment detail (work + submit flow) ───────────────────────────
+  'assignmentDetail.back': 'असाइनमेंट पर वापस जाएँ',
+  'assignmentDetail.answeredCount': '{total} में से {answered} उत्तर दिए',
+  'assignmentDetail.submittedNice': 'असाइनमेंट जमा हो गया — शाबाश!',
+  'assignmentDetail.submittedTitle': 'जमा हो गया',
+  'assignmentDetail.grading': 'जाँच चल रही है…',
+  'assignmentDetail.notFoundTitle': 'असाइनमेंट नहीं मिला',
+  'assignmentDetail.notFoundDescription':
+    'यह हटाया जा चुका हो सकता है या आपके पास इसकी अनुमति नहीं है।',
+  'assignmentDetail.backToDashboard': 'डैशबोर्ड पर वापस जाएँ',
+  'assignmentDetail.noQuestions': 'इस असाइनमेंट में कोई प्रश्न नहीं है',
+  'assignmentDetail.submit': 'असाइनमेंट जमा करें',
+  'assignmentDetail.confirmTitle': 'असाइनमेंट जमा करें?',
+  'assignmentDetail.confirmBody':
+    'आपने {total} में से {answered} प्रश्नों के उत्तर दिए हैं। जमा करने के बाद आप उत्तर नहीं बदल पाएँगे।',
+  'assignmentDetail.confirmSubmit': 'जमा करें',
+  'assignmentDetail.submitting': 'जमा हो रहा है…',
+
+  // ── Due for Review panel (SRS) ───────────────────────────────────────
+  'dueReview.title': 'दोहराव के लिए तैयार',
+  'dueReview.overdueCount': '{count} का समय निकल गया',
+  'dueReview.statusOverdue': 'समय निकल गया',
+  'dueReview.statusToday': 'आज करना है',
+  'dueReview.statusSoon': 'आगे आने वाला',
+  'dueReview.overdueSince': '{date} से बाकी',
+  'dueReview.dueOn': 'अंतिम तिथि {date}',
+  'dueReview.interval': 'हर {days} दिन',
+  'dueReview.reviewedTimes': '{count} बार दोहराया',
+  'dueReview.moreTopics': '+{count} और विषय',
+  'dueReview.emptyDescription':
+    'अभी कुछ बाकी नहीं — कुछ असाइनमेंट पूरे करें, आपका दोहराव कार्यक्रम यहाँ दिखेगा।',
+  'dueReview.footer': 'दोहराव की तिथियाँ आगे बढ़ाने के लिए अपने असाइनमेंट का अभ्यास करें।',
+
+  // ── Recommendations panel ────────────────────────────────────────────
+  'recommendations.title': 'आगे किसका अभ्यास करें',
+  'recommendations.todaysPlan': 'आज की योजना: ~{minutes} मिनट',
+  'recommendations.yourScore': 'आपका स्कोर',
+  'recommendations.planTopicsOne': 'आज की योजना में {count} विषय',
+  'recommendations.planTopicsMany': 'आज की योजना में {count} विषय',
+  'recommendations.viewProgress': 'प्रगति देखें →',
+  'recommendations.viewLearningPath': 'लर्निंग पाथ देखें →',
+  'recommendations.emptyDescription':
+    'अभी कोई सुझाव नहीं — कुछ असाइनमेंट प्रश्नों के उत्तर दें, हम आपको दोहराने लायक अध्याय बताएँगे।',
+
+  // ── Streak badge ─────────────────────────────────────────────────────
+  'streak.days': '{count} दिन की स्ट्रीक',
+  'streak.tierStarter': 'जोश में',
+  'streak.tierWeek': 'हफ़्ते के हीरो',
+  'streak.tierMonth': 'महीने के मास्टर',
+  'streak.tierChampion': 'चैंपियन',
+  'streak.best': 'सर्वश्रेष्ठ: {count}',
+  'streak.grace': 'ग्रेस ✓',
+  'streak.graceTitle': 'ग्रेस दिन इस्तेमाल हुआ — एक दिन छूटने पर भी स्ट्रीक बनी रही',
 };


### PR DESCRIPTION
## Classification
**Improve** — [Language Access](https://github.com/openshiksha/openshiksha/blob/modernization/docs/initiatives/2026-language-access.md) LA-3. Based on `modernization` (LA-1 #308 + LA-2 #309 already merged).

## Legacy reference
None — legacy was English-only.

## What's here
- **~60 new en/hi keys** (`dashboard.*`, `assignments.*`, `assignment.*`, `assignmentDetail.*`, `dueReview.*`, `recommendations.*`, `streak.*`). Parity stays tsc-enforced.
- **String extraction only, zero behavior change** in: `StudentDashboard`, `AssignmentList`, `AssignmentCard`, `AssignmentDetailPage`, `DueForReviewPanel`, `RecommendationsPanel`, `StreakBadge`.
- **Localized relative dates**: `shared/i18n/dateFnsLocale.ts` maps the locale to date-fns `hi` ("3 दिन में", not "in 3 days"). Kept out of the i18n barrel so it only ships in lazy student chunks — entry stays 100.45 kB (budget 160).
- Plurals as explicit one/many keys; server display strings (`priority_display` etc.) untouched (server localization = LA-7).
- **Chrome only**: question text, titles, chapter/subject names render as authored (principle 1) — asserted in tests.

## Tests
- +3 renders-in-Hindi cases (AssignmentList, DueForReviewPanel, RecommendationsPanel) wrapped in `I18nProvider initialLocale='hi'`; existing skeleton/error/empty suites untouched.
- **54 files / 345 tests green**; lint + tsc clean; build + bundle budget green.

## Translation review (new Hindi strings, selection)
| Key | Hindi |
|---|---|
| dashboard.greeting | नमस्ते, {name}! |
| assignments.sectionOverdue / DueSoon / Upcoming / Completed | समय निकल गया / जल्द जमा करें / आने वाले / पूरे हो गए |
| assignment.ctaStart / Continue / Review | शुरू करें / जारी रखें / देखें |
| assignment.dueIn | अंतिम तिथि: {distance} |
| assignmentDetail.submit / confirmBody | असाइनमेंट जमा करें / आपने {total} में से {answered} प्रश्नों के उत्तर दिए हैं… |
| dueReview.title | दोहराव के लिए तैयार |
| recommendations.title | आगे किसका अभ्यास करें |
| streak.days | {count} दिन की स्ट्रीक |

Full list in [docs/changes/2026-06-11-la3-student-chrome-hindi.md](https://github.com/openshiksha/openshiksha/blob/feat/2026-06-11-la3-student-chrome-hindi/docs/changes/2026-06-11-la3-student-chrome-hindi.md) + locale files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)