### PR TITLE
polish(ai): refresh status self-dismisses on misconception + question-quality panels

### DIFF
--- a/docs/ai-features/polish-backlog.md
+++ b/docs/ai-features/polish-backlog.md
@@ -294,7 +294,39 @@ confirms the recompute; a failing refresh shows the inline error.
 
 ---
 
-## Remaining gaps (audit notes — updated 2026-06-11, ASA closed)
+## 2026-06-13 — Refresh confirmations self-dismiss (no stale status lines)
+
+**Surface:** Class misconception insights (`MisconceptionClustersPanel`) and
+question-quality / difficulty calibration (`QuestionQualityPanel`).
+
+**Gap (checklist #2 loading/transient states, #3 copy/tone):**
+Both panels show a reassuring status line after a teacher clicks Refresh —
+"Recomputing from recent submissions…" / "Recalibrating from recent answers…".
+Because the recompute runs async (Celery) there's no signal for when fresh data
+lands, so the line was driven purely by `refresh.isSuccess` and **stayed on
+screen indefinitely**, long after the new data had arrived. The teacher was left
+staring at a "still working" message for a job that had already finished — the
+"refresh confirmation lingers" gap noted in the audit since 2026-06-11.
+
+**Fix:**
+- Each panel now schedules a `setTimeout` (6s) on `refresh.isSuccess` that calls
+  `refresh.reset()`, clearing the mutation's success state so the status line
+  self-dismisses. Effect deps are the stable `refresh.isSuccess` / `refresh.reset`
+  values (not the whole mutation object) so the timer isn't churned every render,
+  and the timeout is cleared on unmount / re-trigger.
+- Used the bare global `setTimeout`/`clearTimeout` (not `window.setTimeout`) so the
+  timer is fake-timer/spy-friendly under happy-dom in tests.
+- Added a test to each panel's spec asserting the status line disappears once the
+  scheduled dismiss callback fires (checklist #8). The error/empty/skeleton paths
+  are unchanged and still pass.
+
+**Verify:** Expand "Class Misconceptions" or "Question Quality" on the teacher
+dashboard and click Refresh/Calibrate. The "Recomputing…/Recalibrating…" line
+appears, then clears on its own a few seconds later instead of sticking around.
+
+---
+
+## Remaining gaps (audit notes — updated 2026-06-13)
 
 - ✅ **Error-as-empty-state sweep complete** — `MisconceptionClustersPanel`
   (#291), `InterventionsPanel` and `WeeklyReportPanel` (both 2026-06-10), and
@@ -307,10 +339,10 @@ confirms the recompute; a failing refresh shows the inline error.
   rows but `ClassMisconceptionCluster` carries no `model_used`, so the cards
   can't show the `✨ AI-generated` vs stub badge used everywhere else. Needs a
   model field + migration → guardrailed out of polish runs; note for ASA.
-- **Refresh confirmation lingers** — `MisconceptionClustersPanel`'s
-  "Recomputing from recent submissions…" status (and now
-  `QuestionQualityPanel`'s matching "Recalibrating…" line) stays visible
-  after the delayed refetch lands; could clear once new data arrives. Minor.
+- ✅ **Refresh confirmation lingers** — fixed 2026-06-13: `MisconceptionClustersPanel`
+  and `QuestionQualityPanel` now self-dismiss the "Recomputing…/Recalibrating…"
+  status line after 6s via `refresh.reset()`, instead of leaving it on screen
+  after the async recompute finishes.
 - **Hint system** — solid: loading ("Thinking of a good hint…"), error, and
   exhausted states all present. Low priority.
 - ✅ **Unwired backend surfaces — all four groups lit.**

--- a/frontend_modern/src/features/teacher/MisconceptionClustersPanel.test.tsx
+++ b/frontend_modern/src/features/teacher/MisconceptionClustersPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
@@ -146,6 +146,37 @@ describe('MisconceptionClustersPanel', () => {
       })
     );
     await waitFor(() => expect(screen.getByRole('status')).toBeDefined());
+  });
+
+  it('clears the "Recomputing…" confirmation after a short delay', async () => {
+    // Spy on the dismiss timer rather than running fake timers (happy-dom +
+    // userEvent + waitFor don't compose with fake timers). We capture the
+    // scheduled self-dismiss callback and invoke it directly.
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue({ data: [CLUSTER] });
+    mockPost.mockResolvedValue({ data: { detail: 'queued' } });
+
+    renderPanel();
+    await user.click(screen.getByRole('button', { name: /class misconceptions/i }));
+    await waitFor(() => expect(screen.getByText('4 students')).toBeDefined());
+
+    await user.click(screen.getByRole('button', { name: /refresh/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/recomputing from recent submissions/i)).toBeDefined()
+    );
+
+    // Pull the 6s self-dismiss callback the panel scheduled and fire it.
+    const dismiss = setTimeoutSpy.mock.calls.find(([, delay]) => delay === 6000)?.[0] as
+      | (() => void)
+      | undefined;
+    expect(dismiss).toBeDefined();
+    act(() => dismiss!());
+
+    await waitFor(() =>
+      expect(screen.queryByText(/recomputing from recent submissions/i)).toBeNull()
+    );
+    setTimeoutSpy.mockRestore();
   });
 
   it('shows an inline error when the refresh fails', async () => {

--- a/frontend_modern/src/features/teacher/MisconceptionClustersPanel.tsx
+++ b/frontend_modern/src/features/teacher/MisconceptionClustersPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Badge, Button, Skeleton } from '@/shared/ui';
 import {
   useMisconceptionClusters,
@@ -72,6 +72,17 @@ export const MisconceptionClustersPanel = ({ subjectRoomId }: Props) => {
     refetch,
   } = useMisconceptionClusters(subjectRoomId, isExpanded);
   const refresh = useRefreshMisconceptionClusters(subjectRoomId);
+
+  // The "Recomputing…" confirmation is reassuring right after a click, but the
+  // recompute runs async (Celery), so we can't reliably detect when fresh data
+  // lands. Clear it on a timer instead of leaving a stale status line forever.
+  const refreshSucceeded = refresh.isSuccess;
+  const resetRefresh = refresh.reset;
+  useEffect(() => {
+    if (!refreshSucceeded) return;
+    const timer = setTimeout(() => resetRefresh(), 6000);
+    return () => clearTimeout(timer);
+  }, [refreshSucceeded, resetRefresh]);
 
   const items = clusters ?? [];
 

--- a/frontend_modern/src/features/teacher/QuestionQualityPanel.test.tsx
+++ b/frontend_modern/src/features/teacher/QuestionQualityPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
@@ -177,6 +177,37 @@ describe('QuestionQualityPanel', () => {
     await waitFor(() =>
       expect(screen.getByText(/recalibrating from recent answers/i)).toBeDefined()
     );
+  });
+
+  it('clears the "Recalibrating…" confirmation after a short delay', async () => {
+    // Spy on the dismiss timer rather than running fake timers (happy-dom +
+    // userEvent + waitFor don't compose with fake timers). We capture the
+    // scheduled self-dismiss callback and invoke it directly.
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const user = userEvent.setup();
+    serveList(() => Promise.resolve({ data: { results: [CALIBRATION] } }));
+    mockPost.mockResolvedValue({ data: { detail: 'queued' } });
+
+    renderPanel();
+    await user.click(screen.getByRole('button', { name: /question quality/i }));
+    await waitFor(() => expect(screen.getByText('Too hard')).toBeDefined());
+
+    await user.click(screen.getByRole('button', { name: /refresh/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/recalibrating from recent answers/i)).toBeDefined()
+    );
+
+    // Pull the 6s self-dismiss callback the panel scheduled and fire it.
+    const dismiss = setTimeoutSpy.mock.calls.find(([, delay]) => delay === 6000)?.[0] as
+      | (() => void)
+      | undefined;
+    expect(dismiss).toBeDefined();
+    act(() => dismiss!());
+
+    await waitFor(() =>
+      expect(screen.queryByText(/recalibrating from recent answers/i)).toBeNull()
+    );
+    setTimeoutSpy.mockRestore();
   });
 
   it('shows an inline error when the recalibration fails to start', async () => {

--- a/frontend_modern/src/features/teacher/QuestionQualityPanel.tsx
+++ b/frontend_modern/src/features/teacher/QuestionQualityPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Badge, Button, Skeleton } from '@/shared/ui';
 import {
   useCalibrationSummary,
@@ -120,6 +120,17 @@ export const QuestionQualityPanel = ({ subjectRoomId }: Props) => {
   } = useFlaggedCalibrations(subjectRoomId, isExpanded);
   const { data: summary } = useCalibrationSummary(subjectRoomId, isExpanded);
   const refresh = useRefreshCalibrations(subjectRoomId);
+
+  // The "Recalibrating…" confirmation reassures right after a click, but the
+  // recalibration runs async, so we can't reliably detect when fresh verdicts
+  // land. Clear it on a timer instead of leaving a stale status line forever.
+  const refreshSucceeded = refresh.isSuccess;
+  const resetRefresh = refresh.reset;
+  useEffect(() => {
+    if (!refreshSucceeded) return;
+    const timer = setTimeout(() => resetRefresh(), 6000);
+    return () => clearTimeout(timer);
+  }, [refreshSucceeded, resetRefresh]);
 
   const items = flagged ?? [];
 


### PR DESCRIPTION
## What gap was fixed

Two teacher AI panels — **Class Misconceptions** (`MisconceptionClustersPanel`) and **Question Quality** (`QuestionQualityPanel`) — show a reassuring status line after a teacher clicks Refresh/Calibrate:

- "Recomputing from recent submissions — new patterns appear here shortly."
- "Recalibrating from recent answers — updated verdicts appear here shortly."

Because the recompute runs **async via Celery**, there's no signal for when fresh data lands, so the line was driven purely by `refresh.isSuccess` and **stayed on screen indefinitely** — long after the job had finished. The teacher was left staring at a "still working" message for work that had already completed.

This was the **"refresh confirmation lingers"** gap tracked in `docs/ai-features/polish-backlog.md` since 2026-06-11 (checklist #2 transient/loading states, #3 copy/tone).

## Before / after

- **Before:** click Refresh → status line appears → stays forever (until the panel is collapsed/re-rendered).
- **After:** click Refresh → status line appears → **self-dismisses after 6s** via `refresh.reset()`.

## How

- Each panel schedules a `setTimeout(6s)` on `refresh.isSuccess` that calls `refresh.reset()`, clearing the mutation's success state so the conditional status line unmounts.
- Effect deps use the **stable** `refresh.isSuccess` / `refresh.reset` values (not the whole mutation object), so the timer isn't churned on every render; the timeout is cleared on unmount / re-trigger.
- Uses the bare global `setTimeout`/`clearTimeout` (not `window.setTimeout`) so the timer is fake-timer/spy friendly under happy-dom.
- Added a dismiss test to each panel spec. All error / empty / skeleton paths unchanged.

## Verify

Expand "Class Misconceptions" or "Question Quality" on the teacher dashboard and click Refresh/Calibrate. The status line appears, then clears on its own a few seconds later instead of sticking around.

- `npx vitest run src/features/teacher/MisconceptionClustersPanel.test.tsx src/features/teacher/QuestionQualityPanel.test.tsx` → 16 passed
- `npx tsc --noEmit` clean · `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)