### PR TITLE
feat(i18n): LA-7 — transactional emails in the recipient's language

### DIFF
--- a/backend/openshiksha/apps/ai/emails.py
+++ b/backend/openshiksha/apps/ai/emails.py
@@ -4,16 +4,47 @@ Email helpers for the Parent Intelligence Dashboard.
 Sends a parent a plain-text digest of their child's weekly progress summary.
 Follows the fail-soft convention used in core.emails: an SMTP error is logged,
 never raised, so one bad address can't break the weekly Celery batch.
+
+Localization (LA-7): the static chrome renders in the parent's
+``preferred_language`` (the AI ``summary_text`` is already generated in that
+language by ``generate_parent_progress_summary``).
 """
 
 import logging
 
 from django.core.mail import send_mail
 
+from openshiksha.apps.core.emails import format_email_string
+
 logger = logging.getLogger(__name__)
 
 # Highest-priority severity is surfaced first in the email lead line.
 _SEVERITY_RANK = {"urgent": 0, "attention": 1, "info": 2}
+
+_STRINGS = {
+    "en": {
+        "subject": "{child_name}'s weekly learning summary ({week_range})",
+        "greeting": "Hi {parent_name},",
+        "intro": "Here is {child_name}'s learning summary for the week of {week_range}.",
+        "needs_attention": "Needs attention — {label}: {detail}",
+        "home_activity": "Try this at home — {title}: {desc}",
+        "activity_default_title": "This week",
+        "cta": "Log in to OpenShiksha and open Insights for {child_name} to see the full dashboard.",
+        "signature": "— OpenShiksha",
+        "footer": "(You can turn off these weekly emails in your profile settings.)",
+    },
+    "hi": {
+        "subject": "{child_name} की साप्ताहिक लर्निंग समरी ({week_range})",
+        "greeting": "नमस्ते {parent_name},",
+        "intro": "{week_range} के सप्ताह की {child_name} की सीखने की समरी यह रही।",
+        "needs_attention": "ध्यान दें — {label}: {detail}",
+        "home_activity": "घर पर आज़माएँ — {title}: {desc}",
+        "activity_default_title": "इस सप्ताह",
+        "cta": "पूरा डैशबोर्ड देखने के लिए OpenShiksha पर लॉग इन करके {child_name} के लिए इनसाइट्स खोलें।",
+        "signature": "— OpenShiksha",
+        "footer": "(आप प्रोफ़ाइल सेटिंग्स में ये साप्ताहिक ईमेल बंद कर सकते हैं।)",
+    },
+}
 
 
 def _lead_alert(alerts: list[dict]) -> dict | None:
@@ -34,14 +65,17 @@ def notify_parent_weekly_summary(parent, child, summary) -> bool:
         logger.info("notify_parent_weekly_summary: skipped, parent %d has no email", parent.pk)
         return False
 
+    def _s(key: str, **kwargs) -> str:
+        return format_email_string(_STRINGS, parent, key, **kwargs)
+
     child_name = child.first_name or child.username
     parent_name = parent.first_name or parent.username
     week_range = f"{summary.week_start.strftime('%b %d')} – {summary.week_end.strftime('%b %d')}"
 
     lines = [
-        f"Hi {parent_name},",
+        _s("greeting", parent_name=parent_name),
         "",
-        f"Here is {child_name}'s learning summary for the week of {week_range}.",
+        _s("intro", child_name=child_name, week_range=week_range),
         "",
         (summary.summary_text or "").strip(),
         "",
@@ -51,26 +85,26 @@ def notify_parent_weekly_summary(parent, child, summary) -> bool:
     if lead:
         label = (lead.get("label") or "").strip()
         detail = (lead.get("detail") or "").strip()
-        lines += [f"Needs attention — {label}: {detail}".strip(": ").strip(), ""]
+        lines += [_s("needs_attention", label=label, detail=detail).strip(": ").strip(), ""]
 
     activities = summary.home_activities or []
     if activities:
         act = activities[0]
-        title = (act.get("title") or "This week").strip()
+        title = (act.get("title") or _s("activity_default_title")).strip()
         desc = (act.get("description") or "").strip()
-        lines += [f"Try this at home — {title}: {desc}".strip(": ").strip(), ""]
+        lines += [_s("home_activity", title=title, desc=desc).strip(": ").strip(), ""]
 
     lines += [
-        f"Log in to OpenShiksha and open Insights for {child_name} to see the full dashboard.",
+        _s("cta", child_name=child_name),
         "",
-        "— OpenShiksha",
+        _s("signature"),
         "",
-        "(You can turn off these weekly emails in your profile settings.)",
+        _s("footer"),
     ]
 
     try:
         send_mail(
-            subject=f"{child_name}'s weekly learning summary ({week_range})",
+            subject=_s("subject", child_name=child_name, week_range=week_range),
             message="\n".join(lines),
             from_email=None,
             recipient_list=[parent.email],

--- a/backend/openshiksha/apps/ai/tasks.py
+++ b/backend/openshiksha/apps/ai/tasks.py
@@ -1109,6 +1109,10 @@ def enqueue_weekly_parent_summaries(week_start_iso: str | None = None) -> dict:
                 parent.pk,
                 child.pk,
                 week_start_iso=week_start_iso,
+                # LA-7: the AI narrative generates in the parent's language —
+                # before this, the Monday batch always produced English even
+                # for Hindi-preferring parents.
+                language=getattr(parent, "preferred_language", "en") or "en",
                 send_email=True,
             )
             enqueued += 1

--- a/backend/openshiksha/apps/ai/tests/test_parent_intelligence.py
+++ b/backend/openshiksha/apps/ai/tests/test_parent_intelligence.py
@@ -808,8 +808,68 @@ def test_enqueue_weekly_parent_summaries_fans_out_per_pair(setup):
         setup["parent"].pk,
         setup["child"].pk,
         week_start_iso=expected_week,
+        language="en",
         send_email=True,
     )
+
+
+@pytest.mark.django_db
+def test_enqueue_weekly_parent_summaries_passes_parent_language(setup):
+    """LA-7: a Hindi-preferring parent gets a Hindi AI summary from the Monday batch."""
+    from openshiksha.apps.ai.tasks import enqueue_weekly_parent_summaries
+
+    setup["parent"].preferred_language = "hi"
+    setup["parent"].save()
+
+    with patch("openshiksha.apps.ai.tasks.generate_parent_progress_summary.delay") as mock_delay:
+        enqueue_weekly_parent_summaries()
+
+    assert mock_delay.call_args.kwargs["language"] == "hi"
+
+
+@pytest.mark.django_db
+def test_notify_parent_weekly_summary_renders_hindi_chrome(setup, summary, settings):
+    """LA-7: email chrome follows parent.preferred_language; the AI narrative
+    text is embedded as stored (already language-aware via the generate task)."""
+    from django.core import mail
+
+    from openshiksha.apps.ai.emails import notify_parent_weekly_summary
+
+    settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+    mail.outbox = []
+    setup["parent"].email = "parent@example.com"
+    setup["parent"].preferred_language = "hi"
+    setup["parent"].save()
+
+    sent = notify_parent_weekly_summary(setup["parent"], setup["child"], summary)
+
+    assert sent is True
+    assert len(mail.outbox) == 1
+    assert "साप्ताहिक लर्निंग समरी" in mail.outbox[0].subject
+    assert "Aanya" in mail.outbox[0].subject
+    body = mail.outbox[0].body
+    assert "नमस्ते" in body
+    assert "इनसाइट्स खोलें" in body
+    # The stored narrative passes through verbatim.
+    assert "Aanya did well this week." in body
+
+
+@pytest.mark.django_db
+def test_notify_parent_weekly_summary_english_default(setup, summary, settings):
+    from django.core import mail
+
+    from openshiksha.apps.ai.emails import notify_parent_weekly_summary
+
+    settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+    mail.outbox = []
+    setup["parent"].email = "parent@example.com"
+    setup["parent"].save()
+
+    sent = notify_parent_weekly_summary(setup["parent"], setup["child"], summary)
+
+    assert sent is True
+    assert "weekly learning summary" in mail.outbox[0].subject
+    assert "Hi " in mail.outbox[0].body
 
 
 @pytest.mark.django_db

--- a/backend/openshiksha/apps/core/emails.py
+++ b/backend/openshiksha/apps/core/emails.py
@@ -3,6 +3,12 @@ Email notification helpers for OpenShiksha.
 
 All functions are silent on failure (fail_silently=True) so email errors
 never surface as grading or task errors.
+
+Localization (LA-7): every email renders in the recipient's
+``User.preferred_language`` (en/hi, default en) via a tiny per-module string
+catalog — mirroring the frontend's deliberately dependency-free i18n module
+(docs/initiatives/2026-language-access.md, principle 2). No gettext/.po
+machinery for two languages of plain-text email.
 """
 
 import logging
@@ -12,6 +18,80 @@ from django.core.mail import send_mail
 logger = logging.getLogger(__name__)
 
 
+def format_email_string(catalog: dict, user, key: str, **kwargs) -> str:
+    """
+    Render ``catalog[lang][key]`` for the user's preferred language with
+    ``str.format`` interpolation. Falls back to English when the language or
+    the key is missing — an untranslated email beats a broken one
+    (initiative principle 3).
+    """
+    lang = getattr(user, "preferred_language", "en") or "en"
+    template = catalog.get(lang, {}).get(key) or catalog["en"][key]
+    return template.format(**kwargs)
+
+
+_STRINGS = {
+    "en": {
+        "remedial.subject": "You have a new practice assignment",
+        "remedial.body": (
+            "Hi {name},\n\n"
+            "Your teacher has created a practice assignment to help you strengthen "
+            "'{chapter_name}' before {due_date}.\n\n"
+            "Log in to OpenShiksha to start practising.\n\n"
+            "— OpenShiksha"
+        ),
+        "reminder.subject": "Reminder: '{assignment_title}' is due {due_date}",
+        "reminder.body": (
+            "Hi {name},\n\n"
+            "This is a friendly reminder that your assignment '{assignment_title}' "
+            "is due {due_date}.\n\n"
+            "Log in to OpenShiksha to complete it before the deadline.\n\n"
+            "— OpenShiksha\n\n"
+            "(You can turn off these reminders in your profile settings.)"
+        ),
+        "graded.subject": "Your assignment has been graded: {score_pct}%",
+        "graded.body": (
+            "Hi {name},\n\n"
+            "Your submission for '{assignment_title}' has been graded.\n\n"
+            "Score: {score_pct}%\n\n"
+            "Log in to OpenShiksha to review your results.\n\n"
+            "— OpenShiksha"
+        ),
+    },
+    "hi": {
+        "remedial.subject": "आपके लिए एक नया अभ्यास असाइनमेंट है",
+        "remedial.body": (
+            "नमस्ते {name},\n\n"
+            "आपके शिक्षक ने '{chapter_name}' को मज़बूत करने के लिए एक अभ्यास "
+            "असाइनमेंट बनाया है — अंतिम तिथि {due_date}।\n\n"
+            "अभ्यास शुरू करने के लिए OpenShiksha पर लॉग इन करें।\n\n"
+            "— OpenShiksha"
+        ),
+        "reminder.subject": "याद दिलाना: '{assignment_title}' की अंतिम तिथि {due_date} है",
+        "reminder.body": (
+            "नमस्ते {name},\n\n"
+            "यह एक दोस्ताना याद दिलाना है कि आपके असाइनमेंट '{assignment_title}' "
+            "की अंतिम तिथि {due_date} है।\n\n"
+            "समय रहते पूरा करने के लिए OpenShiksha पर लॉग इन करें।\n\n"
+            "— OpenShiksha\n\n"
+            "(आप प्रोफ़ाइल सेटिंग्स में ये रिमाइंडर बंद कर सकते हैं।)"
+        ),
+        "graded.subject": "आपका असाइनमेंट जाँच लिया गया है: {score_pct}%",
+        "graded.body": (
+            "नमस्ते {name},\n\n"
+            "'{assignment_title}' के लिए आपका जमा किया गया काम जाँच लिया गया है।\n\n"
+            "स्कोर: {score_pct}%\n\n"
+            "अपने परिणाम देखने के लिए OpenShiksha पर लॉग इन करें।\n\n"
+            "— OpenShiksha"
+        ),
+    },
+}
+
+
+def _s(user, key: str, **kwargs) -> str:
+    return format_email_string(_STRINGS, user, key, **kwargs)
+
+
 def notify_remedial_assigned(student, chapter_name: str, due_date_str: str) -> None:
     """Email a student when a remedial practice assignment is created for them."""
     if not student.email:
@@ -19,14 +99,8 @@ def notify_remedial_assigned(student, chapter_name: str, due_date_str: str) -> N
     name = student.first_name or student.username
     try:
         send_mail(
-            subject="You have a new practice assignment",
-            message=(
-                f"Hi {name},\n\n"
-                f"Your teacher has created a practice assignment to help you strengthen "
-                f"'{chapter_name}' before {due_date_str}.\n\n"
-                f"Log in to OpenShiksha to start practising.\n\n"
-                f"— OpenShiksha"
-            ),
+            subject=_s(student, "remedial.subject"),
+            message=_s(student, "remedial.body", name=name, chapter_name=chapter_name, due_date=due_date_str),
             from_email=None,
             recipient_list=[student.email],
             fail_silently=False,
@@ -43,15 +117,8 @@ def notify_due_date_reminder(student, assignment_title: str, due_date_str: str) 
     name = student.first_name or student.username
     try:
         send_mail(
-            subject=f"Reminder: '{assignment_title}' is due {due_date_str}",
-            message=(
-                f"Hi {name},\n\n"
-                f"This is a friendly reminder that your assignment '{assignment_title}' "
-                f"is due {due_date_str}.\n\n"
-                f"Log in to OpenShiksha to complete it before the deadline.\n\n"
-                f"— OpenShiksha\n\n"
-                f"(You can turn off these reminders in your profile settings.)"
-            ),
+            subject=_s(student, "reminder.subject", assignment_title=assignment_title, due_date=due_date_str),
+            message=_s(student, "reminder.body", name=name, assignment_title=assignment_title, due_date=due_date_str),
             from_email=None,
             recipient_list=[student.email],
             fail_silently=False,
@@ -68,14 +135,8 @@ def notify_grading_complete(student, assignment_title: str, score_pct: int) -> N
     name = student.first_name or student.username
     try:
         send_mail(
-            subject=f"Your assignment has been graded: {score_pct}%",
-            message=(
-                f"Hi {name},\n\n"
-                f"Your submission for '{assignment_title}' has been graded.\n\n"
-                f"Score: {score_pct}%\n\n"
-                f"Log in to OpenShiksha to review your results.\n\n"
-                f"— OpenShiksha"
-            ),
+            subject=_s(student, "graded.subject", score_pct=score_pct),
+            message=_s(student, "graded.body", name=name, assignment_title=assignment_title, score_pct=score_pct),
             from_email=None,
             recipient_list=[student.email],
             fail_silently=False,

--- a/backend/openshiksha/apps/core/tests/test_email_notifications.py
+++ b/backend/openshiksha/apps/core/tests/test_email_notifications.py
@@ -133,6 +133,78 @@ class TestEmailHelpers:
 
 
 # ---------------------------------------------------------------------------
+# Localized emails (LA-7): preferred_language = "hi" renders Hindi
+# ---------------------------------------------------------------------------
+
+
+class TestEmailLocalization:
+    @pytest.fixture
+    def hindi_student(self, db, school):
+        from openshiksha.apps.core.models import User, UserRole
+
+        return User.objects.create_user(
+            username="hindi_student",
+            password="pass",
+            role=UserRole.STUDENT,
+            school=school,
+            email="hindi@test.example",
+            first_name="Asha",
+            preferred_language="hi",
+        )
+
+    def test_remedial_email_in_hindi(self, hindi_student):
+        from openshiksha.apps.core.emails import notify_remedial_assigned
+
+        notify_remedial_assigned(hindi_student, "Algebra", "May 27")
+
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].subject == "आपके लिए एक नया अभ्यास असाइनमेंट है"
+        body = mail.outbox[0].body
+        assert "नमस्ते Asha" in body
+        # Authored content (chapter name) and dates stay as passed.
+        assert "Algebra" in body
+        assert "May 27" in body
+
+    def test_grading_email_in_hindi(self, hindi_student):
+        from openshiksha.apps.core.emails import notify_grading_complete
+
+        notify_grading_complete(hindi_student, "Chapter 3 Test", 78)
+
+        assert len(mail.outbox) == 1
+        assert "जाँच लिया गया है" in mail.outbox[0].subject
+        assert "78%" in mail.outbox[0].subject
+        assert "स्कोर: 78%" in mail.outbox[0].body
+        assert "Chapter 3 Test" in mail.outbox[0].body
+
+    def test_reminder_email_in_hindi(self, hindi_student):
+        from openshiksha.apps.core.emails import notify_due_date_reminder
+
+        notify_due_date_reminder(hindi_student, "Chapter 3 Test", "May 27")
+
+        assert len(mail.outbox) == 1
+        assert "अंतिम तिथि" in mail.outbox[0].subject
+        assert "Chapter 3 Test" in mail.outbox[0].subject
+        assert "रिमाइंडर बंद कर सकते हैं" in mail.outbox[0].body
+
+    def test_english_remains_the_default(self, db, student_with_email):
+        from openshiksha.apps.core.emails import notify_grading_complete
+
+        assert student_with_email.preferred_language == "en"
+        notify_grading_complete(student_with_email, "Chapter 3 Test", 78)
+
+        assert mail.outbox[0].subject == "Your assignment has been graded: 78%"
+
+    def test_unknown_language_falls_back_to_english(self, db, student_with_email):
+        from openshiksha.apps.core.emails import notify_grading_complete
+
+        # Bypass model validation deliberately — the catalog must not crash.
+        student_with_email.preferred_language = "fr"
+        notify_grading_complete(student_with_email, "Chapter 3 Test", 78)
+
+        assert mail.outbox[0].subject == "Your assignment has been graded: 78%"
+
+
+# ---------------------------------------------------------------------------
 # Integration: email sent during grade_submission task
 # ---------------------------------------------------------------------------
 

--- a/docs/changes/2026-06-12-la7-localized-emails.md
+++ b/docs/changes/2026-06-12-la7-localized-emails.md
@@ -1,0 +1,48 @@
+# LA-7 — transactional emails in the recipient's language
+
+**Date:** 2026-06-12
+**Classification:** Improve
+**Initiative:** [Language Access — i18n en/हिंदी](../initiatives/2026-language-access.md) (LA-7)
+
+## Summary
+
+All four transactional emails (remedial assigned, grading complete, due-date
+reminder, parent weekly summary) now render in the recipient's
+`preferred_language`. Also fixes a real bug: the Monday parent-summary batch
+(`enqueue_weekly_parent_summaries`) never passed a language, so Hindi-preferring
+parents always received English AI narratives.
+
+## What changed and why
+
+- **`core/emails.py`** — per-module string catalog (`_STRINGS["en"/"hi"]`) +
+  `format_email_string(catalog, user, key, **vars)` helper reading
+  `user.preferred_language` with English fallback (missing key/language never
+  crashes — an untranslated email beats a broken one). No gettext/.po — same
+  no-heavyweight-machinery principle as the frontend module.
+- **`ai/emails.py`** — parent weekly summary chrome (subject, greeting, intro,
+  needs-attention/home-activity prefixes, CTA, footer) through the same helper.
+  The AI `summary_text` passes through verbatim — it is already generated in
+  the requested language.
+- **`ai/tasks.py`** — `enqueue_weekly_parent_summaries` passes
+  `language=parent.preferred_language` to `generate_parent_progress_summary`
+  (the dark-language bug).
+
+Dates inside emails (e.g. "May 27", week ranges) stay English-formatted —
+locale-aware date formatting is LA-8.
+
+## Tests
+
+- `test_email_notifications.py` +5 (`TestEmailLocalization`): Hindi
+  remedial/grading/reminder subject+body, English default unchanged, unknown
+  language falls back to English.
+- `test_parent_intelligence.py` +3: enqueue passes the parent's language;
+  Hindi chrome dispatch (first direct test of `notify_parent_weekly_summary`
+  delivery content); English default. Existing fans-out assertion updated for
+  the new `language` kwarg.
+- 69 targeted tests green; full suite + `manage.py check` green; no model
+  changes → no migration.
+
+## Next steps
+
+LA-6a (teacher dashboard chrome) lands next; LA-8 will localize dates/numbers
+including inside these emails.


### PR DESCRIPTION
## Classification
**Improve** — [Language Access](https://github.com/openshiksha/openshiksha/blob/modernization/docs/initiatives/2026-language-access.md) LA-7. Independent, based on `modernization`.

## What's here
- **Per-module en/hi string catalogs** (`core/emails.py`, `ai/emails.py`) + `format_email_string(catalog, user, key, **vars)` reading `preferred_language` with English fallback — same no-gettext philosophy as the frontend i18n module.
- All 4 transactional emails localized: remedial assigned, grading complete, due-date reminder, parent weekly summary chrome (the AI `summary_text` is already language-aware and passes through verbatim).
- **Bug fix:** `enqueue_weekly_parent_summaries` never passed a language — Hindi-preferring parents always got English AI narratives from the Monday batch. Now passes `parent.preferred_language`.
- Dates inside emails stay English-formatted (LA-8 scope).

## Tests
- +5 `TestEmailLocalization` (Hindi subject/body per email, English default, unknown-language fallback); +3 parent-summary tests (enqueue passes language, first direct Hindi/English dispatch-content tests). **Full suite: 940 passed**, coverage 93.81%; no migrations.

## Translation review (selection)
| Email | Hindi subject |
|---|---|
| Remedial | आपके लिए एक नया अभ्यास असाइनमेंट है |
| Reminder | याद दिलाना: '{title}' की अंतिम तिथि {date} है |
| Graded | आपका असाइनमेंट जाँच लिया गया है: {pct}% |
| Parent weekly | {child} की साप्ताहिक लर्निंग समरी ({range}) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)