### PR TITLE
feat(i18n): LA-6e-1 — authoring preview & edit-safety chrome in Hindi

### DIFF
--- a/docs/changes/2026-06-13-la6e1-authoring-preview-hindi.md
+++ b/docs/changes/2026-06-13-la6e1-authoring-preview-hindi.md
@@ -1,0 +1,53 @@
+# LA-6e-1 — authoring preview & edit-safety chrome in Hindi
+
+**Date:** 2026-06-13
+**Classification:** Improve
+**Initiative:** Language Access (2026-language-access.md) — LA-6e
+
+## Summary
+
+Localized four teacher authoring-safety surfaces that were still hardcoded
+English: the assignment **snapshot preview**, the **re-sync modal**, the
+**edit-safety banner**, and the **problem-set preview page**. Chrome strings only
+— authored content, student responses, AI/diff payloads, and the math rendering
+are untouched (Principle 1). After this, a Hindi-medium teacher previewing what
+students see, diffing a drifted assignment, or editing a live problem set stays
+in Hindi.
+
+## Legacy reference
+
+None — legacy Django 1.11 had no teacher i18n. Pure "improve".
+
+## What changed
+
+- **`EditSafetyBanner.tsx`** — replaced the free-text `noun="this question"` prop
+  with a typed `subject?: 'question' | 'problemSet'` so the headline is a proper
+  localized full sentence (English capitalization / Hindi word order both work).
+  Body copy now keys off `editSafety.body` / `editSafety.bodyGraded`. The inline
+  `<strong>future</strong>` emphasis was folded into the translated sentence (a
+  translated sentence can't carry mid-string markup cleanly across languages).
+- **`AssignmentSnapshotPreview.tsx`** — heading, frozen note, show/hide, drift
+  banner + compare link, update action, undo bar.
+- **`ResyncAssignmentModal.tsx`** — title/subtitle, load/no-drift/apply errors,
+  regrade note (singular/plural), apply-button states, and the `DiffSummary`
+  added/removed/answer/content lines (singular/plural keys).
+- **`ProblemSetPreviewPage.tsx`** — mode banner, edit/preview toggle, confirm
+  dialogs, header question-count (reuses `teacher.minutesApprox`), empty states,
+  per-question edit/remove, add-more block, footer buttons.
+- **Locale files** — ~55 new keys added to both `en.ts` and `hi.ts` under LA-6e-1
+  sections. Glossary register: असाइनमेंट, समस्या सेट, स्नैपशॉट, संस्करण, प्रश्न.
+  Parity guard stays green.
+
+## Tests
+
+- Updated `EditSafetyBanner.test.tsx` to the new `subject` prop + a hi-render case.
+- Added a renders-in-Hindi case to `AssignmentSnapshotPreview.test.tsx`,
+  `ResyncAssignmentModal.test.tsx`, `ProblemSetPreviewPage.test.tsx` (wrap in
+  `<I18nProvider initialLocale="hi">`, `waitFor` the lazy Hindi dict, assert a
+  Glossary Hindi string).
+- Full suite green: 57 files / 361 tests. Lint + tsc clean. Build under budget.
+
+## Next steps
+
+LA-6e-2 (question bank, preview, record-response, widget gallery), LA-6e-3
+(versions + classroom code — uses LA-8 `formatDate`), LA-6e-4 (CreateQuestionPage).

--- a/frontend_modern/src/features/teacher/AssignmentSnapshotPreview.test.tsx
+++ b/frontend_modern/src/features/teacher/AssignmentSnapshotPreview.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi } from 'vitest';
+import { I18nProvider } from '@/shared/i18n';
 import { AssignmentSnapshotPreview } from './AssignmentSnapshotPreview';
 import type { ProblemSetWithQuestions } from '@/types/index';
 
@@ -25,7 +26,9 @@ vi.mock('./ResyncAssignmentModal', () => ({
 }));
 
 const renderPreview = (
-  overrides: Partial<{ drift: boolean; hasResyncHistory: boolean }> & { questions?: unknown[] } = {},
+  overrides: Partial<{ drift: boolean; hasResyncHistory: boolean; locale: 'en' | 'hi' }> & {
+    questions?: unknown[];
+  } = {},
 ) => {
   const problemSet = {
     id: 9,
@@ -41,15 +44,18 @@ const renderPreview = (
     source_assignment: null,
     questions: overrides.questions ?? [{ id: 101, subparts: [{ question_text: 'Frozen prompt' }] }],
   } as unknown as ProblemSetWithQuestions;
+  const locale = overrides.locale ?? 'en';
   return render(
-    <MemoryRouter>
-      <AssignmentSnapshotPreview
-        assignmentId={7}
-        problemSet={problemSet}
-        snapshotDrift={overrides.drift ?? false}
-        hasResyncHistory={overrides.hasResyncHistory ?? false}
-      />
-    </MemoryRouter>,
+    <I18nProvider initialLocale={locale}>
+      <MemoryRouter>
+        <AssignmentSnapshotPreview
+          assignmentId={7}
+          problemSet={problemSet}
+          snapshotDrift={overrides.drift ?? false}
+          hasResyncHistory={overrides.hasResyncHistory ?? false}
+        />
+      </MemoryRouter>
+    </I18nProvider>,
   );
 };
 
@@ -101,5 +107,13 @@ describe('<AssignmentSnapshotPreview />', () => {
     renderPreview({ questions: [] });
     fireEvent.click(screen.getByTestId('snapshot-toggle'));
     expect(screen.getByText(/snapshot is empty/i)).toBeInTheDocument();
+  });
+
+  it('renders the drift banner in Hindi when the locale is हिं', async () => {
+    renderPreview({ drift: true, locale: 'hi' });
+    // लाइव सेट = "live set" per the Glossary register.
+    await waitFor(() => {
+      expect(screen.getByTestId('snapshot-drift-banner')).toHaveTextContent(/लाइव सेट/);
+    });
   });
 });

--- a/frontend_modern/src/features/teacher/AssignmentSnapshotPreview.tsx
+++ b/frontend_modern/src/features/teacher/AssignmentSnapshotPreview.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useT } from '@/shared/i18n';
 import { QuestionCard } from '../student/QuestionCard';
 import { ResyncAssignmentModal } from './ResyncAssignmentModal';
 import { useUndoResync } from './useAssignmentResync';
@@ -36,6 +37,7 @@ export function AssignmentSnapshotPreview({
   snapshotDrift,
   hasResyncHistory = false,
 }: Props) {
+  const t = useT();
   const [open, setOpen] = useState(false);
   const [resyncOpen, setResyncOpen] = useState(false);
   const undo = useUndoResync(assignmentId);
@@ -51,14 +53,14 @@ export function AssignmentSnapshotPreview({
       >
         <div>
           <h2 className="font-display text-base font-semibold text-ink-900">
-            What students see · snapshot
+            {t('snapshot.heading')}
           </h2>
           <p className="mt-0.5 text-xs text-ink-400">
-            Frozen at assign time — editing the set later doesn't change this view.
+            {t('snapshot.frozenNote')}
           </p>
         </div>
         <span className="text-sm font-medium text-brand-700">
-          {open ? 'Hide' : 'Show'}
+          {open ? t('snapshot.hide') : t('snapshot.show')}
         </span>
       </button>
 
@@ -68,15 +70,14 @@ export function AssignmentSnapshotPreview({
           data-testid="snapshot-drift-banner"
           className="border-b border-amber-200 bg-amber-50 px-6 py-3 text-sm text-amber-900"
         >
-          <p className="font-semibold">The live set has changed since this assignment was given.</p>
+          <p className="font-semibold">{t('snapshot.driftTitle')}</p>
           <p className="mt-0.5 text-amber-800">
-            What students see and how this assignment grades come from the frozen snapshot above —
-            newer assignments will use the updated set.{' '}
+            {t('snapshot.driftBody')}{' '}
             <Link
               to={`/teacher/problem-sets/${problemSet.id}/preview`}
               className="font-semibold underline hover:text-amber-950"
             >
-              Compare with the live set
+              {t('snapshot.driftCompareLink')}
             </Link>
             .
           </p>
@@ -87,10 +88,10 @@ export function AssignmentSnapshotPreview({
               data-testid="open-resync-modal"
               className="rounded-md bg-amber-200/80 px-3 py-1 text-xs font-semibold text-amber-950 hover:bg-amber-200"
             >
-              Update this assignment…
+              {t('snapshot.updateThis')}
             </button>
             <span className="text-xs text-amber-800">
-              We'll show what changes before anything is applied.
+              {t('snapshot.previewBeforeApply')}
             </span>
           </div>
         </div>
@@ -101,7 +102,7 @@ export function AssignmentSnapshotPreview({
           data-testid="undo-resync-bar"
           className="flex flex-wrap items-center justify-between gap-2 border-b border-ink-100 bg-ink-50/60 px-6 py-2 text-xs text-ink-600"
         >
-          <span>This assignment was updated; an earlier snapshot is kept in history.</span>
+          <span>{t('snapshot.historyNote')}</span>
           <button
             type="button"
             onClick={() => undo.mutate()}
@@ -109,7 +110,7 @@ export function AssignmentSnapshotPreview({
             data-testid="undo-resync"
             className="rounded-md border border-ink-200 bg-white px-2 py-1 font-medium text-ink-700 hover:bg-ink-100 disabled:opacity-50"
           >
-            {undo.isPending ? 'Undoing…' : 'Undo last update'}
+            {undo.isPending ? t('snapshot.undoing') : t('snapshot.undoLast')}
           </button>
         </div>
       )}
@@ -118,7 +119,7 @@ export function AssignmentSnapshotPreview({
         <div className="space-y-4 bg-paper px-6 py-5">
           {questions.length === 0 ? (
             <p className="text-sm italic text-ink-400">
-              This assignment's snapshot is empty.
+              {t('snapshot.empty')}
             </p>
           ) : (
             questions.map((q, i) => (

--- a/frontend_modern/src/features/teacher/CreateQuestionPage.tsx
+++ b/frontend_modern/src/features/teacher/CreateQuestionPage.tsx
@@ -737,7 +737,7 @@ export const CreateQuestionPage = ({ editMode = false }: { editMode?: boolean })
           <EditSafetyBanner
             assignedCount={existingQuestion.assigned_count ?? 0}
             hasGradedSubmissions={existingQuestion.has_graded_submissions ?? false}
-            noun="this question"
+            subject="question"
           />
         )}
 

--- a/frontend_modern/src/features/teacher/EditSafetyBanner.test.tsx
+++ b/frontend_modern/src/features/teacher/EditSafetyBanner.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
+import { I18nProvider } from '@/shared/i18n';
 import { EditSafetyBanner } from './EditSafetyBanner';
 
 describe('<EditSafetyBanner />', () => {
@@ -15,7 +16,7 @@ describe('<EditSafetyBanner />', () => {
       <EditSafetyBanner
         assignedCount={1}
         hasGradedSubmissions={false}
-        noun="this question"
+        subject="question"
       />,
     );
     expect(screen.getByTestId('edit-safety-banner')).toBeInTheDocument();
@@ -29,13 +30,26 @@ describe('<EditSafetyBanner />', () => {
       <EditSafetyBanner
         assignedCount={3}
         hasGradedSubmissions
-        noun="this problem set"
+        subject="problemSet"
       />,
     );
     expect(screen.getByText(/used in 3 assignments\./i)).toBeInTheDocument();
     expect(screen.getByText(/graded against/i)).toBeInTheDocument();
     // First letter of the noun is capitalised in the headline.
     expect(screen.getByText(/^This problem set/)).toBeInTheDocument();
+  });
+
+  it('renders the Hindi headline when the locale is हिं', async () => {
+    render(
+      <I18nProvider initialLocale="hi">
+        <EditSafetyBanner assignedCount={2} hasGradedSubmissions={false} subject="problemSet" />
+      </I18nProvider>,
+    );
+    // Hindi dict loads via dynamic import — strings swap once it arrives.
+    // समस्या सेट = "problem set" per the Glossary register.
+    await waitFor(() => {
+      expect(screen.getByText(/समस्या सेट/)).toBeInTheDocument();
+    });
   });
 
   it('never disables anything (informational only)', () => {

--- a/frontend_modern/src/features/teacher/EditSafetyBanner.tsx
+++ b/frontend_modern/src/features/teacher/EditSafetyBanner.tsx
@@ -8,22 +8,32 @@
  * a graded submission exists, because that's the case where the silent-edit
  * surprise was historically worst.
  */
+import { useT } from '@/shared/i18n';
+
 interface EditSafetyBannerProps {
   assignedCount: number;
   hasGradedSubmissions: boolean;
-  /** "this question" or "this problem set". */
-  noun?: string;
+  /** Which thing is being edited — drives the localized headline noun. */
+  subject?: 'question' | 'problemSet';
 }
 
 export function EditSafetyBanner({
   assignedCount,
   hasGradedSubmissions,
-  noun = 'this question',
+  subject = 'question',
 }: EditSafetyBannerProps) {
+  const t = useT();
   if (!assignedCount || assignedCount <= 0) return null;
 
-  const countLabel =
-    assignedCount === 1 ? '1 assignment' : `${assignedCount} assignments`;
+  const single = assignedCount === 1;
+  const headlineKey =
+    subject === 'problemSet'
+      ? single
+        ? 'editSafety.usedSetOne'
+        : 'editSafety.usedSetMany'
+      : single
+        ? 'editSafety.usedQuestionOne'
+        : 'editSafety.usedQuestionMany';
 
   return (
     <div
@@ -31,22 +41,9 @@ export function EditSafetyBanner({
       className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
       data-testid="edit-safety-banner"
     >
-      <p className="font-semibold">
-        {noun.charAt(0).toUpperCase() + noun.slice(1)} is used in {countLabel}.
-      </p>
+      <p className="font-semibold">{t(headlineKey, { count: assignedCount })}</p>
       <p className="mt-1 text-amber-800">
-        {hasGradedSubmissions ? (
-          <>
-            Your edits apply to <strong>future</strong> assignments only —
-            existing ones keep exactly what students were given and were graded
-            against.
-          </>
-        ) : (
-          <>
-            Your edits apply to <strong>future</strong> assignments only —
-            existing ones keep exactly what students were given.
-          </>
-        )}
+        {t(hasGradedSubmissions ? 'editSafety.bodyGraded' : 'editSafety.body')}
       </p>
     </div>
   );

--- a/frontend_modern/src/features/teacher/ProblemSetPreviewPage.test.tsx
+++ b/frontend_modern/src/features/teacher/ProblemSetPreviewPage.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { I18nProvider } from '@/shared/i18n';
 import { ProblemSetPreviewPage } from './ProblemSetPreviewPage';
 
 const mockPreview = vi.fn();
@@ -22,18 +23,20 @@ vi.mock('../student/QuestionCard', () => ({
   ),
 }));
 
-const renderAt = () => {
+const renderAt = (locale: 'en' | 'hi' = 'en') => {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>
-      <MemoryRouter initialEntries={['/teacher/problem-sets/7/preview']}>
-        <Routes>
-          <Route
-            path="/teacher/problem-sets/:id/preview"
-            element={<ProblemSetPreviewPage />}
-          />
-        </Routes>
-      </MemoryRouter>
+      <I18nProvider initialLocale={locale}>
+        <MemoryRouter initialEntries={['/teacher/problem-sets/7/preview']}>
+          <Routes>
+            <Route
+              path="/teacher/problem-sets/:id/preview"
+              element={<ProblemSetPreviewPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </I18nProvider>
     </QueryClientProvider>,
   );
 };
@@ -108,6 +111,19 @@ describe('<ProblemSetPreviewPage />', () => {
     expect(screen.getByTestId('edit-safety-banner')).toBeInTheDocument();
     expect(screen.getByText(/used in 3 assignments\./i)).toBeInTheDocument();
     expect(screen.getByText(/graded against/i)).toBeInTheDocument();
+  });
+
+  it('renders the read-only banner in Hindi when the locale is हिं', async () => {
+    mockPreview.mockReturnValue({
+      data: { ...baseData, created_by_me: false, assigned_count: 0, has_graded_submissions: false },
+      isLoading: false,
+      isError: false,
+    });
+    renderAt('hi');
+    // विद्यार्थी प्रीव्यू = "Student preview" per the Glossary register.
+    await waitFor(() => {
+      expect(screen.getByText(/विद्यार्थी प्रीव्यू/)).toBeInTheDocument();
+    });
   });
 
   it('does not call the mutation when the confirm dialog is dismissed', () => {

--- a/frontend_modern/src/features/teacher/ProblemSetPreviewPage.tsx
+++ b/frontend_modern/src/features/teacher/ProblemSetPreviewPage.tsx
@@ -4,6 +4,7 @@ import { useProblemSetPreview } from './useProblemSetPreview';
 import { useRemoveQuestionFromProblemSet } from './useRemoveQuestionFromProblemSet';
 import { QuestionCard } from '../student/QuestionCard';
 import { Button, EmptyState, LoadingSpinner } from '@/shared/ui';
+import { useT } from '@/shared/i18n';
 import { EditSafetyBanner } from './EditSafetyBanner';
 
 /**
@@ -21,6 +22,7 @@ import { EditSafetyBanner } from './EditSafetyBanner';
  * time, so existing assignments keep exactly what students were given.
  */
 export const ProblemSetPreviewPage = () => {
+  const t = useT();
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const setId = id ? Number(id) : null;
@@ -40,9 +42,9 @@ export const ProblemSetPreviewPage = () => {
     return (
       <div className="mx-auto max-w-2xl px-4 py-10">
         <EmptyState
-          title="Couldn't load this preview"
-          description="The problem set may have been removed, or you may not have access to it."
-          action={<Button onClick={() => navigate('/teacher')}>Back to dashboard</Button>}
+          title={t('psPreview.loadErrorTitle')}
+          description={t('psPreview.loadErrorDesc')}
+          action={<Button onClick={() => navigate('/teacher')}>{t('psPreview.backToDashboard')}</Button>}
         />
       </div>
     );
@@ -62,8 +64,8 @@ export const ProblemSetPreviewPage = () => {
     if (
       !window.confirm(
         assignedCount > 0
-          ? 'Remove this question from the live set?\n\nExisting assignments keep it — they grade and render the frozen copy.'
-          : 'Remove this question from the set?',
+          ? t('psPreview.confirmRemoveAssigned')
+          : t('psPreview.confirmRemove'),
       )
     ) {
       return;
@@ -96,14 +98,12 @@ export const ProblemSetPreviewPage = () => {
               isEditing ? 'text-amber-900' : 'text-brand-900'
             }`}
           >
-            {isEditing ? 'Editing set · live changes' : 'Student preview · read-only'}
+            {isEditing ? t('psPreview.editingTitle') : t('psPreview.readOnlyTitle')}
           </p>
           <p
             className={`text-xs ${isEditing ? 'text-amber-800' : 'text-brand-700'}`}
           >
-            {isEditing
-              ? 'Changes apply to future assignments only — existing ones keep what students were given.'
-              : "This is exactly how students see the set — answers hidden, variables filled in. You can't type or submit here."}
+            {isEditing ? t('psPreview.editingBody') : t('psPreview.readOnlyBody')}
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-2">
@@ -114,7 +114,7 @@ export const ProblemSetPreviewPage = () => {
               data-testid="toggle-edit"
               className="rounded-md border border-ink-200 bg-white px-3 py-1.5 text-xs font-medium text-ink-700 hover:bg-ink-50"
             >
-              {isEditing ? 'Done editing' : 'Edit set'}
+              {isEditing ? t('psPreview.doneEditing') : t('psPreview.editSet')}
             </button>
           )}
           <button
@@ -124,7 +124,7 @@ export const ProblemSetPreviewPage = () => {
               isEditing ? 'text-amber-800 hover:text-amber-900' : 'text-brand-700 hover:text-brand-900'
             }`}
           >
-            ← Back
+            {t('psPreview.back')}
           </button>
         </div>
       </div>
@@ -134,7 +134,7 @@ export const ProblemSetPreviewPage = () => {
         <EditSafetyBanner
           assignedCount={assignedCount}
           hasGradedSubmissions={hasGraded}
-          noun="this problem set"
+          subject="problemSet"
         />
       )}
 
@@ -144,20 +144,23 @@ export const ProblemSetPreviewPage = () => {
         <p className="mt-1 text-sm text-ink-500">
           {data.subject_name && <span>{data.subject_name}</span>}
           {data.chapter_name && <span> · {data.chapter_name}</span>}
-          <span> · {data.question_count} question{data.question_count !== 1 ? 's' : ''}</span>
-          {data.estimated_minutes != null && <span> · ~{data.estimated_minutes} min</span>}
+          <span>
+            {' · '}
+            {t(data.question_count === 1 ? 'psPreview.questionsOne' : 'psPreview.questionsMany', {
+              count: data.question_count,
+            })}
+          </span>
+          {data.estimated_minutes != null && (
+            <span> · {t('teacher.minutesApprox', { minutes: data.estimated_minutes })}</span>
+          )}
         </p>
       </div>
 
       {/* Questions — rendered exactly as a student sees them, locked */}
       {data.questions.length === 0 ? (
         <EmptyState
-          title="This set has no questions yet"
-          description={
-            isEditing
-              ? 'Use the Add question button below to start filling it in.'
-              : 'Add questions to the set, then preview again.'
-          }
+          title={t('psPreview.emptyTitle')}
+          description={isEditing ? t('psPreview.emptyEditingDesc') : t('psPreview.emptyDesc')}
         />
       ) : (
         <div className="space-y-4">
@@ -181,7 +184,7 @@ export const ProblemSetPreviewPage = () => {
                     }
                     className="rounded-md border border-ink-200 bg-white px-3 py-1.5 text-xs font-medium text-ink-700 hover:bg-ink-50"
                   >
-                    Edit question
+                    {t('psPreview.editQuestion')}
                   </button>
                   <button
                     type="button"
@@ -190,7 +193,7 @@ export const ProblemSetPreviewPage = () => {
                     onClick={() => handleRemove(q.id)}
                     className="rounded-md border border-red-200 bg-white px-3 py-1.5 text-xs font-medium text-red-700 hover:bg-red-50 disabled:opacity-50"
                   >
-                    Remove from set
+                    {t('psPreview.removeFromSet')}
                   </button>
                 </div>
               )}
@@ -202,13 +205,13 @@ export const ProblemSetPreviewPage = () => {
       {isEditing && (
         <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-dashed border-ink-200 bg-paper px-4 py-3">
           <div>
-            <p className="text-sm font-semibold text-ink-800">Add more questions</p>
+            <p className="text-sm font-semibold text-ink-800">{t('psPreview.addMoreTitle')}</p>
             <p className="text-xs text-ink-500">
-              Pick from the question bank, or author a new question — you'll come back here when done.
+              {t('psPreview.addMoreDesc')}
             </p>
           </div>
           <Button onClick={() => navigate(addPath)} variant="brand">
-            Add question
+            {t('psPreview.addQuestion')}
           </Button>
         </div>
       )}
@@ -219,10 +222,10 @@ export const ProblemSetPreviewPage = () => {
           onClick={() => setId != null && navigate(`/teacher/problem-sets/${setId}/versions`)}
           data-testid="view-versions"
         >
-          View version history
+          {t('psPreview.viewVersions')}
         </Button>
         <Button variant="ghost" onClick={() => navigate('/teacher')}>
-          Back to dashboard
+          {t('psPreview.backToDashboard')}
         </Button>
       </div>
     </div>

--- a/frontend_modern/src/features/teacher/ResyncAssignmentModal.test.tsx
+++ b/frontend_modern/src/features/teacher/ResyncAssignmentModal.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { I18nProvider } from '@/shared/i18n';
 import { ResyncAssignmentModal } from './ResyncAssignmentModal';
 import type { ResyncPreview } from './useAssignmentResync';
 
@@ -83,6 +84,23 @@ describe('<ResyncAssignmentModal />', () => {
     expect(summary).toHaveTextContent(/1 answer changed/i);
     expect(screen.getByTestId('resync-regrade-note')).toHaveTextContent(/3 graded submissions/i);
     expect(screen.getByTestId('resync-apply')).toHaveTextContent(/Update and re-grade 3/);
+  });
+
+  it('renders the title in Hindi when the locale is हिं', async () => {
+    mockPreview.mockReturnValue({
+      data: { ...drift({}), has_drift: false },
+      isLoading: false,
+      isError: false,
+    });
+    render(
+      <I18nProvider initialLocale="hi">
+        <ResyncAssignmentModal assignmentId={7} open onClose={() => {}} />
+      </I18nProvider>,
+    );
+    // असाइनमेंट = "assignment" per the Glossary register.
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /असाइनमेंट/ })).toBeInTheDocument();
+    });
   });
 
   it('calls the apply mutation and closes when confirmed', async () => {

--- a/frontend_modern/src/features/teacher/ResyncAssignmentModal.tsx
+++ b/frontend_modern/src/features/teacher/ResyncAssignmentModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { LoadingSpinner } from '@/shared/ui';
+import { useT } from '@/shared/i18n';
 import { useResyncPreview, useApplyResync } from './useAssignmentResync';
 
 interface Props {
@@ -20,6 +21,7 @@ interface Props {
  * source of truth until they click Apply.
  */
 export function ResyncAssignmentModal({ assignmentId, open, onClose, onApplied }: Props) {
+  const t = useT();
   const preview = useResyncPreview(assignmentId, open);
   const apply = useApplyResync(assignmentId);
 
@@ -61,10 +63,10 @@ export function ResyncAssignmentModal({ assignmentId, open, onClose, onApplied }
       <div className="w-full max-w-lg overflow-hidden rounded-xl bg-paper shadow-lift">
         <div className="border-b border-ink-100 px-6 py-4">
           <h2 id="resync-title" className="font-display text-lg font-semibold text-ink-900">
-            Update this assignment to the latest content?
+            {t('resync.title')}
           </h2>
           <p className="mt-1 text-xs text-ink-500">
-            Re-snapshots from the live set. Reversible from this page.
+            {t('resync.subtitle')}
           </p>
         </div>
 
@@ -74,10 +76,10 @@ export function ResyncAssignmentModal({ assignmentId, open, onClose, onApplied }
               <LoadingSpinner size="md" />
             </div>
           ) : preview.isError || !preview.data ? (
-            <p className="text-sm text-red-700">Couldn't load the preview. Try again.</p>
+            <p className="text-sm text-red-700">{t('resync.loadError')}</p>
           ) : !hasDrift ? (
             <p className="text-sm text-ink-600">
-              The snapshot already matches the live set — there's nothing to re-sync.
+              {t('resync.noDrift')}
             </p>
           ) : (
             <>
@@ -90,20 +92,16 @@ export function ResyncAssignmentModal({ assignmentId, open, onClose, onApplied }
                 }`}
                 data-testid="resync-regrade-note"
               >
-                {regradeCount > 0 ? (
-                  <>
-                    <strong>{regradeCount}</strong> graded submission{regradeCount === 1 ? '' : 's'}{' '}
-                    will be <strong>re-graded</strong> against the new answer key. Some students may
-                    end up with different scores.
-                  </>
-                ) : (
-                  <>No graded submissions will be re-graded — only what students see is changing.</>
-                )}
+                {regradeCount > 0
+                  ? t(regradeCount === 1 ? 'resync.regradeOne' : 'resync.regradeMany', {
+                      count: regradeCount,
+                    })
+                  : t('resync.noRegrade')}
               </div>
             </>
           )}
           {apply.isError && (
-            <p className="text-sm text-red-700">The re-sync failed. Try again.</p>
+            <p className="text-sm text-red-700">{t('resync.applyError')}</p>
           )}
         </div>
 
@@ -113,7 +111,7 @@ export function ResyncAssignmentModal({ assignmentId, open, onClose, onApplied }
             onClick={onClose}
             className="rounded-md border border-ink-200 bg-white px-3 py-1.5 text-sm font-medium text-ink-700 hover:bg-ink-50"
           >
-            Cancel
+            {t('common.cancel')}
           </button>
           <button
             type="button"
@@ -123,10 +121,10 @@ export function ResyncAssignmentModal({ assignmentId, open, onClose, onApplied }
             className="rounded-md bg-brand-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-brand-700 disabled:opacity-50"
           >
             {apply.isPending
-              ? 'Updating…'
+              ? t('resync.updating')
               : regradeCount > 0
-                ? `Update and re-grade ${regradeCount}`
-                : 'Update assignment'}
+                ? t('resync.updateAndRegrade', { count: regradeCount })
+                : t('resync.updateAssignment')}
           </button>
         </div>
       </div>
@@ -139,16 +137,31 @@ function DiffSummary({
 }: {
   diff: NonNullable<ReturnType<typeof useResyncPreview>['data']>['diff'];
 }) {
+  const t = useT();
   const lines: string[] = [];
   if (diff.questions_added.length)
-    lines.push(`${diff.questions_added.length} question${diff.questions_added.length === 1 ? '' : 's'} added`);
+    lines.push(
+      t(diff.questions_added.length === 1 ? 'resync.diffAddedOne' : 'resync.diffAddedMany', {
+        count: diff.questions_added.length,
+      }),
+    );
   if (diff.questions_removed.length)
-    lines.push(`${diff.questions_removed.length} question${diff.questions_removed.length === 1 ? '' : 's'} removed`);
+    lines.push(
+      t(diff.questions_removed.length === 1 ? 'resync.diffRemovedOne' : 'resync.diffRemovedMany', {
+        count: diff.questions_removed.length,
+      }),
+    );
   if (diff.answer_changes.length)
-    lines.push(`${diff.answer_changes.length} answer${diff.answer_changes.length === 1 ? '' : 's'} changed`);
+    lines.push(
+      t(diff.answer_changes.length === 1 ? 'resync.diffAnswerOne' : 'resync.diffAnswerMany', {
+        count: diff.answer_changes.length,
+      }),
+    );
   if (diff.content_changes.length)
     lines.push(
-      `${diff.content_changes.length} other content edit${diff.content_changes.length === 1 ? '' : 's'} (prompts, options, widgets)`,
+      t(diff.content_changes.length === 1 ? 'resync.diffContentOne' : 'resync.diffContentMany', {
+        count: diff.content_changes.length,
+      }),
     );
   if (!lines.length) return null;
   return (

--- a/frontend_modern/src/shared/i18n/locales/en.ts
+++ b/frontend_modern/src/shared/i18n/locales/en.ts
@@ -557,6 +557,85 @@ export const en = {
   'grading.emptyDesc':
     'Record a student’s open-ended answer and AI will suggest a grade for your review.',
 
+  // ── LA-6e-1: edit-safety banner ──────────────────────────────────────
+  'editSafety.usedQuestionOne': 'This question is used in 1 assignment.',
+  'editSafety.usedQuestionMany': 'This question is used in {count} assignments.',
+  'editSafety.usedSetOne': 'This problem set is used in 1 assignment.',
+  'editSafety.usedSetMany': 'This problem set is used in {count} assignments.',
+  'editSafety.body':
+    'Your edits apply to future assignments only — existing ones keep exactly what students were given.',
+  'editSafety.bodyGraded':
+    'Your edits apply to future assignments only — existing ones keep exactly what students were given and were graded against.',
+
+  // ── LA-6e-1: assignment snapshot preview ─────────────────────────────
+  'snapshot.heading': 'What students see · snapshot',
+  'snapshot.frozenNote': "Frozen at assign time — editing the set later doesn't change this view.",
+  'snapshot.hide': 'Hide',
+  'snapshot.show': 'Show',
+  'snapshot.driftTitle': 'The live set has changed since this assignment was given.',
+  'snapshot.driftBody':
+    'What students see and how this assignment grades come from the frozen snapshot above — newer assignments will use the updated set.',
+  'snapshot.driftCompareLink': 'Compare with the live set',
+  'snapshot.updateThis': 'Update this assignment…',
+  'snapshot.previewBeforeApply': "We'll show what changes before anything is applied.",
+  'snapshot.historyNote': 'This assignment was updated; an earlier snapshot is kept in history.',
+  'snapshot.undoLast': 'Undo last update',
+  'snapshot.undoing': 'Undoing…',
+  'snapshot.empty': "This assignment's snapshot is empty.",
+
+  // ── LA-6e-1: re-sync assignment modal ────────────────────────────────
+  'resync.title': 'Update this assignment to the latest content?',
+  'resync.subtitle': 'Re-snapshots from the live set. Reversible from this page.',
+  'resync.loadError': "Couldn't load the preview. Try again.",
+  'resync.noDrift': "The snapshot already matches the live set — there's nothing to re-sync.",
+  'resync.regradeOne':
+    '{count} graded submission will be re-graded against the new answer key. Some students may end up with different scores.',
+  'resync.regradeMany':
+    '{count} graded submissions will be re-graded against the new answer key. Some students may end up with different scores.',
+  'resync.noRegrade': 'No graded submissions will be re-graded — only what students see is changing.',
+  'resync.applyError': 'The re-sync failed. Try again.',
+  'resync.updating': 'Updating…',
+  'resync.updateAndRegrade': 'Update and re-grade {count}',
+  'resync.updateAssignment': 'Update assignment',
+  'resync.diffAddedOne': '{count} question added',
+  'resync.diffAddedMany': '{count} questions added',
+  'resync.diffRemovedOne': '{count} question removed',
+  'resync.diffRemovedMany': '{count} questions removed',
+  'resync.diffAnswerOne': '{count} answer changed',
+  'resync.diffAnswerMany': '{count} answers changed',
+  'resync.diffContentOne': '{count} other content edit (prompts, options, widgets)',
+  'resync.diffContentMany': '{count} other content edits (prompts, options, widgets)',
+
+  // ── LA-6e-1: problem-set preview page ────────────────────────────────
+  'psPreview.loadErrorTitle': "Couldn't load this preview",
+  'psPreview.loadErrorDesc':
+    'The problem set may have been removed, or you may not have access to it.',
+  'psPreview.backToDashboard': 'Back to dashboard',
+  'psPreview.confirmRemoveAssigned':
+    'Remove this question from the live set?\n\nExisting assignments keep it — they grade and render the frozen copy.',
+  'psPreview.confirmRemove': 'Remove this question from the set?',
+  'psPreview.editingTitle': 'Editing set · live changes',
+  'psPreview.readOnlyTitle': 'Student preview · read-only',
+  'psPreview.editingBody':
+    'Changes apply to future assignments only — existing ones keep what students were given.',
+  'psPreview.readOnlyBody':
+    "This is exactly how students see the set — answers hidden, variables filled in. You can't type or submit here.",
+  'psPreview.doneEditing': 'Done editing',
+  'psPreview.editSet': 'Edit set',
+  'psPreview.back': '← Back',
+  'psPreview.questionsOne': '{count} question',
+  'psPreview.questionsMany': '{count} questions',
+  'psPreview.emptyTitle': 'This set has no questions yet',
+  'psPreview.emptyEditingDesc': 'Use the Add question button below to start filling it in.',
+  'psPreview.emptyDesc': 'Add questions to the set, then preview again.',
+  'psPreview.editQuestion': 'Edit question',
+  'psPreview.removeFromSet': 'Remove from set',
+  'psPreview.addMoreTitle': 'Add more questions',
+  'psPreview.addMoreDesc':
+    "Pick from the question bank, or author a new question — you'll come back here when done.",
+  'psPreview.addQuestion': 'Add question',
+  'psPreview.viewVersions': 'View version history',
+
   // ── Streak badge ─────────────────────────────────────────────────────
   'streak.days': '{count}-day streak',
   'streak.tierStarter': 'On Fire',

--- a/frontend_modern/src/shared/i18n/locales/hi.ts
+++ b/frontend_modern/src/shared/i18n/locales/hi.ts
@@ -553,6 +553,84 @@ export const hi: LocaleDict = {
   'grading.emptyDesc':
     'किसी विद्यार्थी का मुक्त उत्तर दर्ज करें और AI आपकी समीक्षा के लिए एक अंक सुझाएगा।',
 
+  // ── LA-6e-1: edit-safety banner ──────────────────────────────────────
+  'editSafety.usedQuestionOne': 'यह प्रश्न 1 असाइनमेंट में इस्तेमाल हो रहा है।',
+  'editSafety.usedQuestionMany': 'यह प्रश्न {count} असाइनमेंट में इस्तेमाल हो रहा है।',
+  'editSafety.usedSetOne': 'यह समस्या सेट 1 असाइनमेंट में इस्तेमाल हो रहा है।',
+  'editSafety.usedSetMany': 'यह समस्या सेट {count} असाइनमेंट में इस्तेमाल हो रहा है।',
+  'editSafety.body':
+    'आपके बदलाव सिर्फ़ आने वाले असाइनमेंट पर लागू होंगे — मौजूदा असाइनमेंट में विद्यार्थियों को जो दिया गया था वही बना रहेगा।',
+  'editSafety.bodyGraded':
+    'आपके बदलाव सिर्फ़ आने वाले असाइनमेंट पर लागू होंगे — मौजूदा असाइनमेंट में विद्यार्थियों को जो दिया गया और जिस पर ग्रेडिंग हुई, वही बना रहेगा।',
+
+  // ── LA-6e-1: assignment snapshot preview ─────────────────────────────
+  'snapshot.heading': 'विद्यार्थी जो देखते हैं · स्नैपशॉट',
+  'snapshot.frozenNote': 'असाइन करते समय फ़्रीज़ किया गया — सेट को बाद में बदलने से यह व्यू नहीं बदलता।',
+  'snapshot.hide': 'छिपाएँ',
+  'snapshot.show': 'दिखाएँ',
+  'snapshot.driftTitle': 'यह असाइनमेंट देने के बाद से लाइव सेट बदल चुका है।',
+  'snapshot.driftBody':
+    'विद्यार्थी जो देखते हैं और यह असाइनमेंट कैसे ग्रेड होता है, यह ऊपर के फ़्रीज़ स्नैपशॉट से आता है — नए असाइनमेंट अपडेटेड सेट इस्तेमाल करेंगे।',
+  'snapshot.driftCompareLink': 'लाइव सेट से तुलना करें',
+  'snapshot.updateThis': 'यह असाइनमेंट अपडेट करें…',
+  'snapshot.previewBeforeApply': 'कुछ भी लागू करने से पहले हम दिखाएँगे कि क्या बदलेगा।',
+  'snapshot.historyNote': 'यह असाइनमेंट अपडेट हुआ था; एक पुराना स्नैपशॉट इतिहास में रखा गया है।',
+  'snapshot.undoLast': 'पिछला अपडेट पूर्ववत करें',
+  'snapshot.undoing': 'पूर्ववत किया जा रहा है…',
+  'snapshot.empty': 'इस असाइनमेंट का स्नैपशॉट खाली है।',
+
+  // ── LA-6e-1: re-sync assignment modal ────────────────────────────────
+  'resync.title': 'यह असाइनमेंट नई सामग्री पर अपडेट करें?',
+  'resync.subtitle': 'लाइव सेट से दोबारा स्नैपशॉट लेता है। इस पेज से वापस लाया जा सकता है।',
+  'resync.loadError': 'प्रीव्यू लोड नहीं हो सका। फिर कोशिश करें।',
+  'resync.noDrift': 'स्नैपशॉट पहले से लाइव सेट से मेल खाता है — दोबारा सिंक करने को कुछ नहीं है।',
+  'resync.regradeOne':
+    '{count} ग्रेड किया गया सबमिशन नई आंसर-की के अनुसार दोबारा ग्रेड होगा। कुछ विद्यार्थियों के अंक बदल सकते हैं।',
+  'resync.regradeMany':
+    '{count} ग्रेड किए गए सबमिशन नई आंसर-की के अनुसार दोबारा ग्रेड होंगे। कुछ विद्यार्थियों के अंक बदल सकते हैं।',
+  'resync.noRegrade': 'कोई ग्रेड किया गया सबमिशन दोबारा ग्रेड नहीं होगा — सिर्फ़ विद्यार्थी जो देखते हैं वही बदल रहा है।',
+  'resync.applyError': 'दोबारा सिंक विफल रहा। फिर कोशिश करें।',
+  'resync.updating': 'अपडेट हो रहा है…',
+  'resync.updateAndRegrade': 'अपडेट करें और {count} दोबारा ग्रेड करें',
+  'resync.updateAssignment': 'असाइनमेंट अपडेट करें',
+  'resync.diffAddedOne': '{count} प्रश्न जोड़ा गया',
+  'resync.diffAddedMany': '{count} प्रश्न जोड़े गए',
+  'resync.diffRemovedOne': '{count} प्रश्न हटाया गया',
+  'resync.diffRemovedMany': '{count} प्रश्न हटाए गए',
+  'resync.diffAnswerOne': '{count} उत्तर बदला गया',
+  'resync.diffAnswerMany': '{count} उत्तर बदले गए',
+  'resync.diffContentOne': '{count} अन्य सामग्री बदलाव (प्रॉम्प्ट, विकल्प, विजेट)',
+  'resync.diffContentMany': '{count} अन्य सामग्री बदलाव (प्रॉम्प्ट, विकल्प, विजेट)',
+
+  // ── LA-6e-1: problem-set preview page ────────────────────────────────
+  'psPreview.loadErrorTitle': 'यह प्रीव्यू लोड नहीं हो सका',
+  'psPreview.loadErrorDesc': 'हो सकता है यह समस्या सेट हटा दिया गया हो, या आपके पास इसकी पहुँच न हो।',
+  'psPreview.backToDashboard': 'डैशबोर्ड पर वापस',
+  'psPreview.confirmRemoveAssigned':
+    'इस प्रश्न को लाइव सेट से हटाएँ?\n\nमौजूदा असाइनमेंट इसे रखते हैं — वे फ़्रीज़ की गई कॉपी पर ग्रेड और रेंडर करते हैं।',
+  'psPreview.confirmRemove': 'इस प्रश्न को सेट से हटाएँ?',
+  'psPreview.editingTitle': 'सेट संपादित हो रहा है · लाइव बदलाव',
+  'psPreview.readOnlyTitle': 'विद्यार्थी प्रीव्यू · केवल पढ़ने के लिए',
+  'psPreview.editingBody':
+    'बदलाव सिर्फ़ आने वाले असाइनमेंट पर लागू होंगे — मौजूदा असाइनमेंट में विद्यार्थियों को जो दिया गया था वही बना रहेगा।',
+  'psPreview.readOnlyBody':
+    'विद्यार्थी सेट को ठीक ऐसे ही देखते हैं — उत्तर छिपे, चर भरे हुए। आप यहाँ टाइप या सबमिट नहीं कर सकते।',
+  'psPreview.doneEditing': 'संपादन पूरा',
+  'psPreview.editSet': 'सेट संपादित करें',
+  'psPreview.back': '← वापस',
+  'psPreview.questionsOne': '{count} प्रश्न',
+  'psPreview.questionsMany': '{count} प्रश्न',
+  'psPreview.emptyTitle': 'इस सेट में अभी कोई प्रश्न नहीं है',
+  'psPreview.emptyEditingDesc': 'इसे भरना शुरू करने के लिए नीचे "प्रश्न जोड़ें" बटन इस्तेमाल करें।',
+  'psPreview.emptyDesc': 'सेट में प्रश्न जोड़ें, फिर दोबारा प्रीव्यू करें।',
+  'psPreview.editQuestion': 'प्रश्न संपादित करें',
+  'psPreview.removeFromSet': 'सेट से हटाएँ',
+  'psPreview.addMoreTitle': 'और प्रश्न जोड़ें',
+  'psPreview.addMoreDesc':
+    'प्रश्न बैंक से चुनें, या नया प्रश्न बनाएँ — पूरा होने पर आप यहीं वापस आएँगे।',
+  'psPreview.addQuestion': 'प्रश्न जोड़ें',
+  'psPreview.viewVersions': 'संस्करण इतिहास देखें',
+
   // ── Streak badge ─────────────────────────────────────────────────────
   'streak.days': '{count} दिन की स्ट्रीक',
   'streak.tierStarter': 'जोश में',


### PR DESCRIPTION
## Classification
**Improve** — Language Access initiative, **LA-6e** (teacher surface remainder).

## What & why
Localizes four teacher authoring-safety surfaces that were still hardcoded English. Chrome strings only — authored content, student responses, AI/diff payloads, and math rendering untouched (Principle 1).

- **`EditSafetyBanner`** — replaces the free-text `noun="this question"` prop with a typed `subject: 'question' | 'problemSet'`, so the headline is a proper localized full sentence (English capitalization / Hindi word order both work). Inline `<strong>future</strong>` emphasis folded into the translated sentence.
- **`AssignmentSnapshotPreview`** — heading, frozen note, show/hide, drift banner + compare link, update action, undo bar.
- **`ResyncAssignmentModal`** — title/subtitle, errors, regrade note (sing/plural), apply-button states, `DiffSummary` lines (sing/plural).
- **`ProblemSetPreviewPage`** — mode banner, edit/preview toggle, confirm dialogs, header count, empty states, per-question edit/remove, footer buttons.

## Legacy reference
None — legacy Django had no teacher i18n. Pure improve.

## Tests
- `EditSafetyBanner.test.tsx` updated to the new `subject` prop + hi-render case.
- Added a renders-in-Hindi case to the other three surfaces (`<I18nProvider initialLocale="hi">`, `waitFor` the lazy Hindi dict, assert a Glossary string).
- Full suite green: **57 files / 361 tests**. Lint + tsc clean. Build under budget (entry 127 kB).

## Translation review — new Hindi strings
~55 keys under the LA-6e-1 sections of `hi.ts` (`editSafety.*`, `snapshot.*`, `resync.*`, `psPreview.*`). Glossary register: असाइनमेंट, समस्या सेट, स्नैपशॉट, संस्करण, प्रश्न, रूब्रिक-adjacent. Parity guard enforces key + `{var}` parity.

## How to verify
Log in as a teacher, switch to हिं → open a problem-set preview, toggle edit on an assigned set (edit-safety banner in Hindi), open an assignment with snapshot drift, click "Update this assignment…" → modal renders in Hindi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)