### PR TITLE
feat(i18n): LA-5b — parent dashboard chrome in Hindi; batch bookkeeping

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,20 +4,24 @@
 > The per-day `docs/daily-plans/*.md` files are point-in-time snapshots; this
 > file is the living tracker. Update it whenever a PR merges.
 
-**Last updated:** 2026-05-30 (after class misconception insights branch)
+**Last updated:** 2026-06-11 (Language Access batch LA-1..5 — all four prior "Remaining" items now shipped)
 
 ---
 
 ## 🔜 Remaining (what's left)
 
-In priority order. Nothing below is started unless noted.
+The headline backlog is **clear** — every prior "Remaining" item has shipped
+(see Completed). Ongoing work is tracked on the
+[initiatives board](initiatives/STATUS.md); the active initiative is
+**[Language Access (i18n en/हिंदी)](initiatives/2026-language-access.md)**,
+whose next increments are LA-6 (teacher chrome), LA-7 (localized emails),
+LA-8 (`Intl` dates/numbers), LA-9 (third-language pilot).
 
-| # | Task | Type | Notes |
-|---|------|------|-------|
-| 1 | **P8 — operational bulk Cabinet import run** | Ops | The importer (`import_cabinet_questions`) shipped in PR #100. This is the *operational* run: clone `openshiksha-cabinet`, run the importer with a mapping file against real content. |
-| 2 | **Phase 2 — UI rebuild** | Frontend | Design-system pass to Linear/Vercel-quality polish; bottom tab bar on mobile. Large, follows the feature build-out. |
-| 3 | **Teacher AI Assistant (broader)** | AI | Weekly class reports (#95), class misconception insights, auto-assignment drafts, and open-ended/free-text grading (this PR) shipped. Remaining: teacher-facing dashboard cards surfacing these (cluster API, open-grade review queue). Future. |
-| 4 | **i18n toggle (`en` / `hi`) on parent insights** | Frontend | The parent-summary API already accepts `language`; expose a header toggle once a global language switcher lands. |
+Previously listed, now done:
+- ~~P8 — operational bulk Cabinet import run~~ → Cabinet Data Fidelity initiative closed 2026-06-04; `audit_cabinet_fidelity --strict` green on the real 646-question corpus.
+- ~~Phase 2 — UI rebuild~~ → V2 "Chalk & Unlock" design overhaul closed 2026-06-04 (M1–M7, PRs #188–#207).
+- ~~Teacher AI Assistant dashboard cards~~ → AI Surface Activation closed 2026-06-11 (ASA-1..9, #285–#303): misconception clusters, AI-drafted assignments, open-response grading queue all surfaced.
+- ~~i18n toggle (en/hi) on parent insights~~ → Language Access LA-1..5 (2026-06-11): global EN|हिं switcher, durable `preferred_language`, student/parent/public chrome in Hindi, AI explanations + parent summaries generate in the reader's language.
 
 ---
 

--- a/docs/changes/2026-06-11-la5b-parent-chrome-docs.md
+++ b/docs/changes/2026-06-11-la5b-parent-chrome-docs.md
@@ -1,0 +1,48 @@
+# LA-5b — parent dashboard chrome in Hindi + initiative bookkeeping
+
+**Date:** 2026-06-11
+**Classification:** Improve
+**Initiative:** [Language Access — i18n en/हिंदी](../initiatives/2026-language-access.md) (LA-5, second half — closes the batch)
+
+## Summary
+
+The parent dashboard (tabs, headings, status badges, empty states, date
+labels) renders in Hindi — completing the parent journey: dashboard chrome
+(this PR) + AI weekly summary in Hindi (LA-4). Also lands the batch
+bookkeeping: initiative ledger rows for LA-1..5, backlog statuses, glossary
+growth (~11 terms encountered this batch), STATUS.md headline, and a ROADMAP
+refresh that ticks all four stale "Remaining" items (everything previously
+listed has shipped).
+
+## Legacy files referenced
+
+None — legacy was English-only.
+
+## What changed and why
+
+- **`ParentDashboard.tsx`** — 21 new `parent.*` keys: page heading, child
+  picker (grade chip), overview header, Progress/Assignments tabs, status
+  badges (Submitted / Overdue / Pending), proficiency "questions practised"
+  counts (one/many), empty states, due/overdue date lines. Dates format with
+  `hi-IN` when the locale is Hindi. Authored/server content (subject names,
+  chapter tags, problem-set titles) renders as authored (principle 1).
+- **Docs:** initiative doc (ledger + backlog ✅s + glossary), STATUS.md
+  (headline + active row → next increment LA-6), ROADMAP.md (stale
+  "Remaining" items 1–4 ticked with pointers to the initiatives that closed
+  them; board now points to the initiatives STATUS as the live tracker).
+
+## Tests
+
+- New `ParentDashboard.test.tsx` (English chrome + full-Hindi chrome with
+  authored-content-stays assertion).
+- Full suite 57 files / 355 tests green; lint/tsc/build/budget green
+  (entry 104.68 kB of 160 kB).
+
+## Migration notes
+
+None (frontend + docs only).
+
+## Next steps
+
+LA-6 (teacher chrome) is the natural next batch anchor; LA-7 (localized
+emails via `preferred_language`); LA-8 (`Intl` numbers/dates).

--- a/docs/initiatives/2026-language-access.md
+++ b/docs/initiatives/2026-language-access.md
@@ -68,11 +68,11 @@ just never lets anyone ask for it.
 
 | ID | Increment | Status |
 |----|-----------|--------|
-| LA-1 | i18n foundation: `src/shared/i18n/` provider + `useT()` + en/hi locale files + navbar/drawer language switcher + `<html lang>` sync + pilot migration (auth pages) | ⬜ planned 2026-06-11 |
-| LA-2 | `User.preferred_language` + profile API + ProfilePage selector + login seeding | ⬜ planned 2026-06-11 |
-| LA-3 | Student core loop chrome in Hindi: dashboard, assignment list/detail, panels | ⬜ planned 2026-06-11 |
-| LA-4 | AI content in the reader's language: explanations + parent-summary language wiring (+ regenerate-on-language-change) | ⬜ planned 2026-06-11 |
-| LA-5 | Key-parity CI guard (Vitest), Hindi glossary, parent + registration chrome | ⬜ planned 2026-06-11 |
+| LA-1 | i18n foundation: `src/shared/i18n/` provider + `useT()` + en/hi locale files + navbar/drawer language switcher + `<html lang>` sync + pilot migration (auth pages) | ✅ 2026-06-11 [#308](https://github.com/openshiksha/openshiksha/pull/308) |
+| LA-2 | `User.preferred_language` + profile API + ProfilePage selector + login seeding | ✅ 2026-06-11 [#309](https://github.com/openshiksha/openshiksha/pull/309) |
+| LA-3 | Student core loop chrome in Hindi: dashboard, assignment list/detail, panels | ✅ 2026-06-11 [#310](https://github.com/openshiksha/openshiksha/pull/310) |
+| LA-4 | AI content in the reader's language: explanations + parent-summary language wiring (+ regenerate-on-language-change) | ✅ 2026-06-11 [#311](https://github.com/openshiksha/openshiksha/pull/311) |
+| LA-5 | Key-parity CI guard (Vitest), Hindi glossary, parent + registration chrome (+ home page, added per user request) | ✅ 2026-06-11 [#312](https://github.com/openshiksha/openshiksha/pull/312) + LA-5b |
 | LA-6 | Teacher surfaces chrome (dashboard panels, create-assignment, grading queue) | ⬜ |
 | LA-7 | Localized transactional emails (grading complete, remedial, due reminders, parent weekly) honoring `preferred_language` | ⬜ |
 | LA-8 | Number/date formatting via `Intl` keyed to locale (dates on cards, "due in X days") | ⬜ |
@@ -113,9 +113,24 @@ just never lets anyone ask for it.
 | Hint | संकेत | |
 | Explanation | व्याख्या | |
 | Teacher / Student / Parent | शिक्षक / विद्यार्थी / अभिभावक | |
+| Sign in / Log in | साइन इन करें / लॉग इन करें | transliterate — universal |
+| Username / Password | यूज़रनेम / पासवर्ड | transliterate |
+| Register / Create account | रजिस्टर करें / खाता बनाएँ | |
+| Overdue | समय निकल गया | "अतिदेय" too formal for K-12 |
+| Pending | बाकी है | |
+| Progress | प्रगति | |
+| Grace day | ग्रेस ✓ | product term, transliterate |
+| Classroom join code | क्लासरूम जॉइन कोड | transliterate — classroom English |
+| Insights | इनसाइट्स | transliterate — product term |
+| Learning path | लर्निंग पाथ | transliterate — product term |
 
 ## Progress Ledger (append-only)
 
 | Date | Increment | PR | Learning |
 |---|---|---|---|
 | 2026-06-11 | Initiative promoted; LA-1..5 planned as the first batch ([plan](../daily-plans/2026-06-11-plan.md)) | — | The backend has spoken Hindi since the explanations feature shipped, but no UI could ask for it — wire `language` params into the product the day they ship, or they sit dark like the `/ai/` groups did. |
+| 2026-06-11 | LA-1 — i18n foundation, EN\|हिं switcher, login pilot. Entry chunk 93→96.5 kB; hi dict is its own lazy chunk. | [#308](https://github.com/openshiksha/openshiksha/pull/308) | A no-provider English fallback in `useI18n` (instead of throwing) kept every existing component test wrapper-free — the migration cost stays linear in surfaces, not in test files. |
+| 2026-06-11 | LA-2 — `preferred_language` end-to-end; precedence device > profile > en; switcher PATCHes profile when authenticated. | [#309](https://github.com/openshiksha/openshiksha/pull/309) | Seeding from the profile must NOT write localStorage — otherwise the first login would mint a device override and later profile changes would never propagate. |
+| 2026-06-11 | LA-3 — student core loop chrome in Hindi (~60 keys); date-fns `hi` locale for relative dates, kept out of the entry chunk. | [#310](https://github.com/openshiksha/openshiksha/pull/310) | "3 दिन में" beats "in 3 days में" — localizing the chrome without the dates reads worse than not localizing at all; date-fns ships a tree-shakeable hi locale, no Intl machinery needed yet (LA-8). |
+| 2026-06-11 | LA-4 — explanations + parent summaries generate in the reader's language; regenerate-in-place affordance on language mismatch. | [#311](https://github.com/openshiksha/openshiksha/pull/311) | The backend already regenerated in place (`update_or_create` with `language` in defaults) — the "gap" was purely frontend. Read the task before writing backend code; two pinning tests were all the backend needed. |
+| 2026-06-11 | LA-5 — runtime parity guard (key sets + `{var}` placeholder drift); home page + all registration pages in Hindi (home added per user request); parent dashboard chrome (LA-5b). | [#312](https://github.com/openshiksha/openshiksha/pull/312) + LA-5b | The anonymous journey (home → register → login) is the highest-leverage Hindi surface: it's what a non-English-speaking parent sees before anyone can help them. |

--- a/docs/initiatives/STATUS.md
+++ b/docs/initiatives/STATUS.md
@@ -4,7 +4,18 @@
 > task advances the **top active initiative** here. See [`README.md`](README.md)
 > for how. Keep this file short - one row per initiative.
 
-**Last updated:** 2026-06-11 (evening) — **Language Access (i18n en/हिंदी)
+**Last updated:** 2026-06-11 (night) — **Language Access first batch LA-1..5
+shipped** across [#308](https://github.com/openshiksha/openshiksha/pull/308)–[#312](https://github.com/openshiksha/openshiksha/pull/312)
+(+ LA-5b): in-house i18n module + EN|हिं switcher (no i18next — perf budget
+defended, entry ~104 kB of 160), durable `User.preferred_language` with the
+device > profile > en precedence contract, the student core loop + parent
+dashboard + the whole public surface (home, login, registration) in Hindi,
+AI explanations + parent summaries generating in the reader's language
+(regenerate-in-place on language switch), and a runtime key-parity guard
+(key sets + `{var}` placeholder drift). Home page added to LA-5 scope per
+user request. Next: **LA-6** (teacher chrome), **LA-7** (localized emails).
+
+Earlier (2026-06-11 evening) — **Language Access (i18n en/हिंदी)
 promoted as the new top initiative**
 ([doc](2026-language-access.md), [plan](../daily-plans/2026-06-11-plan.md)).
 The board had no active bet after ASA closed this morning. Rationale: the
@@ -87,7 +98,7 @@ at 160 kB defends the cut.
 
 | Priority | Initiative | Status | Headline progress | Next increment |
 |:--:|---|---|---|---|
-| 1 | [Language Access — i18n en/हिंदी](2026-language-access.md) | **Active** | Promoted 2026-06-11. Backend already speaks Hindi (`language="hi"` on `/ai/explanations/` + parent summaries) but the frontend has zero i18n — no module, no switcher, no `preferred_language` on User. First batch LA-1..5 planned in [2026-06-11-plan.md](../daily-plans/2026-06-11-plan.md). | **LA-1** — i18n foundation (`src/shared/i18n/`), language switcher, auth-pages pilot |
+| 1 | [Language Access — i18n en/हिंदी](2026-language-access.md) | **Active** | **First batch LA-1..5 shipped 2026-06-11** ([#308](https://github.com/openshiksha/openshiksha/pull/308)–[#312](https://github.com/openshiksha/openshiksha/pull/312) + LA-5b): i18n module + EN\|हिं switcher, `preferred_language` end-to-end, student core loop + parent dashboard + full public surface (home/login/registration) in Hindi, AI content in the reader's language, runtime key-parity guard. Devanagari verified in-browser (Noto Sans Devanagari behind Inter/Fraunces). | **LA-6** — teacher surfaces chrome; then LA-7 localized emails |
 | - | [AI Surface Activation](ai-surface-activation.md) | Done | **Closed 2026-06-11 — North Star reached.** ASA-1..9 shipped across [#285](https://github.com/openshiksha/openshiksha/pull/285)–[#289](https://github.com/openshiksha/openshiksha/pull/289), [#293](https://github.com/openshiksha/openshiksha/pull/293)–[#302](https://github.com/openshiksha/openshiksha/pull/302): all four dark `/ai/` endpoint groups lit (explanations, misconception clusters, assignment drafts, open-response grading), error-as-empty-state sweep complete, shared `AIBadge` provenance, server-side SRS guard. Close ([#303](https://github.com/openshiksha/openshiksha/pull/303)): [endpoint-consumer map](../ai-features/endpoint-consumer-map.md) + DoD audit — 17 endpoints directly consumed, 4 indirect by design, 1 API-only (`/ai/predictions/`). | `useAsyncGeneration` refactor carried to maintenance; `/ai/predictions/` surface is a future product call |
 | - | [Authoring Integrity & Versioning](authoring-integrity-versioning.md) | Done | **All three phases shipped 2026-06-08/09.** Phase 1 (AIV-1..3, [#270](https://github.com/openshiksha/openshiksha/pull/270)–[#274](https://github.com/openshiksha/openshiksha/pull/274)): snapshot foundation + grader/student readers + edit-safety UI. Phase 2 (AIV-4/5, [#276](https://github.com/openshiksha/openshiksha/pull/276)–[#277](https://github.com/openshiksha/openshiksha/pull/277)): editable preview + drift surface. Phase 3 (AIV-6/7/8, [#279](https://github.com/openshiksha/openshiksha/pull/279)–[#281](https://github.com/openshiksha/openshiksha/pull/281)): guarded re-sync + `ProblemSetVersion` dedup + version history & diff UI. DoD met end-to-end. | - |
 | - | [Teacher Workspace](teacher-workspace.md) | Done | Closed 2026-06-09 with **TW-2** (editable preview) shipped in [#276](https://github.com/openshiksha/openshiksha/pull/276). Earlier increments: TW-1, TW-3a/b, TW-4, TW-5, TW-6, TW-7 closed 2026-06-07 across [#250](https://github.com/openshiksha/openshiksha/pull/250), [#261](https://github.com/openshiksha/openshiksha/pull/261)–[#266](https://github.com/openshiksha/openshiksha/pull/266). | - |

--- a/frontend_modern/src/features/parent/ParentDashboard.test.tsx
+++ b/frontend_modern/src/features/parent/ParentDashboard.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { I18nProvider, type Locale } from '@/shared/i18n';
+import { UserRole } from '@/types/index';
+import { ParentDashboard } from './ParentDashboard';
+
+const { mockGet } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    get: mockGet,
+  },
+}));
+
+const CHILD = {
+  id: 5,
+  username: 'asha',
+  email: '',
+  first_name: 'Asha',
+  last_name: 'Verma',
+  role: UserRole.STUDENT,
+  grade: 8,
+};
+
+const PROFICIENCY = {
+  id: 1,
+  tag_name: 'Polynomials',
+  subject_name: 'Mathematics',
+  classroom_display: 'Class 8A',
+  score: 0.72,
+  tick_count: 12,
+};
+
+function mockEndpoints() {
+  mockGet.mockImplementation((url: string) => {
+    if (url.startsWith('/users/me/children/')) return Promise.resolve({ data: [CHILD] });
+    if (url.includes('proficiency')) return Promise.resolve({ data: { results: [PROFICIENCY] } });
+    if (url.includes('assignments')) return Promise.resolve({ data: [] });
+    return Promise.resolve({ data: [] });
+  });
+}
+
+function renderDashboard(locale: Locale = 'en') {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <I18nProvider initialLocale={locale}>
+        <MemoryRouter>
+          <ParentDashboard />
+        </MemoryRouter>
+      </I18nProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('ParentDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('renders the dashboard chrome in English by default', async () => {
+    mockEndpoints();
+    renderDashboard();
+
+    await waitFor(() => expect(screen.getByText('Parent Dashboard')).toBeDefined());
+    expect(screen.getByText("Asha's Overview")).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Progress' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Assignments' })).toBeDefined();
+  });
+
+  it('renders the dashboard chrome in Hindi when the locale is hi', async () => {
+    mockEndpoints();
+    renderDashboard('hi');
+
+    // Hindi dictionary loads via dynamic import — wait for the swap.
+    await waitFor(() => expect(screen.getByText('अभिभावक डैशबोर्ड')).toBeDefined());
+    expect(screen.getByText('Asha की प्रगति-झलक')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'प्रगति' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'असाइनमेंट' })).toBeDefined();
+    // Authored/server content (subject, chapter tag) stays as authored.
+    await waitFor(() => expect(screen.getByText('Mathematics')).toBeDefined());
+    expect(screen.getByText('Polynomials')).toBeDefined();
+  });
+});

--- a/frontend_modern/src/features/parent/ParentDashboard.tsx
+++ b/frontend_modern/src/features/parent/ParentDashboard.tsx
@@ -4,6 +4,7 @@ import { useChildren } from './useChildren';
 import { useChildProficiency } from './useChildProficiency';
 import { useChildAssignments } from './useChildAssignments';
 import { Badge, Card, EmptyState, LoadingSpinner, SectionHeading } from '@/shared/ui';
+import { useI18n, useT } from '@/shared/i18n';
 import type { User, StudentProficiency, Assignment } from '@/types/index';
 
 interface SubjectGroup {
@@ -25,6 +26,7 @@ const groupBySubject = (records: StudentProficiency[]): SubjectGroup[] => {
 };
 
 const ProficiencyBar = ({ record }: { record: StudentProficiency }) => {
+  const t = useT();
   const pct = Math.round(record.score * 100);
   const barColor = pct >= 70 ? 'bg-emerald-500' : pct >= 40 ? 'bg-amber-400' : 'bg-rose-400';
 
@@ -41,13 +43,16 @@ const ProficiencyBar = ({ record }: { record: StudentProficiency }) => {
         />
       </div>
       <p className="text-xs text-ink-400 mt-1">
-        {record.tick_count} question{record.tick_count !== 1 ? 's' : ''} practised
+        {t(record.tick_count === 1 ? 'parent.questionsPractisedOne' : 'parent.questionsPractisedMany', {
+          count: record.tick_count,
+        })}
       </p>
     </div>
   );
 };
 
 const ChildView = ({ child }: { child: User }) => {
+  const t = useT();
   const { data: records, isLoading } = useChildProficiency(child.id);
 
   if (isLoading) {
@@ -61,8 +66,8 @@ const ChildView = ({ child }: { child: User }) => {
   if (!records || records.length === 0) {
     return (
       <EmptyState
-        title="No progress yet"
-        description={`${child.first_name || child.username} hasn't submitted any assignments yet.`}
+        title={t('parent.noProgressTitle')}
+        description={t('parent.noProgressDescription', { name: child.first_name || child.username })}
       />
     );
   }
@@ -95,12 +100,14 @@ const AssignmentStatusBadge = ({
   status: Assignment['child_submission_status'];
   isOverdue: boolean;
 }) => {
-  if (status === 'submitted') return <Badge tone="success">Submitted</Badge>;
-  if (isOverdue) return <Badge tone="urgent">Overdue</Badge>;
-  return <Badge tone="attention">Pending</Badge>;
+  const t = useT();
+  if (status === 'submitted') return <Badge tone="success">{t('parent.statusSubmitted')}</Badge>;
+  if (isOverdue) return <Badge tone="urgent">{t('parent.statusOverdue')}</Badge>;
+  return <Badge tone="attention">{t('parent.statusPending')}</Badge>;
 };
 
 const ChildAssignmentsView = ({ child }: { child: User }) => {
+  const { t, locale } = useI18n();
   const { data: assignments, isLoading } = useChildAssignments(child.id);
 
   if (isLoading) {
@@ -114,8 +121,8 @@ const ChildAssignmentsView = ({ child }: { child: User }) => {
   if (!assignments || assignments.length === 0) {
     return (
       <EmptyState
-        title="No assignments yet"
-        description="Assignments will appear here once the teacher creates them."
+        title={t('assignments.emptyTitle')}
+        description={t('parent.noAssignmentsDescription')}
       />
     );
   }
@@ -131,7 +138,7 @@ const ChildAssignmentsView = ({ child }: { child: User }) => {
         const dueDate = new Date(a.due_at);
         const isOverdue = dueDate < now;
         const isSubmitted = a.child_submission_status === 'submitted';
-        const dueFmt = dueDate.toLocaleDateString('en-IN', {
+        const dueFmt = dueDate.toLocaleDateString(locale === 'hi' ? 'hi-IN' : 'en-IN', {
           day: 'numeric',
           month: 'short',
           year: 'numeric',
@@ -151,8 +158,9 @@ const ChildAssignmentsView = ({ child }: { child: User }) => {
                 isOverdue && !isSubmitted ? 'text-rose-600 font-medium' : 'text-ink-400'
               }`}
             >
-              {isOverdue && !isSubmitted ? 'Overdue — ' : 'Due '}
-              {dueFmt}
+              {isOverdue && !isSubmitted
+                ? t('parent.overdueOn', { date: dueFmt })
+                : t('parent.dueOn', { date: dueFmt })}
             </p>
           </Card>
         );
@@ -162,6 +170,7 @@ const ChildAssignmentsView = ({ child }: { child: User }) => {
 };
 
 export const ParentDashboard = () => {
+  const t = useT();
   const { data: children, isLoading } = useChildren();
   const [selectedChildId, setSelectedChildId] = useState<number | undefined>();
   const [activeTab, setActiveTab] = useState<'progress' | 'assignments'>('progress');
@@ -180,10 +189,10 @@ export const ParentDashboard = () => {
   if (!children || children.length === 0) {
     return (
       <div className="max-w-2xl mx-auto px-4 py-8">
-        <SectionHeading as="h1" title="Parent Dashboard" className="mb-6" />
+        <SectionHeading as="h1" title={t('parent.title')} className="mb-6" />
         <EmptyState
-          title="No children linked to your account"
-          description="Ask the school admin to link your children's accounts."
+          title={t('parent.noChildrenTitle')}
+          description={t('parent.noChildrenDescription')}
         />
       </div>
     );
@@ -193,8 +202,8 @@ export const ParentDashboard = () => {
     <div className="max-w-2xl mx-auto px-4 py-8">
       <SectionHeading
         as="h1"
-        title="Parent Dashboard"
-        description="Monitor your children's learning progress."
+        title={t('parent.title')}
+        description={t('parent.description')}
         className="mb-6"
       />
 
@@ -212,7 +221,9 @@ export const ParentDashboard = () => {
             >
               {child.first_name || child.username}
               {child.grade != null && (
-                <span className="ml-1 opacity-70">Gr.{child.grade}</span>
+                <span className="ml-1 opacity-70">
+                  {t('parent.gradeShort', { grade: child.grade })}
+                </span>
               )}
             </button>
           ))}
@@ -224,17 +235,19 @@ export const ParentDashboard = () => {
           <div className="mb-4 flex items-start justify-between gap-3 flex-wrap">
             <div>
               <h2 className="text-lg font-display font-semibold text-ink-800">
-                {selectedChild.first_name || selectedChild.username}'s Overview
+                {t('parent.overview', { name: selectedChild.first_name || selectedChild.username })}
               </h2>
               {selectedChild.grade != null && (
-                <p className="text-sm text-ink-500">Grade {selectedChild.grade}</p>
+                <p className="text-sm text-ink-500">
+                  {t('parent.grade', { grade: selectedChild.grade })}
+                </p>
               )}
             </div>
             <Link
               to={`/parent/insights/${selectedChild.id}`}
               className="shrink-0 px-3 py-2 text-sm font-semibold rounded-lg bg-brand-50 text-brand-700 hover:bg-brand-100 transition-colors motion-reduce:transition-none focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2"
             >
-              View Insights →
+              {t('parent.viewInsights')}
             </Link>
           </div>
 
@@ -250,7 +263,7 @@ export const ParentDashboard = () => {
                     : 'border-transparent text-ink-500 hover:text-ink-700'
                 }`}
               >
-                {tab === 'progress' ? 'Progress' : 'Assignments'}
+                {tab === 'progress' ? t('parent.tabProgress') : t('parent.tabAssignments')}
               </button>
             ))}
           </div>

--- a/frontend_modern/src/shared/i18n/locales/en.ts
+++ b/frontend_modern/src/shared/i18n/locales/en.ts
@@ -199,6 +199,29 @@ export const en = {
   'explanation.regenerateInLocale': 'Explain in English',
   'explanation.regenerating': 'Rewriting…',
 
+  // ── Parent dashboard ─────────────────────────────────────────────────
+  'parent.title': 'Parent Dashboard',
+  'parent.description': "Monitor your children's learning progress.",
+  'parent.noChildrenTitle': 'No children linked to your account',
+  'parent.noChildrenDescription': "Ask the school admin to link your children's accounts.",
+  'parent.gradeShort': 'Gr.{grade}',
+  'parent.grade': 'Grade {grade}',
+  'parent.overview': "{name}'s Overview",
+  'parent.viewInsights': 'View Insights →',
+  'parent.tabProgress': 'Progress',
+  'parent.tabAssignments': 'Assignments',
+  'parent.noProgressTitle': 'No progress yet',
+  'parent.noProgressDescription': "{name} hasn't submitted any assignments yet.",
+  'parent.noAssignmentsDescription':
+    'Assignments will appear here once the teacher creates them.',
+  'parent.questionsPractisedOne': '{count} question practised',
+  'parent.questionsPractisedMany': '{count} questions practised',
+  'parent.statusSubmitted': 'Submitted',
+  'parent.statusOverdue': 'Overdue',
+  'parent.statusPending': 'Pending',
+  'parent.overdueOn': 'Overdue — {date}',
+  'parent.dueOn': 'Due {date}',
+
   // ── Streak badge ─────────────────────────────────────────────────────
   'streak.days': '{count}-day streak',
   'streak.tierStarter': 'On Fire',

--- a/frontend_modern/src/shared/i18n/locales/hi.ts
+++ b/frontend_modern/src/shared/i18n/locales/hi.ts
@@ -201,6 +201,28 @@ export const hi: LocaleDict = {
   'explanation.regenerateInLocale': 'हिंदी में समझाएँ',
   'explanation.regenerating': 'फिर से लिखी जा रही है…',
 
+  // ── Parent dashboard ─────────────────────────────────────────────────
+  'parent.title': 'अभिभावक डैशबोर्ड',
+  'parent.description': 'अपने बच्चों की पढ़ाई की प्रगति देखें।',
+  'parent.noChildrenTitle': 'आपके खाते से कोई बच्चा नहीं जुड़ा है',
+  'parent.noChildrenDescription': 'अपने बच्चों के खाते जोड़ने के लिए स्कूल एडमिन से कहें।',
+  'parent.gradeShort': 'कक्षा {grade}',
+  'parent.grade': 'कक्षा {grade}',
+  'parent.overview': '{name} की प्रगति-झलक',
+  'parent.viewInsights': 'इनसाइट्स देखें →',
+  'parent.tabProgress': 'प्रगति',
+  'parent.tabAssignments': 'असाइनमेंट',
+  'parent.noProgressTitle': 'अभी कोई प्रगति नहीं',
+  'parent.noProgressDescription': '{name} ने अभी तक कोई असाइनमेंट जमा नहीं किया है।',
+  'parent.noAssignmentsDescription': 'शिक्षक के असाइनमेंट बनाते ही वे यहाँ दिखेंगे।',
+  'parent.questionsPractisedOne': '{count} प्रश्न का अभ्यास हुआ',
+  'parent.questionsPractisedMany': '{count} प्रश्नों का अभ्यास हुआ',
+  'parent.statusSubmitted': 'जमा हो गया',
+  'parent.statusOverdue': 'समय निकल गया',
+  'parent.statusPending': 'बाकी है',
+  'parent.overdueOn': 'समय निकल गया — {date}',
+  'parent.dueOn': 'अंतिम तिथि {date}',
+
   // ── Streak badge ─────────────────────────────────────────────────────
   'streak.days': '{count} दिन की स्ट्रीक',
   'streak.tierStarter': 'जोश में',


### PR DESCRIPTION
## Classification
**Improve** — [Language Access](https://github.com/openshiksha/openshiksha/blob/modernization/docs/initiatives/2026-language-access.md) LA-5 (second half — closes the LA-1..5 batch). **Stacked on #312** — retarget to `modernization` after #312 merges.

## What's here
**Parent dashboard in Hindi** (completes the parent journey — chrome here, AI weekly summary in Hindi via #311):
- 21 `parent.*` keys: heading, child picker (grade chips), overview header, Progress/Assignments tabs, status badges (जमा हो गया / समय निकल गया / बाकी है), questions-practised counts, empty states, due/overdue date lines.
- Due dates format with `hi-IN` when the locale is Hindi.
- Authored/server content (subject names, chapter tags, titles) renders as authored — asserted in the new test.

**Batch bookkeeping**
- Initiative doc: ledger rows for LA-1..5 (with per-PR learnings), backlog ✅s, glossary +11 terms encountered this batch.
- `STATUS.md`: headline + active-row update — next increment **LA-6 (teacher chrome)**.
- `ROADMAP.md`: all four stale "Remaining" items ticked (each shipped via a closed initiative); board now defers to the initiatives STATUS as the live tracker.

## Tests
- New `ParentDashboard.test.tsx` (English + full-Hindi chrome). **57 files / 355 tests green**; lint/tsc/build green; entry 104.68 kB of 160 kB.

## Translation review (new Hindi strings, selection)
| Key | Hindi |
|---|---|
| parent.title | अभिभावक डैशबोर्ड |
| parent.tabProgress / tabAssignments | प्रगति / असाइनमेंट |
| parent.statusSubmitted / Overdue / Pending | जमा हो गया / समय निकल गया / बाकी है |
| parent.overview | {name} की प्रगति-झलक |
| parent.noChildrenTitle | आपके खाते से कोई बच्चा नहीं जुड़ा है |

🤖 Generated with [Claude Code](https://claude.com/claude-code)