### PR TITLE
feat(i18n): LA-8 — locale-aware date/number helper

### DIFF
--- a/docs/changes/2026-06-13-la8-format-helper.md
+++ b/docs/changes/2026-06-13-la8-format-helper.md
@@ -1,0 +1,58 @@
+# LA-8 — locale-aware date/number helper
+
+**Date:** 2026-06-13
+**Classification:** Improve / foundation-hardening
+**Initiative:** Language Access (2026-language-access.md) — LA-8
+
+## Summary
+
+Added a single `Intl`-backed `formatDate`/`formatNumber` helper so every surface
+formats absolute dates and counts the same way for the active locale, instead of
+each screen reinventing `toLocaleDateString` with an ad-hoc (often `undefined`)
+locale. This is the foundation half that LA-6a–d were meant to consume; it was
+skipped in the prior run and is now shipped, so the LA-6e date surfaces (versions,
+snapshots, due-date chips) can render "27 मई 2026" through one helper.
+
+## Legacy reference
+
+None — legacy Django 1.11 server-rendered English templates with no `Intl` layer
+and no language preference. Pure "improve"; nothing to port.
+
+## What changed
+
+- **New `frontend_modern/src/shared/i18n/format.ts`:**
+  - `formatDate(value, locale, opts?)` — `Intl.DateTimeFormat` keyed to
+    `hi-IN`/`en-IN`. Default medium day-first style ("27 May 2026" / "27 मई 2026");
+    accepts `opts` overrides. Invalid input returned verbatim (never throws).
+  - `formatNumber(value, locale, opts?)` — `Intl.NumberFormat` with Indian
+    grouping but **Latin numerals** for both locales (deliberate product decision
+    for K-12 counts — documented in a code comment, do not "fix" to Devanagari).
+  - `useFormat()` hook returning `formatDate`/`formatNumber` bound to the active
+    locale, mirroring `useT()`.
+  - Exported from `shared/i18n/index.ts`.
+- **Swapped the first ad-hoc absolute-date render:**
+  `CreateAssignmentPage.formatDueDate` previously called
+  `toLocaleDateString(undefined, …)` — i.e. browser default locale, so a
+  Hindi-medium teacher saw English dates. Now takes the active `locale` and routes
+  through the shared `formatDate`, so all four due-date displays on that page
+  localize.
+
+## Why `Intl`, not a dependency
+
+`Intl` is built into every browser — adds nothing to the entry chunk (principle 2,
+160 kB budget). Verified: entry chunk stayed at 123 kB after build. For *relative*
+dates ("3 दिन में") the LA-3 date-fns `hi` locale is still used; this helper is for
+absolute dates and numbers only.
+
+## Tests
+
+- New `format.test.ts` — 8 cases: en/hi medium date, `opts` override,
+  invalid-input passthrough (both locales), `Date` instance input, Indian grouping
+  with Latin digits (en + hi), non-finite passthrough.
+- Full suite green: 58 files / 365 tests. Lint + tsc clean. Build under budget.
+
+## Next steps
+
+PR 4 (LA-6e-3 versions + classroom code) and PR 5 (CreateQuestionPage) consume
+`formatDate` for their timestamps. The 6a–d date renders can be back-filled to the
+helper opportunistically.

--- a/frontend_modern/src/features/teacher/CreateAssignmentPage.tsx
+++ b/frontend_modern/src/features/teacher/CreateAssignmentPage.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useSubjectRooms, type TeacherSubjectRoom } from './useSubjectRooms';
 import { useProblemSets, type TeacherProblemSet } from './useProblemSets';
 import { useCreateAssignment } from './useCreateAssignment';
-import { useT } from '@/shared/i18n';
+import { useT, useI18n, formatDate, type Locale } from '@/shared/i18n';
 import {
   Badge,
   Button,
@@ -18,18 +18,16 @@ import {
 
 // ── Pretty due-date helpers ────────────────────────────────────────────────
 
-const formatDueDate = (iso: string): string => {
+// Absolute due-date in the active locale via the shared LA-8 `formatDate`
+// helper (so a Hindi-medium teacher sees "बुधवार, 27 मई 2026", not English).
+const formatDueDate = (iso: string, locale: Locale): string => {
   if (!iso) return '';
-  try {
-    return new Date(iso).toLocaleDateString(undefined, {
-      weekday: 'long',
-      month: 'long',
-      day: 'numeric',
-      year: 'numeric',
-    });
-  } catch {
-    return iso;
-  }
+  return formatDate(iso, locale, {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
 };
 
 const daysFromToday = (iso: string): number | null => {
@@ -50,6 +48,7 @@ const daysFromToday = (iso: string): number | null => {
 export const CreateAssignmentPage = () => {
   const navigate = useNavigate();
   const t = useT();
+  const { locale } = useI18n();
   const [searchParams] = useSearchParams();
 
   const [subjectRoomId, setSubjectRoomId] = useState<number | ''>('');
@@ -168,7 +167,7 @@ export const CreateAssignmentPage = () => {
                   {
                     count: selectedRoom.student_count,
                     room: selectedRoom.classroom_display,
-                    date: formatDueDate(dueDate),
+                    date: formatDueDate(dueDate, locale),
                   },
                 )}
             </>
@@ -341,12 +340,12 @@ export const CreateAssignmentPage = () => {
             {daysOut !== null && daysOut >= 0 && (
               <p className="mt-3 text-xs text-ink-500">
                 {daysOut === 0
-                  ? t('assignForm.dueTodayHint', { date: formatDueDate(dueDate) })
+                  ? t('assignForm.dueTodayHint', { date: formatDueDate(dueDate, locale) })
                   : t(
                       daysOut === 1
                         ? 'assignForm.dueInDaysHintOne'
                         : 'assignForm.dueInDaysHintMany',
-                      { count: daysOut, date: formatDueDate(dueDate) },
+                      { count: daysOut, date: formatDueDate(dueDate, locale) },
                     )}
               </p>
             )}
@@ -478,6 +477,7 @@ interface AssignmentPreviewProps {
 
 const AssignmentPreview = ({ room, set, dueDate, valid, submitting, error }: AssignmentPreviewProps) => {
   const t = useT();
+  const { locale } = useI18n();
   // Empty state when nothing is picked yet
   if (!room) {
     return (
@@ -506,7 +506,7 @@ const AssignmentPreview = ({ room, set, dueDate, valid, submitting, error }: Ass
   }
 
   const daysOut = daysFromToday(dueDate);
-  const formattedDue = formatDueDate(dueDate);
+  const formattedDue = formatDueDate(dueDate, locale);
   let dueText: string;
   if (!dueDate) {
     dueText = t('assignForm.noDueYet');

--- a/frontend_modern/src/shared/i18n/format.test.ts
+++ b/frontend_modern/src/shared/i18n/format.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { formatDate, formatNumber } from './format';
+
+/**
+ * LA-8 — locale-aware date/number helper. Asserts the medium day-first style,
+ * an opts override, invalid-input passthrough, and Indian-grouping/Latin-digit
+ * number formatting for both locales.
+ */
+
+describe('formatDate', () => {
+  const may27 = '2026-05-27T10:00:00Z';
+
+  it('formats a medium day-first date in English', () => {
+    expect(formatDate(may27, 'en')).toBe('27 May 2026');
+  });
+
+  it('formats a medium day-first date in Hindi', () => {
+    // Devanagari month name; day/year stay Latin numerals.
+    expect(formatDate(may27, 'hi')).toBe('27 मई 2026');
+  });
+
+  it('honours an opts override', () => {
+    expect(formatDate(may27, 'en', { month: 'long', year: 'numeric' })).toBe('May 2026');
+  });
+
+  it('returns invalid input verbatim instead of throwing', () => {
+    expect(formatDate('not-a-date', 'en')).toBe('not-a-date');
+    expect(formatDate('not-a-date', 'hi')).toBe('not-a-date');
+  });
+
+  it('accepts a Date instance', () => {
+    expect(formatDate(new Date(may27), 'en')).toBe('27 May 2026');
+  });
+});
+
+describe('formatNumber', () => {
+  it('uses Indian grouping with Latin digits in English', () => {
+    expect(formatNumber(100000, 'en')).toBe('1,00,000');
+  });
+
+  it('uses Indian grouping with Latin digits in Hindi (not Devanagari)', () => {
+    expect(formatNumber(100000, 'hi')).toBe('1,00,000');
+  });
+
+  it('returns non-finite input verbatim', () => {
+    expect(formatNumber(NaN, 'en')).toBe('NaN');
+  });
+});

--- a/frontend_modern/src/shared/i18n/format.ts
+++ b/frontend_modern/src/shared/i18n/format.ts
@@ -1,0 +1,78 @@
+import { useI18n, type Locale } from './i18nContext';
+
+/**
+ * LA-8 — locale-aware date/number formatting via the platform `Intl` API.
+ *
+ * One shared helper so every surface formats absolute dates and counts the same
+ * way for the active locale, instead of each screen reinventing
+ * `toLocaleDateString`. `Intl` is built into the browser, so this adds nothing
+ * to the entry chunk (principle 2 — no dependency for what the platform gives
+ * us free). For *relative* dates ("3 दिन में") keep using the date-fns `hi`
+ * locale wired up in LA-3 — this helper is for absolute dates and numbers.
+ *
+ * See docs/initiatives/2026-language-access.md.
+ */
+
+const intlLocale = (locale: Locale): string => (locale === 'hi' ? 'hi-IN' : 'en-IN');
+
+/** Indian convention: "27 May 2026" / "27 मई 2026" (day-first, no comma). */
+const DEFAULT_DATE_OPTS: Intl.DateTimeFormatOptions = {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+};
+
+/**
+ * Format an absolute date for the active locale.
+ *
+ * Defaults to a medium day-first style ("27 May 2026" / "27 मई 2026"); pass
+ * `opts` to override. Invalid input is returned verbatim instead of throwing,
+ * so a malformed API timestamp degrades to the raw string rather than crashing
+ * a render.
+ */
+export const formatDate = (
+  value: string | number | Date,
+  locale: Locale,
+  opts: Intl.DateTimeFormatOptions = DEFAULT_DATE_OPTS,
+): string => {
+  const d = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(d.getTime())) return String(value);
+  return new Intl.DateTimeFormat(intlLocale(locale), opts).format(d);
+};
+
+/**
+ * Format a number for the active locale.
+ *
+ * `en-IN`/`hi-IN` give Indian digit grouping (1,00,000) but keep **Latin
+ * numerals** for both locales — a deliberate product decision for K-12 counts.
+ * Do NOT "fix" this to Devanagari digits; Hindi-medium teachers and students
+ * read scores and counts in Latin numerals.
+ */
+export const formatNumber = (
+  value: number,
+  locale: Locale,
+  opts?: Intl.NumberFormatOptions,
+): string => {
+  if (!Number.isFinite(value)) return String(value);
+  return new Intl.NumberFormat(intlLocale(locale), opts).format(value);
+};
+
+export interface BoundFormat {
+  formatDate: (value: string | number | Date, opts?: Intl.DateTimeFormatOptions) => string;
+  formatNumber: (value: number, opts?: Intl.NumberFormatOptions) => string;
+}
+
+/**
+ * Hook returning `formatDate`/`formatNumber` already bound to the active locale,
+ * mirroring `useT()`:
+ *
+ *   const { formatDate } = useFormat();
+ *   <span>{formatDate(assignment.due_date)}</span>
+ */
+export const useFormat = (): BoundFormat => {
+  const { locale } = useI18n();
+  return {
+    formatDate: (value, opts) => formatDate(value, locale, opts),
+    formatNumber: (value, opts) => formatNumber(value, locale, opts),
+  };
+};

--- a/frontend_modern/src/shared/i18n/index.ts
+++ b/frontend_modern/src/shared/i18n/index.ts
@@ -2,5 +2,7 @@ export { I18nProvider } from './I18nProvider';
 export { useI18n, resolveInitialLocale, LOCALE_STORAGE_KEY } from './i18nContext';
 export type { Locale, Translate, TranslateVars } from './i18nContext';
 export { useT } from './useT';
+export { formatDate, formatNumber, useFormat } from './format';
+export type { BoundFormat } from './format';
 export { LanguageSwitcher } from './LanguageSwitcher';
 export type { LocaleKey, LocaleDict } from './locales/en';


### PR DESCRIPTION
## Classification
**Improve / foundation-hardening** — Language Access initiative, **LA-8**.

## What & why
Adds a single `Intl`-backed `formatDate`/`formatNumber`/`useFormat` helper in `shared/i18n` so every surface formats absolute dates and counts the same way for the active locale, instead of each screen reinventing `toLocaleDateString` (often with a `undefined`/browser-default locale). This is the foundation half LA-6a–d were meant to consume; it was skipped last run and is shipped now so LA-6e date surfaces (versions, snapshots, due-date chips) can render "27 मई 2026" through one helper.

- `formatDate(value, locale, opts?)` — medium day-first default ("27 May 2026" / "27 मई 2026"); invalid input returned verbatim (never throws).
- `formatNumber(value, locale, opts?)` — Indian grouping, **Latin numerals** for both locales (deliberate product decision for K-12 counts — do not "fix" to Devanagari).
- `useFormat()` hook binds both to the active locale, mirroring `useT()`.
- Swapped `CreateAssignmentPage.formatDueDate` (was `toLocaleDateString(undefined, …)` → English dates for Hindi teachers) to route through the helper.

## Legacy reference
None — legacy Django had no `Intl` layer and no language preference. Pure improve.

## Bundle budget
`Intl` is built into the browser — entry chunk unchanged at **123 kB** (under the 160 kB budget). Relative dates still use the LA-3 date-fns `hi` locale.

## Tests
- New `format.test.ts` — 8 cases (en/hi medium date, `opts` override, invalid passthrough both locales, `Date` input, Indian grouping Latin-digit en+hi, non-finite passthrough).
- Full suite green: **58 files / 365 tests**. Lint + tsc clean. Build under budget.

## Translation review
No new locale-file keys in this PR (helper only; `CreateAssignmentPage` keys already existed).

## How to verify
Log in as a teacher, switch to हिं, open Create Assignment, pick a due date → the due-date copy renders the date in Hindi ("27 मई 2026") instead of English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)