### PR TITLE
feat(i18n): LA-6e-2 — question bank, preview, record-response & widget gallery in Hindi

### DIFF
--- a/docs/changes/2026-06-13-la6e2-question-bank-hindi.md
+++ b/docs/changes/2026-06-13-la6e2-question-bank-hindi.md
@@ -1,0 +1,56 @@
+# LA-6e-2 — question bank, preview, record-response & widget gallery in Hindi
+
+**Date:** 2026-06-13
+**Classification:** Improve
+**Initiative:** Language Access (2026-language-access.md) — LA-6e
+
+## Summary
+
+Localized four high-traffic teacher surfaces: the **question bank** (+ its
+add-to-set sheet), the **question preview panel**, the **record-response / rubric**
+authoring panel that feeds the AI grading queue, and the **widget gallery**.
+Chrome strings only — question text, MCQ options, math (KaTeX), AI-suggested
+rubric text, student responses, and sandboxed widget content all render as-is
+(Principle 1). Filter/search state logic untouched.
+
+## Legacy reference
+
+None — legacy Django 1.11 had no teacher i18n. Pure "improve".
+
+## What changed
+
+- **`questionPreviewMeta.ts`** — added `localizedTypeLabel(t, type)` mapping the six
+  question types to `qtype.*` keys (MCQ stays "MCQ" per Glossary). `typeLabel`
+  kept for the still-English `CreateProblemSetPage`.
+- **`QuestionPreviewPanel.tsx`** — part labels, image alt, numeric/fill-blank
+  notes, interactive-widget note, type badge, difficulty title, and the default
+  empty-state (now computed via `t()` when not overridden).
+- **`QuestionBankPage.tsx`** — header, search placeholder, all filter
+  labels/options (subject/difficulty/chapter), clear-filters, results count
+  (singular/plural), empty states, row + footer actions, and the full
+  **add-to-problem-set sheet** (title, success, no-sets, per-set count, errors).
+- **`RecordResponsePanel.tsx`** — the rubric form (max marks, model answer,
+  marking points + sum-mismatch warning, save/update), the rubric summary, and
+  the record-response form (class/student/question selects with their loading and
+  placeholder states, success/error notes, submit button).
+- **`WidgetGalleryPanel.tsx`** — gallery heading/description, no-widgets state,
+  answer badge, no-schema banner, back-to-gallery, Config/Preview labels, preview
+  note, use-this-widget. Schema field *names* stay as authored (technical).
+- **Locale files** — ~115 new keys in both `en.ts` and `hi.ts` under LA-6e-2
+  sections (`qtype.*`, `qbank.*`, `addToSet.*`, `qpreview.*`, `widgetGallery.*`,
+  `recordResp.*`). Glossary register: प्रश्न बैंक, कठिनाई, अध्याय, रूब्रिक, समस्या सेट,
+  विषय. Parity guard stays green.
+
+## Tests
+
+- Added a renders-in-Hindi case to `QuestionBankPage.test.tsx`,
+  `RecordResponsePanel.test.tsx`, `WidgetGalleryPanel.test.tsx`.
+- Added a new `QuestionPreviewPanel.test.tsx` (it had none) — English empty-state +
+  a Hindi type-badge case.
+- Full suite green: 58 files / 362 tests. Lint + tsc clean. Build under budget
+  (entry 128 kB).
+
+## Next steps
+
+LA-6e-3 (versions + classroom code — uses LA-8 `formatDate`), LA-6e-4
+(CreateQuestionPage).

--- a/frontend_modern/src/features/teacher/QuestionBankPage.test.tsx
+++ b/frontend_modern/src/features/teacher/QuestionBankPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { I18nProvider } from '@/shared/i18n';
 import { QuestionBankPage } from './QuestionBankPage';
 import type { Question, Subject, ChapterItem } from '@/types/index';
 
@@ -78,6 +79,25 @@ beforeEach(() => {
 });
 
 describe('QuestionBankPage — URL-driven filters & continuity', () => {
+  it('renders the page title in Hindi when the locale is हिं', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={qc}>
+        <I18nProvider initialLocale="hi">
+          <MemoryRouter initialEntries={['/teacher/questions']}>
+            <Routes>
+              <Route path="/teacher/questions" element={<QuestionBankPage />} />
+            </Routes>
+          </MemoryRouter>
+        </I18nProvider>
+      </QueryClientProvider>,
+    );
+    // प्रश्न बैंक = "question bank" per the Glossary register.
+    await waitFor(() => {
+      expect(screen.getByText('प्रश्न बैंक')).toBeInTheDocument();
+    });
+  });
+
   it('reads filters from the URL on first render', async () => {
     renderBank('/teacher/questions?q=2+2&subject=1&diff=3');
     await waitFor(() => {

--- a/frontend_modern/src/features/teacher/QuestionBankPage.tsx
+++ b/frontend_modern/src/features/teacher/QuestionBankPage.tsx
@@ -7,7 +7,8 @@ import { useProblemSets } from './useProblemSets';
 import { useAddQuestionToProblemSet } from './useAddQuestionToProblemSet';
 import { previewFromQuestionText } from './previewFromQuestionText';
 import { QuestionPreviewPanel } from './QuestionPreviewPanel';
-import { difficultyStars, typeLabel, typeTone } from './questionPreviewMeta';
+import { difficultyStars, localizedTypeLabel, typeTone } from './questionPreviewMeta';
+import { useT } from '@/shared/i18n';
 import {
   Badge,
   Button,
@@ -34,6 +35,7 @@ const QuestionRow = ({
   onFocus: () => void;
   onEdit: () => void;
 }) => {
+  const t = useT();
   const previewText = previewFromQuestionText(question.subparts[0]?.question_text);
   const visibleTags = question.tags.slice(0, 3);
   const extraTags = question.tags.length - 3;
@@ -59,8 +61,10 @@ const QuestionRow = ({
       <div className="min-w-0 flex-1">
         <p className="line-clamp-2 text-sm text-ink-800">{previewText}</p>
         <div className="mt-1.5 flex flex-wrap items-center gap-2">
-          <Badge tone={typeTone(question.question_type)}>{typeLabel(question.question_type)}</Badge>
-          <span className="text-xs tracking-wider text-amber-500" title={`Difficulty ${question.difficulty}/5`}>
+          <Badge tone={typeTone(question.question_type)}>
+            {localizedTypeLabel(t, question.question_type)}
+          </Badge>
+          <span className="text-xs tracking-wider text-amber-500" title={t('qbank.difficultyTitle', { level: question.difficulty })}>
             {difficultyStars(question.difficulty)}
           </span>
           <span className="text-xs text-ink-400">
@@ -91,7 +95,7 @@ const QuestionRow = ({
         }}
         className="mt-1 shrink-0 rounded-md px-1.5 py-0.5 text-xs font-medium text-ink-400 opacity-0 transition-opacity hover:bg-ink-100 hover:text-ink-700 group-hover:opacity-100"
       >
-        Edit
+        {t('qbank.rowEdit')}
       </button>
     </div>
   );
@@ -106,6 +110,7 @@ const AddToProblemSetSheet = ({
   question: Question;
   onClose: () => void;
 }) => {
+  const t = useT();
   const [selectedPsId, setSelectedPsId] = useState<number | null>(null);
   const { data: problemSets, isLoading } = useProblemSets(question.subject);
   const addQuestion = useAddQuestionToProblemSet();
@@ -150,20 +155,20 @@ const AddToProblemSetSheet = ({
         <div className="flex items-center justify-between border-b border-ink-100 px-6 py-5">
           <div>
             <p className="text-xs font-semibold uppercase tracking-widest text-brand-600">
-              Add to set
+              {t('addToSet.eyebrow')}
             </p>
             <h3
               id="add-to-set-title"
               className="font-display text-lg font-semibold text-ink-900"
             >
-              Question #{question.id}
+              {t('addToSet.questionTitle', { id: question.id })}
             </h3>
           </div>
           <button
             ref={closeButtonRef}
             type="button"
             onClick={onClose}
-            aria-label="Close add-to-set dialog"
+            aria-label={t('addToSet.closeLabel')}
             className="rounded-full p-1.5 text-ink-400 transition-colors hover:bg-ink-100 hover:text-ink-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
           >
             <svg viewBox="0 0 16 16" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2">
@@ -175,11 +180,11 @@ const AddToProblemSetSheet = ({
         <div className="flex-1 overflow-y-auto p-6">
           {success ? (
             <EmptyState
-              title="Added!"
-              description="The question is now in the problem set."
+              title={t('addToSet.addedTitle')}
+              description={t('addToSet.addedDesc')}
               action={
                 <div className="flex flex-wrap justify-center gap-3">
-                  <Button onClick={onClose}>Done</Button>
+                  <Button onClick={onClose}>{t('addToSet.done')}</Button>
                   <Button
                     variant="ghost"
                     onClick={() => {
@@ -187,7 +192,7 @@ const AddToProblemSetSheet = ({
                       setSelectedPsId(null);
                     }}
                   >
-                    Add to another
+                    {t('addToSet.addAnother')}
                   </Button>
                 </div>
               }
@@ -200,14 +205,10 @@ const AddToProblemSetSheet = ({
           ) : !problemSets || problemSets.length === 0 ? (
             <div className="rounded-xl border border-dashed border-ink-200 bg-white p-6 text-center">
               <p className="text-sm text-ink-600">
-                No problem sets in{' '}
-                <strong className="text-ink-800">
-                  {question.subject_name ?? 'this subject'}
-                </strong>{' '}
-                yet.
+                {t('addToSet.noSets', { subject: question.subject_name ?? t('addToSet.thisSubject') })}
               </p>
               <Button size="sm" className="mt-3" onClick={onClose}>
-                Build one →
+                {t('addToSet.buildOne')}
               </Button>
             </div>
           ) : (
@@ -235,10 +236,17 @@ const AddToProblemSetSheet = ({
                     <p className="text-xs text-ink-500">{ps.chapter_name}</p>
                     <div className="mt-1 flex flex-wrap items-center gap-2">
                       <Badge tone="brand">
-                        {ps.question_count} {ps.question_count === 1 ? 'question' : 'questions'}
+                        {t(
+                          ps.question_count === 1
+                            ? 'addToSet.questionsCountOne'
+                            : 'addToSet.questionsCountMany',
+                          { count: ps.question_count },
+                        )}
                       </Badge>
                       {ps.estimated_minutes && (
-                        <span className="text-xs text-ink-500">~{ps.estimated_minutes} min</span>
+                        <span className="text-xs text-ink-500">
+                          {t('teacher.minutesApprox', { minutes: ps.estimated_minutes })}
+                        </span>
                       )}
                     </div>
                   </div>
@@ -252,15 +260,15 @@ const AddToProblemSetSheet = ({
           <div className="flex items-center justify-end gap-2 border-t border-ink-100 bg-white px-6 py-4">
             {addQuestion.isError && (
               <p className="mr-auto text-xs font-medium text-rose-600">
-                Failed to add. Please try again.
+                {t('addToSet.failedToAdd')}
               </p>
             )}
             <Button variant="ghost" onClick={onClose}>
-              Cancel
+              {t('common.cancel')}
             </Button>
             <Button onClick={handleAdd} disabled={!selectedPsId || addQuestion.isPending}>
               {addQuestion.isPending && <LoadingSpinner size="sm" />}
-              Add
+              {t('addToSet.add')}
             </Button>
           </div>
         )}
@@ -283,6 +291,7 @@ const numberOrEmpty = (raw: string | null): number | '' => {
 };
 
 export const QuestionBankPage = () => {
+  const t = useT();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -377,11 +386,11 @@ export const QuestionBankPage = () => {
       {/* Header */}
       <SectionHeading
         as="h1"
-        eyebrow="Authoring"
-        title="Question Bank"
-        description="Browse and reuse questions across your assignments. Click a question to preview exactly how students will see it."
+        eyebrow={t('qbank.eyebrow')}
+        title={t('qbank.title')}
+        description={t('qbank.description')}
         action={
-          <Button onClick={() => navigate('/teacher/questions/new')}>+ Create Question</Button>
+          <Button onClick={() => navigate('/teacher/questions/new')}>{t('qbank.createQuestion')}</Button>
         }
       />
 
@@ -392,7 +401,7 @@ export const QuestionBankPage = () => {
           {/* Filter bar */}
           <div className="space-y-3 border-b border-ink-100 px-5 py-4">
             <Input
-              placeholder="Search question text, subject, chapter…"
+              placeholder={t('qbank.searchPlaceholder')}
               value={search}
               onChange={(e) => handleSearchChange(e.target.value)}
               leftIcon={
@@ -413,7 +422,7 @@ export const QuestionBankPage = () => {
                   setSelectedChapter('');
                 }}
               >
-                <option value="">All subjects</option>
+                <option value="">{t('qbank.allSubjects')}</option>
                 {(subjects ?? []).map((s) => (
                   <option key={s.id} value={s.id}>
                     {s.name}
@@ -426,10 +435,10 @@ export const QuestionBankPage = () => {
                   setSelectedDifficulty(e.target.value ? Number(e.target.value) : '')
                 }
               >
-                <option value="">Any difficulty</option>
+                <option value="">{t('qbank.anyDifficulty')}</option>
                 {[1, 2, 3, 4, 5].map((d) => (
                   <option key={d} value={d}>
-                    {'★'.repeat(d)} ({d}/5)
+                    {t('qbank.difficultyOption', { stars: '★'.repeat(d), level: d })}
                   </option>
                 ))}
               </Select>
@@ -440,13 +449,15 @@ export const QuestionBankPage = () => {
                 setSelectedChapter(e.target.value ? Number(e.target.value) : '')
               }
               disabled={selectedSubject === ''}
-              hint={selectedSubject === '' ? 'Pick a subject first' : undefined}
+              hint={selectedSubject === '' ? t('qbank.pickSubjectFirst') : undefined}
             >
-              <option value="">All chapters</option>
+              <option value="">{t('qbank.allChapters')}</option>
               {(chapters ?? []).map((c) => (
                 <option key={c.id} value={c.id}>
                   {c.name}
-                  {c.standard_number !== undefined ? ` · Grade ${c.standard_number}` : ''}
+                  {c.standard_number !== undefined
+                    ? ` · ${t('qbank.gradeSuffix', { grade: c.standard_number })}`
+                    : ''}
                 </option>
               ))}
             </Select>
@@ -456,7 +467,7 @@ export const QuestionBankPage = () => {
                 onClick={clearFilters}
                 className="text-xs font-medium text-ink-500 hover:text-ink-800"
               >
-                Clear filters
+                {t('qbank.clearFilters')}
               </button>
             )}
           </div>
@@ -471,9 +482,9 @@ export const QuestionBankPage = () => {
               </div>
             ) : !questions || questions.length === 0 ? (
               <div className="py-10 text-center">
-                <p className="text-sm text-ink-500">No questions found</p>
+                <p className="text-sm text-ink-500">{t('qbank.noQuestionsFound')}</p>
                 <p className="mt-1 text-xs text-ink-400">
-                  {hasFilters ? 'Try adjusting filters.' : 'Author your first question.'}
+                  {hasFilters ? t('qbank.adjustFilters') : t('qbank.authorFirst')}
                 </p>
                 {!hasFilters && (
                   <Button
@@ -481,14 +492,17 @@ export const QuestionBankPage = () => {
                     className="mt-3"
                     onClick={() => navigate('/teacher/questions/new')}
                   >
-                    Create a question →
+                    {t('qbank.createAQuestion')}
                   </Button>
                 )}
               </div>
             ) : (
               <>
                 <p className="px-3 pt-1 pb-2 text-xs text-ink-400">
-                  {questions.length} question{questions.length !== 1 ? 's' : ''}
+                  {t(
+                    questions.length === 1 ? 'qbank.resultsCountOne' : 'qbank.resultsCountMany',
+                    { count: questions.length },
+                  )}
                 </p>
                 <div className="max-h-[40rem] space-y-1.5 overflow-y-auto pr-1">
                   {questions.map((q) => (
@@ -514,13 +528,13 @@ export const QuestionBankPage = () => {
         <div className="lg:col-span-7 xl:col-span-8">
           <QuestionPreviewPanel
             question={focusedQuestion}
-            emptyTitle="Pick a question to preview"
-            emptyDescription="Click any row on the left to see exactly how students will see it — full LaTeX, options, images, and all."
+            emptyTitle={t('qbank.previewEmptyTitle')}
+            emptyDescription={t('qbank.previewEmptyDesc')}
             footer={
               focusedQuestion ? (
                 <>
                   <p className="text-xs text-ink-500">
-                    Reuse this question in any of your problem sets.
+                    {t('qbank.reuseNote')}
                   </p>
                   <div className="flex flex-wrap items-center gap-2">
                     <Button
@@ -532,7 +546,7 @@ export const QuestionBankPage = () => {
                         )
                       }
                     >
-                      Edit
+                      {t('qbank.rowEdit')}
                     </Button>
                     <Button
                       variant="ghost"
@@ -543,10 +557,10 @@ export const QuestionBankPage = () => {
                         )
                       }
                     >
-                      Use in new set
+                      {t('qbank.useInNewSet')}
                     </Button>
                     <Button size="sm" onClick={() => setModalQuestion(focusedQuestion)}>
-                      + Add to problem set
+                      {t('qbank.addToProblemSet')}
                     </Button>
                   </div>
                 </>

--- a/frontend_modern/src/features/teacher/QuestionPreviewPanel.test.tsx
+++ b/frontend_modern/src/features/teacher/QuestionPreviewPanel.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { I18nProvider } from '@/shared/i18n';
+import { QuestionPreviewPanel } from './QuestionPreviewPanel';
+import type { Question } from '@/types/index';
+
+// RichContent renders HTML/LaTeX; we only assert chrome here.
+const makeQuestion = (): Question =>
+  ({
+    id: 100,
+    question_type: 'numeric',
+    difficulty: 3,
+    subject: 1,
+    subject_name: 'Mathematics',
+    chapter: 10,
+    chapter_name: 'Algebra',
+    standard: 8,
+    tags: [],
+    stem_text: '',
+    subparts: [
+      { id: 1, question_text: 'What is 2 + 2?', options: [], subpart_type: 'numeric', image_url: null },
+    ],
+  }) as unknown as Question;
+
+describe('<QuestionPreviewPanel />', () => {
+  it('shows the localized empty state when no question is selected (English default)', () => {
+    render(<QuestionPreviewPanel question={null} />);
+    expect(screen.getByText('Pick a question to preview')).toBeInTheDocument();
+  });
+
+  it('renders the question-type badge in Hindi when the locale is हिं', async () => {
+    render(
+      <I18nProvider initialLocale="hi">
+        <QuestionPreviewPanel question={makeQuestion()} />
+      </I18nProvider>,
+    );
+    // संख्यात्मक = "numeric" question type per the Glossary register.
+    await waitFor(() => {
+      expect(screen.getByText('संख्यात्मक')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend_modern/src/features/teacher/QuestionPreviewPanel.tsx
+++ b/frontend_modern/src/features/teacher/QuestionPreviewPanel.tsx
@@ -1,7 +1,8 @@
 import { ReactNode } from 'react';
 import { Badge, Card } from '@/shared/ui';
 import { RichContent } from '@/shared/ui/RichContent';
-import { difficultyStars, typeLabel, typeTone } from './questionPreviewMeta';
+import { useT } from '@/shared/i18n';
+import { difficultyStars, localizedTypeLabel, typeTone } from './questionPreviewMeta';
 import type { MCQOption, Question, QuestionSubpart } from '@/types/index';
 
 const optionLetter = (i: number) => String.fromCharCode(65 + i);
@@ -39,12 +40,13 @@ const SubpartPreview = ({
   index: number;
   total: number;
 }) => {
+  const t = useT();
   const hasOptions = Array.isArray(subpart.options) && subpart.options.length > 0;
   return (
     <div className="rounded-xl border border-ink-100 bg-white p-5 shadow-soft">
       {total > 1 && (
         <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-brand-600">
-          Part {String.fromCharCode(97 + index)}
+          {t('qpreview.part', { letter: String.fromCharCode(97 + index) })}
         </p>
       )}
       <div className="prose-osh text-ink-800">
@@ -53,7 +55,7 @@ const SubpartPreview = ({
       {subpart.image_url && (
         <img
           src={subpart.image_url}
-          alt="Question diagram"
+          alt={t('qpreview.diagramAlt')}
           className="mt-4 max-h-64 rounded-lg border border-ink-100 object-contain"
         />
       )}
@@ -79,15 +81,15 @@ const SubpartPreview = ({
           <svg viewBox="0 0 16 16" className="h-3.5 w-3.5" fill="currentColor">
             <path d="M3 4h10v2H3zm0 6h10v2H3z" />
           </svg>
-          Numeric answer
+          {t('qpreview.numericAnswer')}
         </p>
       )}
       {!hasOptions && subpart.subpart_type === 'fill_blank' && (
-        <p className="mt-4 text-xs text-ink-500">Fill-in-the-blank response.</p>
+        <p className="mt-4 text-xs text-ink-500">{t('qpreview.fillBlankResponse')}</p>
       )}
       {subpart.is_interactive && (
         <p className="mt-4 inline-flex items-center gap-2 rounded-lg border border-violet-200 bg-violet-50 px-3 py-1.5 text-xs font-medium text-violet-800">
-          🧪 Sandboxed interactive widget (rendered for students)
+          {t('qpreview.interactiveWidget')}
         </p>
       )}
     </div>
@@ -115,12 +117,18 @@ interface QuestionPreviewPanelProps {
  */
 export const QuestionPreviewPanel = ({
   question,
-  emptyTitle = 'Pick a question to preview',
-  emptyDescription = 'Click any row on the left to see exactly how students will see it — full LaTeX, options, images, and all.',
+  emptyTitle,
+  emptyDescription,
   footer,
 }: QuestionPreviewPanelProps) => {
+  const t = useT();
   if (!question) {
-    return <KeyholeEmpty title={emptyTitle} description={emptyDescription} />;
+    return (
+      <KeyholeEmpty
+        title={emptyTitle ?? t('qpreview.emptyTitle')}
+        description={emptyDescription ?? t('qpreview.emptyDesc')}
+      />
+    );
   }
 
   return (
@@ -128,10 +136,12 @@ export const QuestionPreviewPanel = ({
       {/* Header strip */}
       <div className="-m-6 mb-5 rounded-t-xl2 border-b border-ink-100 bg-paper px-6 py-4">
         <div className="flex flex-wrap items-center gap-2">
-          <Badge tone={typeTone(question.question_type)}>{typeLabel(question.question_type)}</Badge>
+          <Badge tone={typeTone(question.question_type)}>
+            {localizedTypeLabel(t, question.question_type)}
+          </Badge>
           <span
             className="text-sm tracking-wider text-amber-500"
-            title={`Difficulty ${question.difficulty}/5`}
+            title={t('qpreview.difficultyTitle', { level: question.difficulty })}
           >
             {difficultyStars(question.difficulty)}
           </span>

--- a/frontend_modern/src/features/teacher/RecordResponsePanel.test.tsx
+++ b/frontend_modern/src/features/teacher/RecordResponsePanel.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { I18nProvider } from '@/shared/i18n';
 import { RecordResponsePanel } from './RecordResponsePanel';
 import type { OpenResponseRubric } from './useOpenRubrics';
 
@@ -93,6 +94,22 @@ async function fillSelections(user: ReturnType<typeof userEvent.setup>) {
 describe('RecordResponsePanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('renders the panel header in Hindi when the locale is हिं', async () => {
+    mockApi();
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <I18nProvider initialLocale="hi">
+          <RecordResponsePanel />
+        </I18nProvider>
+      </QueryClientProvider>,
+    );
+    // "AI ग्रेडिंग के लिए उत्तर दर्ज करें" — the collapsed header.
+    await waitFor(() => {
+      expect(screen.getByText(/AI ग्रेडिंग के लिए उत्तर दर्ज करें/)).toBeInTheDocument();
+    });
   });
 
   it('is collapsed by default and fetches nothing until opened', () => {

--- a/frontend_modern/src/features/teacher/RecordResponsePanel.tsx
+++ b/frontend_modern/src/features/teacher/RecordResponsePanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Button, Skeleton } from '@/shared/ui';
+import { useT } from '@/shared/i18n';
 import { useSubjectRooms } from './useSubjectRooms';
 import {
   useRoomStudents,
@@ -23,6 +24,7 @@ interface RubricFormProps {
  * so partial credit is transparent.
  */
 const RubricForm = ({ subpartId, existing, onDone }: RubricFormProps) => {
+  const t = useT();
   const save = useSaveRubric();
   const [maxMarks, setMaxMarks] = useState(existing?.max_marks ?? 5);
   const [modelAnswer, setModelAnswer] = useState(existing?.model_answer ?? '');
@@ -52,7 +54,7 @@ const RubricForm = ({ subpartId, existing, onDone }: RubricFormProps) => {
       }}
     >
       <label className="block text-xs text-ink-600">
-        Maximum marks
+        {t('recordResp.maxMarks')}
         <input
           type="number"
           min={1}
@@ -67,33 +69,33 @@ const RubricForm = ({ subpartId, existing, onDone }: RubricFormProps) => {
         />
       </label>
       <label className="block text-xs text-ink-600">
-        Model answer <span className="text-ink-400">(what a full-marks answer says)</span>
+        {t('recordResp.modelAnswer')} <span className="text-ink-400">{t('recordResp.modelAnswerHint')}</span>
         <textarea
           value={modelAnswer}
           onChange={(e) => setModelAnswer(e.target.value)}
           rows={3}
           className="input-brand mt-1 block w-full text-sm"
-          placeholder="e.g. Chlorophyll absorbs red and blue light for photosynthesis and reflects green."
+          placeholder={t('recordResp.modelAnswerPlaceholder')}
         />
       </label>
 
       <div>
         <p className="text-xs text-ink-600 font-medium">
-          Marking points <span className="text-ink-400 font-normal">(optional — enables per-point partial credit)</span>
+          {t('recordResp.markingPoints')} <span className="text-ink-400 font-normal">{t('recordResp.markingPointsHint')}</span>
         </p>
         {criteria.map((c, i) => (
           <div key={i} className="mt-1.5 flex items-center gap-2">
             <input
               type="text"
-              aria-label={`Criterion ${i + 1} label`}
+              aria-label={t('recordResp.criterionLabelAria', { n: i + 1 })}
               value={c.label}
               onChange={(e) => updateCriterion(i, { label: e.target.value })}
-              placeholder="e.g. Names chlorophyll"
+              placeholder={t('recordResp.criterionLabelPlaceholder')}
               className="input-brand flex-1 text-sm"
             />
             <input
               type="number"
-              aria-label={`Criterion ${i + 1} marks`}
+              aria-label={t('recordResp.criterionMarksAria', { n: i + 1 })}
               min={0}
               max={100}
               value={c.marks}
@@ -102,7 +104,7 @@ const RubricForm = ({ subpartId, existing, onDone }: RubricFormProps) => {
             />
             <button
               type="button"
-              aria-label={`Remove criterion ${i + 1}`}
+              aria-label={t('recordResp.removeCriterionAria', { n: i + 1 })}
               onClick={() => setCriteria((rows) => rows.filter((_, idx) => idx !== i))}
               className="text-ink-400 hover:text-rose-600 text-sm px-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 rounded"
             >
@@ -117,28 +119,31 @@ const RubricForm = ({ subpartId, existing, onDone }: RubricFormProps) => {
           className="mt-1.5"
           onClick={() => setCriteria((rows) => [...rows, { label: '', marks: 1 }])}
         >
-          + Marking point
+          {t('recordResp.addMarkingPoint')}
         </Button>
         {sumMismatch && (
           <p className="mt-1 text-xs text-amber-700">
-            Marking points add up to {criteriaSum}, not {maxMarks} — the AI grades per point, so
-            consider matching the total.
+            {t('recordResp.sumMismatch', { sum: criteriaSum, max: maxMarks })}
           </p>
         )}
       </div>
 
       {save.isError && (
         <p className="text-xs text-rose-600">
-          Couldn&apos;t save the rubric just now. Please try again in a moment.
+          {t('recordResp.saveError')}
         </p>
       )}
 
       <div className="flex gap-2 pt-1">
         <Button type="submit" variant="brand" size="sm" disabled={save.isPending || maxMarks < 1}>
-          {save.isPending ? 'Saving…' : existing ? 'Update rubric' : 'Save rubric'}
+          {save.isPending
+            ? t('recordResp.saving')
+            : existing
+              ? t('recordResp.updateRubric')
+              : t('recordResp.saveRubric')}
         </Button>
         <Button type="button" variant="ghost" size="sm" onClick={onDone}>
-          Cancel
+          {t('common.cancel')}
         </Button>
       </div>
     </form>
@@ -146,6 +151,7 @@ const RubricForm = ({ subpartId, existing, onDone }: RubricFormProps) => {
 };
 
 const RubricSection = ({ subpartId }: { subpartId: number }) => {
+  const t = useT();
   const { data: rubric, isLoading } = useRubricForSubpart(subpartId);
   const [editing, setEditing] = useState(false);
 
@@ -160,12 +166,9 @@ const RubricSection = ({ subpartId }: { subpartId: number }) => {
   if (!rubric) {
     return (
       <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-amber-700">
-        <span>
-          No rubric yet — without one the AI falls back to a rough keyword match. Add one for
-          fair, transparent marks.
-        </span>
+        <span>{t('recordResp.noRubricWarning')}</span>
         <Button type="button" variant="ghost" size="sm" onClick={() => setEditing(true)}>
-          Add rubric
+          {t('recordResp.addRubric')}
         </Button>
       </div>
     );
@@ -175,17 +178,23 @@ const RubricSection = ({ subpartId }: { subpartId: number }) => {
     <div className="mt-2 rounded-lg border border-ink-100 bg-paper p-3">
       <div className="flex items-start justify-between gap-2">
         <p className="text-xs text-ink-600">
-          <span className="font-semibold">Rubric:</span> {rubric.max_marks} marks
+          <span className="font-semibold">{t('recordResp.rubricLabel')}</span>{' '}
+          {t('recordResp.marksLabel', { count: rubric.max_marks })}
           {rubric.criteria.length > 0 &&
-            ` · ${rubric.criteria.length} marking point${rubric.criteria.length !== 1 ? 's' : ''}`}
+            ` · ${t(
+              rubric.criteria.length === 1
+                ? 'recordResp.markingPointsCountOne'
+                : 'recordResp.markingPointsCountMany',
+              { count: rubric.criteria.length },
+            )}`}
         </p>
         <Button type="button" variant="ghost" size="sm" onClick={() => setEditing(true)}>
-          Edit
+          {t('recordResp.edit')}
         </Button>
       </div>
       {rubric.model_answer && (
         <p className="mt-1 text-xs text-ink-500 line-clamp-2">
-          <span className="font-semibold">Model answer:</span> {rubric.model_answer}
+          <span className="font-semibold">{t('recordResp.modelAnswerLabel')}</span> {rubric.model_answer}
         </p>
       )}
     </div>
@@ -201,6 +210,7 @@ const RubricSection = ({ subpartId }: { subpartId: number }) => {
  * suggestion fair — the form nudges the teacher to add one before grading.
  */
 export const RecordResponsePanel = () => {
+  const t = useT();
   const [isExpanded, setIsExpanded] = useState(false);
   const [roomId, setRoomId] = useState<number | null>(null);
   const [studentId, setStudentId] = useState<number | null>(null);
@@ -223,7 +233,7 @@ export const RecordResponsePanel = () => {
         aria-expanded={isExpanded}
         className="flex w-full items-center gap-1.5 text-left text-sm font-semibold text-ink-700 hover:text-ink-900 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded"
       >
-        <span>Record a response for AI grading</span>
+        <span>{t('recordResp.recordForAI')}</span>
         <span className={`ml-auto transition-transform ${isExpanded ? 'rotate-180' : ''}`}>▾</span>
       </button>
 
@@ -246,7 +256,7 @@ export const RecordResponsePanel = () => {
         >
           <div className="grid gap-3 sm:grid-cols-2">
             <label className="block text-xs text-ink-600">
-              Class
+              {t('recordResp.class')}
               <select
                 value={roomId == null ? '' : String(roomId)}
                 onChange={(e) => {
@@ -255,7 +265,7 @@ export const RecordResponsePanel = () => {
                 }}
                 className="input-brand mt-1 block w-full text-sm"
               >
-                <option value="">Pick a class…</option>
+                <option value="">{t('recordResp.pickClass')}</option>
                 {(rooms ?? []).map((r) => (
                   <option key={r.id} value={r.id}>
                     {r.subject_name} · {r.classroom_display}
@@ -264,7 +274,7 @@ export const RecordResponsePanel = () => {
               </select>
             </label>
             <label className="block text-xs text-ink-600">
-              Student
+              {t('recordResp.student')}
               <select
                 value={studentId == null ? '' : String(studentId)}
                 onChange={(e) => setStudentId(e.target.value ? Number(e.target.value) : null)}
@@ -273,10 +283,10 @@ export const RecordResponsePanel = () => {
               >
                 <option value="">
                   {roomId == null
-                    ? 'Pick a class first'
+                    ? t('recordResp.pickClassFirst')
                     : studentsLoading
-                      ? 'Loading students…'
-                      : 'Pick a student…'}
+                      ? t('recordResp.loadingStudents')
+                      : t('recordResp.pickStudent')}
                 </option>
                 {(students ?? []).map((s) => (
                   <option key={s.id} value={s.id}>
@@ -288,7 +298,7 @@ export const RecordResponsePanel = () => {
           </div>
 
           <label className="block text-xs text-ink-600">
-            Short-answer question
+            {t('recordResp.shortAnswerQuestion')}
             <select
               value={subpartId == null ? '' : String(subpartId)}
               onChange={(e) => setSubpartId(e.target.value ? Number(e.target.value) : null)}
@@ -296,7 +306,7 @@ export const RecordResponsePanel = () => {
               className="input-brand mt-1 block w-full text-sm disabled:opacity-60"
             >
               <option value="">
-                {subpartsLoading ? 'Loading questions…' : 'Pick a question…'}
+                {subpartsLoading ? t('recordResp.loadingQuestions') : t('recordResp.pickQuestion')}
               </option>
               {(subparts ?? []).map((sp) => (
                 <option key={sp.subpartId} value={sp.subpartId}>
@@ -307,40 +317,38 @@ export const RecordResponsePanel = () => {
           </label>
           {!subpartsLoading && (subparts ?? []).length === 0 && (
             <p className="text-xs text-ink-500">
-              No short-answer questions yet — create one in the question bank first; only
-              short-answer questions can be AI-graded here.
+              {t('recordResp.noShortAnswer')}
             </p>
           )}
 
           {subpartId != null && <RubricSection subpartId={subpartId} />}
 
           <label className="block text-xs text-ink-600">
-            Student&apos;s answer
+            {t('recordResp.studentAnswer')}
             <textarea
               value={responseText}
               onChange={(e) => setResponseText(e.target.value)}
               rows={3}
               className="input-brand mt-1 block w-full text-sm"
-              placeholder="Paste or type the student's written answer…"
+              placeholder={t('recordResp.studentAnswerPlaceholder')}
             />
           </label>
 
           {submit.isError && (
             <p className="text-xs text-rose-600">
-              Couldn&apos;t queue this response just now. Please try again in a moment.
+              {t('recordResp.queueError')}
             </p>
           )}
           {submit.isSuccess && (
             <p className="text-xs text-emerald-700" role="status">
-              Queued — it appears below as “AI grading…” and flips to a suggestion in a few
-              seconds.
+              {t('recordResp.queuedSuccess')}
             </p>
           )}
 
           <div className="flex items-center justify-between gap-2">
-            <p className="text-xs text-ink-400">AI suggests, you finalise — always.</p>
+            <p className="text-xs text-ink-400">{t('recordResp.aiSuggestsNote')}</p>
             <Button type="submit" variant="brand" size="sm" disabled={!canSubmit || submit.isPending}>
-              {submit.isPending ? 'Queuing…' : 'Send to AI grading'}
+              {submit.isPending ? t('recordResp.queuing') : t('recordResp.sendToAI')}
             </Button>
           </div>
         </form>

--- a/frontend_modern/src/features/teacher/WidgetGalleryPanel.test.tsx
+++ b/frontend_modern/src/features/teacher/WidgetGalleryPanel.test.tsx
@@ -9,8 +9,9 @@
  * tests + the Playwright suite.
  */
 
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import { I18nProvider } from '@/shared/i18n';
 import { WidgetGalleryPanel } from './WidgetGalleryPanel';
 
 /** Lookup a config field by its predictable id (matches PropertyField). */
@@ -115,5 +116,17 @@ describe('WidgetGalleryPanel', () => {
     fireEvent.click(screen.getByText(/Use this widget/i));
     const arg = onApply.mock.calls[0][0];
     expect(arg.config.min).toBe(42); // number, not "42"
+  });
+
+  it('renders the gallery heading in Hindi when the locale is हिं', async () => {
+    render(
+      <I18nProvider initialLocale="hi">
+        <WidgetGalleryPanel onApply={vi.fn()} onCancel={vi.fn()} />
+      </I18nProvider>,
+    );
+    // इंटरैक्टिव विजेट = "interactive widget" per the Glossary register.
+    await waitFor(() => {
+      expect(screen.getByText(/इंटरैक्टिव विजेट/)).toBeInTheDocument();
+    });
   });
 });

--- a/frontend_modern/src/features/teacher/WidgetGalleryPanel.tsx
+++ b/frontend_modern/src/features/teacher/WidgetGalleryPanel.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Card } from '@/shared/ui';
 import { InteractiveWidget } from '@/shared/ui/InteractiveWidget';
+import { useT } from '@/shared/i18n';
 import { widgetRegistry } from '@/widgets/registry';
 import type { WidgetModule } from '@/widgets/_sdk/defineWidget';
 
@@ -164,6 +165,7 @@ function ConfigForm({
   config: Record<string, unknown>;
   onChange: (next: Record<string, unknown>) => void;
 }) {
+  const t = useT();
   const properties = schema?.properties ?? {};
   const required = new Set(schema?.required ?? []);
 
@@ -173,7 +175,7 @@ function ConfigForm({
     return (
       <div className="grid gap-2">
         <p className="text-xs text-amber-700">
-          This widget didn&apos;t declare a JSON Schema. Edit the raw config below.
+          {t('widgetGallery.noSchema')}
         </p>
         <textarea
           rows={8}
@@ -221,6 +223,7 @@ export function WidgetGalleryPanel({
   onApply,
   onCancel,
 }: WidgetGalleryPanelProps) {
+  const t = useT();
   const galleryEntries = useMemo<GalleryEntry[]>(
     () => Object.values(widgetRegistry).filter(TEACHER_VISIBLE),
     [],
@@ -253,10 +256,9 @@ export function WidgetGalleryPanel({
       <Card className="grid gap-4">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h3 className="font-display text-lg font-semibold text-ink-900">Pick an interactive widget</h3>
+            <h3 className="font-display text-lg font-semibold text-ink-900">{t('widgetGallery.pickTitle')}</h3>
             <p className="text-sm text-ink-500">
-              The widget renders inside a sandboxed iframe alongside the question text. Pick one to
-              configure — the live preview updates as you fill in the form.
+              {t('widgetGallery.pickDesc')}
             </p>
           </div>
           <button
@@ -264,11 +266,11 @@ export function WidgetGalleryPanel({
             onClick={onCancel}
             className="text-sm text-ink-500 hover:text-ink-900"
           >
-            Cancel
+            {t('common.cancel')}
           </button>
         </div>
         {galleryEntries.length === 0 ? (
-          <p className="text-sm text-ink-500 italic">No teacher-visible widgets are registered yet.</p>
+          <p className="text-sm text-ink-500 italic">{t('widgetGallery.noneRegistered')}</p>
         ) : (
           <div className="grid gap-3 sm:grid-cols-2">
             {galleryEntries.map((entry) => (
@@ -282,7 +284,7 @@ export function WidgetGalleryPanel({
                   <h4 className="font-semibold text-ink-900">{entry.meta.title}</h4>
                   {entry.meta.answerProducing && (
                     <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-semibold text-emerald-900">
-                      answer
+                      {t('widgetGallery.answerBadge')}
                     </span>
                   )}
                 </div>
@@ -316,17 +318,17 @@ export function WidgetGalleryPanel({
           onClick={() => setSelectedKind(undefined)}
           className="text-sm text-ink-500 hover:text-ink-900"
         >
-          ← back to gallery
+          {t('widgetGallery.backToGallery')}
         </button>
       </div>
 
       <div className="grid gap-4 md:grid-cols-2">
         <div className="grid gap-2">
-          <p className="text-xs font-semibold uppercase tracking-widest text-brand-600">Config</p>
+          <p className="text-xs font-semibold uppercase tracking-widest text-brand-600">{t('widgetGallery.config')}</p>
           <ConfigForm schema={schema} config={config} onChange={setConfig} />
         </div>
         <div className="grid gap-2">
-          <p className="text-xs font-semibold uppercase tracking-widest text-brand-600">Preview</p>
+          <p className="text-xs font-semibold uppercase tracking-widest text-brand-600">{t('widgetGallery.preview')}</p>
           <InteractiveWidget
             kind={selected.kind}
             config={config}
@@ -337,8 +339,7 @@ export function WidgetGalleryPanel({
             minHeight={140}
           />
           <p className="text-[11px] text-ink-400">
-            Preview re-renders on every config change. Sandboxed iframe — scripts inside the
-            widget can&apos;t reach the page.
+            {t('widgetGallery.previewNote')}
           </p>
         </div>
       </div>
@@ -349,14 +350,14 @@ export function WidgetGalleryPanel({
           onClick={onCancel}
           className="rounded-md border border-ink-200 px-3 py-1.5 text-sm hover:bg-ink-50"
         >
-          Cancel
+          {t('common.cancel')}
         </button>
         <button
           type="button"
           onClick={() => onApply({ kind: selected.kind, config })}
           className="rounded-md bg-brand-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-brand-700"
         >
-          Use this widget
+          {t('widgetGallery.useThis')}
         </button>
       </div>
     </Card>

--- a/frontend_modern/src/features/teacher/questionPreviewMeta.ts
+++ b/frontend_modern/src/features/teacher/questionPreviewMeta.ts
@@ -3,6 +3,7 @@
  * Kept in a separate file from React components so Vite/fast-refresh's
  * "component-only exports" rule stays happy.
  */
+import type { LocaleKey, Translate } from '@/shared/i18n';
 
 const TYPE_LABEL: Record<string, string> = {
   mcq: 'MCQ',
@@ -24,5 +25,20 @@ const TYPE_TONE: Record<string, 'brand' | 'neutral' | 'success' | 'attention' | 
 
 export const typeLabel = (t: string) => TYPE_LABEL[t] ?? t.replace('_', ' ');
 export const typeTone = (t: string) => TYPE_TONE[t] ?? 'neutral';
+
+const TYPE_KEY: Record<string, LocaleKey> = {
+  mcq: 'qtype.mcq',
+  numeric: 'qtype.numeric',
+  fill_blank: 'qtype.fill_blank',
+  multi_select: 'qtype.multi_select',
+  matching: 'qtype.matching',
+  compound: 'qtype.compound',
+};
+
+/** Locale-aware question-type label. Falls back to the raw type for unknowns. */
+export const localizedTypeLabel = (translate: Translate, type: string): string => {
+  const key = TYPE_KEY[type];
+  return key ? translate(key) : type.replace('_', ' ');
+};
 export const difficultyStars = (d: number) =>
   '★'.repeat(d) + '☆'.repeat(Math.max(0, 5 - d));

--- a/frontend_modern/src/shared/i18n/locales/en.ts
+++ b/frontend_modern/src/shared/i18n/locales/en.ts
@@ -557,6 +557,133 @@ export const en = {
   'grading.emptyDesc':
     'Record a student’s open-ended answer and AI will suggest a grade for your review.',
 
+  // ── LA-6e-2: question-type labels (shared) ───────────────────────────
+  'qtype.mcq': 'MCQ',
+  'qtype.numeric': 'Numeric',
+  'qtype.fill_blank': 'Fill blank',
+  'qtype.multi_select': 'Multi-select',
+  'qtype.matching': 'Matching',
+  'qtype.compound': 'Compound',
+
+  // ── LA-6e-2: question bank page ──────────────────────────────────────
+  'qbank.eyebrow': 'Authoring',
+  'qbank.title': 'Question Bank',
+  'qbank.description':
+    'Browse and reuse questions across your assignments. Click a question to preview exactly how students will see it.',
+  'qbank.createQuestion': '+ Create Question',
+  'qbank.searchPlaceholder': 'Search question text, subject, chapter…',
+  'qbank.allSubjects': 'All subjects',
+  'qbank.anyDifficulty': 'Any difficulty',
+  'qbank.difficultyOption': '{stars} ({level}/5)',
+  'qbank.allChapters': 'All chapters',
+  'qbank.gradeSuffix': 'Grade {grade}',
+  'qbank.pickSubjectFirst': 'Pick a subject first',
+  'qbank.clearFilters': 'Clear filters',
+  'qbank.noQuestionsFound': 'No questions found',
+  'qbank.adjustFilters': 'Try adjusting filters.',
+  'qbank.authorFirst': 'Author your first question.',
+  'qbank.createAQuestion': 'Create a question →',
+  'qbank.resultsCountOne': '{count} question',
+  'qbank.resultsCountMany': '{count} questions',
+  'qbank.difficultyTitle': 'Difficulty {level}/5',
+  'qbank.rowEdit': 'Edit',
+  'qbank.previewEmptyTitle': 'Pick a question to preview',
+  'qbank.previewEmptyDesc':
+    'Click any row on the left to see exactly how students will see it — full LaTeX, options, images, and all.',
+  'qbank.reuseNote': 'Reuse this question in any of your problem sets.',
+  'qbank.useInNewSet': 'Use in new set',
+  'qbank.addToProblemSet': '+ Add to problem set',
+
+  // ── LA-6e-2: add-to-problem-set sheet ────────────────────────────────
+  'addToSet.eyebrow': 'Add to set',
+  'addToSet.questionTitle': 'Question #{id}',
+  'addToSet.closeLabel': 'Close add-to-set dialog',
+  'addToSet.addedTitle': 'Added!',
+  'addToSet.addedDesc': 'The question is now in the problem set.',
+  'addToSet.done': 'Done',
+  'addToSet.addAnother': 'Add to another',
+  'addToSet.noSets': 'No problem sets in {subject} yet.',
+  'addToSet.thisSubject': 'this subject',
+  'addToSet.buildOne': 'Build one →',
+  'addToSet.questionsCountOne': '{count} question',
+  'addToSet.questionsCountMany': '{count} questions',
+  'addToSet.failedToAdd': 'Failed to add. Please try again.',
+  'addToSet.add': 'Add',
+
+  // ── LA-6e-2: question preview panel ──────────────────────────────────
+  'qpreview.part': 'Part {letter}',
+  'qpreview.diagramAlt': 'Question diagram',
+  'qpreview.numericAnswer': 'Numeric answer',
+  'qpreview.fillBlankResponse': 'Fill-in-the-blank response.',
+  'qpreview.interactiveWidget': '🧪 Sandboxed interactive widget (rendered for students)',
+  'qpreview.emptyTitle': 'Pick a question to preview',
+  'qpreview.emptyDesc':
+    'Click any row on the left to see exactly how students will see it — full LaTeX, options, images, and all.',
+  'qpreview.difficultyTitle': 'Difficulty {level}/5',
+
+  // ── LA-6e-2: widget gallery panel ────────────────────────────────────
+  'widgetGallery.pickTitle': 'Pick an interactive widget',
+  'widgetGallery.pickDesc':
+    'The widget renders inside a sandboxed iframe alongside the question text. Pick one to configure — the live preview updates as you fill in the form.',
+  'widgetGallery.noneRegistered': 'No teacher-visible widgets are registered yet.',
+  'widgetGallery.answerBadge': 'answer',
+  'widgetGallery.noSchema': "This widget didn't declare a JSON Schema. Edit the raw config below.",
+  'widgetGallery.backToGallery': '← back to gallery',
+  'widgetGallery.config': 'Config',
+  'widgetGallery.preview': 'Preview',
+  'widgetGallery.previewNote':
+    "Preview re-renders on every config change. Sandboxed iframe — scripts inside the widget can't reach the page.",
+  'widgetGallery.useThis': 'Use this widget',
+
+  // ── LA-6e-2: record-response / rubric panel ──────────────────────────
+  'recordResp.maxMarks': 'Maximum marks',
+  'recordResp.modelAnswer': 'Model answer',
+  'recordResp.modelAnswerHint': '(what a full-marks answer says)',
+  'recordResp.modelAnswerPlaceholder':
+    'e.g. Chlorophyll absorbs red and blue light for photosynthesis and reflects green.',
+  'recordResp.markingPoints': 'Marking points',
+  'recordResp.markingPointsHint': '(optional — enables per-point partial credit)',
+  'recordResp.criterionLabelPlaceholder': 'e.g. Names chlorophyll',
+  'recordResp.criterionLabelAria': 'Criterion {n} label',
+  'recordResp.criterionMarksAria': 'Criterion {n} marks',
+  'recordResp.removeCriterionAria': 'Remove criterion {n}',
+  'recordResp.addMarkingPoint': '+ Marking point',
+  'recordResp.sumMismatch':
+    'Marking points add up to {sum}, not {max} — the AI grades per point, so consider matching the total.',
+  'recordResp.saveError': "Couldn't save the rubric just now. Please try again in a moment.",
+  'recordResp.saving': 'Saving…',
+  'recordResp.updateRubric': 'Update rubric',
+  'recordResp.saveRubric': 'Save rubric',
+  'recordResp.noRubricWarning':
+    'No rubric yet — without one the AI falls back to a rough keyword match. Add one for fair, transparent marks.',
+  'recordResp.addRubric': 'Add rubric',
+  'recordResp.rubricLabel': 'Rubric:',
+  'recordResp.marksLabel': '{count} marks',
+  'recordResp.markingPointsCountOne': '{count} marking point',
+  'recordResp.markingPointsCountMany': '{count} marking points',
+  'recordResp.edit': 'Edit',
+  'recordResp.modelAnswerLabel': 'Model answer:',
+  'recordResp.recordForAI': 'Record a response for AI grading',
+  'recordResp.class': 'Class',
+  'recordResp.pickClass': 'Pick a class…',
+  'recordResp.student': 'Student',
+  'recordResp.pickClassFirst': 'Pick a class first',
+  'recordResp.loadingStudents': 'Loading students…',
+  'recordResp.pickStudent': 'Pick a student…',
+  'recordResp.shortAnswerQuestion': 'Short-answer question',
+  'recordResp.loadingQuestions': 'Loading questions…',
+  'recordResp.pickQuestion': 'Pick a question…',
+  'recordResp.noShortAnswer':
+    'No short-answer questions yet — create one in the question bank first; only short-answer questions can be AI-graded here.',
+  'recordResp.studentAnswer': "Student's answer",
+  'recordResp.studentAnswerPlaceholder': "Paste or type the student's written answer…",
+  'recordResp.queueError': "Couldn't queue this response just now. Please try again in a moment.",
+  'recordResp.queuedSuccess':
+    'Queued — it appears below as "AI grading…" and flips to a suggestion in a few seconds.',
+  'recordResp.aiSuggestsNote': 'AI suggests, you finalise — always.',
+  'recordResp.queuing': 'Queuing…',
+  'recordResp.sendToAI': 'Send to AI grading',
+
   // ── Streak badge ─────────────────────────────────────────────────────
   'streak.days': '{count}-day streak',
   'streak.tierStarter': 'On Fire',

--- a/frontend_modern/src/shared/i18n/locales/hi.ts
+++ b/frontend_modern/src/shared/i18n/locales/hi.ts
@@ -553,6 +553,133 @@ export const hi: LocaleDict = {
   'grading.emptyDesc':
     'किसी विद्यार्थी का मुक्त उत्तर दर्ज करें और AI आपकी समीक्षा के लिए एक अंक सुझाएगा।',
 
+  // ── LA-6e-2: question-type labels (shared) ───────────────────────────
+  'qtype.mcq': 'MCQ',
+  'qtype.numeric': 'संख्यात्मक',
+  'qtype.fill_blank': 'रिक्त स्थान',
+  'qtype.multi_select': 'बहु-चयन',
+  'qtype.matching': 'मिलान',
+  'qtype.compound': 'संयुक्त',
+
+  // ── LA-6e-2: question bank page ──────────────────────────────────────
+  'qbank.eyebrow': 'लेखन',
+  'qbank.title': 'प्रश्न बैंक',
+  'qbank.description':
+    'अपने असाइनमेंट में प्रश्न ब्राउज़ करें और दोबारा इस्तेमाल करें। किसी प्रश्न पर क्लिक करके देखें कि विद्यार्थी उसे ठीक कैसे देखेंगे।',
+  'qbank.createQuestion': '+ प्रश्न बनाएँ',
+  'qbank.searchPlaceholder': 'प्रश्न पाठ, विषय, अध्याय खोजें…',
+  'qbank.allSubjects': 'सभी विषय',
+  'qbank.anyDifficulty': 'कोई भी कठिनाई',
+  'qbank.difficultyOption': '{stars} ({level}/5)',
+  'qbank.allChapters': 'सभी अध्याय',
+  'qbank.gradeSuffix': 'कक्षा {grade}',
+  'qbank.pickSubjectFirst': 'पहले एक विषय चुनें',
+  'qbank.clearFilters': 'फ़िल्टर हटाएँ',
+  'qbank.noQuestionsFound': 'कोई प्रश्न नहीं मिला',
+  'qbank.adjustFilters': 'फ़िल्टर बदलकर देखें।',
+  'qbank.authorFirst': 'अपना पहला प्रश्न बनाएँ।',
+  'qbank.createAQuestion': 'प्रश्न बनाएँ →',
+  'qbank.resultsCountOne': '{count} प्रश्न',
+  'qbank.resultsCountMany': '{count} प्रश्न',
+  'qbank.difficultyTitle': 'कठिनाई {level}/5',
+  'qbank.rowEdit': 'संपादित करें',
+  'qbank.previewEmptyTitle': 'प्रीव्यू के लिए एक प्रश्न चुनें',
+  'qbank.previewEmptyDesc':
+    'बाईं ओर किसी पंक्ति पर क्लिक करके देखें कि विद्यार्थी उसे ठीक कैसे देखेंगे — पूरा LaTeX, विकल्प, चित्र, सब कुछ।',
+  'qbank.reuseNote': 'इस प्रश्न को अपने किसी भी समस्या सेट में दोबारा इस्तेमाल करें।',
+  'qbank.useInNewSet': 'नए सेट में इस्तेमाल करें',
+  'qbank.addToProblemSet': '+ समस्या सेट में जोड़ें',
+
+  // ── LA-6e-2: add-to-problem-set sheet ────────────────────────────────
+  'addToSet.eyebrow': 'सेट में जोड़ें',
+  'addToSet.questionTitle': 'प्रश्न #{id}',
+  'addToSet.closeLabel': 'सेट-में-जोड़ें डायलॉग बंद करें',
+  'addToSet.addedTitle': 'जोड़ा गया!',
+  'addToSet.addedDesc': 'प्रश्न अब समस्या सेट में है।',
+  'addToSet.done': 'पूरा',
+  'addToSet.addAnother': 'किसी और में जोड़ें',
+  'addToSet.noSets': '{subject} में अभी कोई समस्या सेट नहीं है।',
+  'addToSet.thisSubject': 'इस विषय',
+  'addToSet.buildOne': 'एक बनाएँ →',
+  'addToSet.questionsCountOne': '{count} प्रश्न',
+  'addToSet.questionsCountMany': '{count} प्रश्न',
+  'addToSet.failedToAdd': 'जोड़ नहीं सके। कृपया फिर कोशिश करें।',
+  'addToSet.add': 'जोड़ें',
+
+  // ── LA-6e-2: question preview panel ──────────────────────────────────
+  'qpreview.part': 'भाग {letter}',
+  'qpreview.diagramAlt': 'प्रश्न का चित्र',
+  'qpreview.numericAnswer': 'संख्यात्मक उत्तर',
+  'qpreview.fillBlankResponse': 'रिक्त स्थान भरने वाला उत्तर।',
+  'qpreview.interactiveWidget': '🧪 सैंडबॉक्स्ड इंटरैक्टिव विजेट (विद्यार्थियों के लिए रेंडर होता है)',
+  'qpreview.emptyTitle': 'प्रीव्यू के लिए एक प्रश्न चुनें',
+  'qpreview.emptyDesc':
+    'बाईं ओर किसी पंक्ति पर क्लिक करके देखें कि विद्यार्थी उसे ठीक कैसे देखेंगे — पूरा LaTeX, विकल्प, चित्र, सब कुछ।',
+  'qpreview.difficultyTitle': 'कठिनाई {level}/5',
+
+  // ── LA-6e-2: widget gallery panel ────────────────────────────────────
+  'widgetGallery.pickTitle': 'एक इंटरैक्टिव विजेट चुनें',
+  'widgetGallery.pickDesc':
+    'विजेट प्रश्न पाठ के साथ एक सैंडबॉक्स्ड iframe में रेंडर होता है। कॉन्फ़िगर करने के लिए एक चुनें — फ़ॉर्म भरते ही लाइव प्रीव्यू अपडेट होता है।',
+  'widgetGallery.noneRegistered': 'अभी कोई शिक्षक-दृश्य विजेट पंजीकृत नहीं है।',
+  'widgetGallery.answerBadge': 'उत्तर',
+  'widgetGallery.noSchema': 'इस विजेट ने JSON Schema घोषित नहीं किया। नीचे रॉ कॉन्फ़िग संपादित करें।',
+  'widgetGallery.backToGallery': '← गैलरी पर वापस',
+  'widgetGallery.config': 'कॉन्फ़िग',
+  'widgetGallery.preview': 'प्रीव्यू',
+  'widgetGallery.previewNote':
+    'हर कॉन्फ़िग बदलाव पर प्रीव्यू दोबारा रेंडर होता है। सैंडबॉक्स्ड iframe — विजेट के अंदर के स्क्रिप्ट पेज तक नहीं पहुँच सकते।',
+  'widgetGallery.useThis': 'यह विजेट इस्तेमाल करें',
+
+  // ── LA-6e-2: record-response / rubric panel ──────────────────────────
+  'recordResp.maxMarks': 'अधिकतम अंक',
+  'recordResp.modelAnswer': 'मॉडल उत्तर',
+  'recordResp.modelAnswerHint': '(पूरे अंक वाला उत्तर क्या कहता है)',
+  'recordResp.modelAnswerPlaceholder':
+    'उदा. क्लोरोफिल प्रकाश-संश्लेषण के लिए लाल और नीला प्रकाश सोखता है और हरा परावर्तित करता है।',
+  'recordResp.markingPoints': 'अंकन बिंदु',
+  'recordResp.markingPointsHint': '(वैकल्पिक — प्रति-बिंदु आंशिक अंक सक्षम करता है)',
+  'recordResp.criterionLabelPlaceholder': 'उदा. क्लोरोफिल का नाम लेता है',
+  'recordResp.criterionLabelAria': 'मापदंड {n} लेबल',
+  'recordResp.criterionMarksAria': 'मापदंड {n} अंक',
+  'recordResp.removeCriterionAria': 'मापदंड {n} हटाएँ',
+  'recordResp.addMarkingPoint': '+ अंकन बिंदु',
+  'recordResp.sumMismatch':
+    'अंकन बिंदुओं का योग {sum} है, {max} नहीं — AI प्रति-बिंदु ग्रेड करता है, तो कुल मिलाना ठीक रहेगा।',
+  'recordResp.saveError': 'रूब्रिक अभी सहेजा नहीं जा सका। कृपया थोड़ी देर में फिर कोशिश करें।',
+  'recordResp.saving': 'सहेजा जा रहा है…',
+  'recordResp.updateRubric': 'रूब्रिक अपडेट करें',
+  'recordResp.saveRubric': 'रूब्रिक सहेजें',
+  'recordResp.noRubricWarning':
+    'अभी कोई रूब्रिक नहीं — इसके बिना AI मोटे कीवर्ड मिलान पर निर्भर करता है। निष्पक्ष, पारदर्शी अंकों के लिए एक जोड़ें।',
+  'recordResp.addRubric': 'रूब्रिक जोड़ें',
+  'recordResp.rubricLabel': 'रूब्रिक:',
+  'recordResp.marksLabel': '{count} अंक',
+  'recordResp.markingPointsCountOne': '{count} अंकन बिंदु',
+  'recordResp.markingPointsCountMany': '{count} अंकन बिंदु',
+  'recordResp.edit': 'संपादित करें',
+  'recordResp.modelAnswerLabel': 'मॉडल उत्तर:',
+  'recordResp.recordForAI': 'AI ग्रेडिंग के लिए उत्तर दर्ज करें',
+  'recordResp.class': 'क्लास',
+  'recordResp.pickClass': 'एक क्लास चुनें…',
+  'recordResp.student': 'विद्यार्थी',
+  'recordResp.pickClassFirst': 'पहले एक क्लास चुनें',
+  'recordResp.loadingStudents': 'विद्यार्थी लोड हो रहे हैं…',
+  'recordResp.pickStudent': 'एक विद्यार्थी चुनें…',
+  'recordResp.shortAnswerQuestion': 'लघु-उत्तर प्रश्न',
+  'recordResp.loadingQuestions': 'प्रश्न लोड हो रहे हैं…',
+  'recordResp.pickQuestion': 'एक प्रश्न चुनें…',
+  'recordResp.noShortAnswer':
+    'अभी कोई लघु-उत्तर प्रश्न नहीं — पहले प्रश्न बैंक में एक बनाएँ; यहाँ सिर्फ़ लघु-उत्तर प्रश्न ही AI से ग्रेड हो सकते हैं।',
+  'recordResp.studentAnswer': 'विद्यार्थी का उत्तर',
+  'recordResp.studentAnswerPlaceholder': 'विद्यार्थी का लिखा उत्तर पेस्ट या टाइप करें…',
+  'recordResp.queueError': 'यह उत्तर अभी कतार में नहीं डाला जा सका। कृपया थोड़ी देर में फिर कोशिश करें।',
+  'recordResp.queuedSuccess':
+    'कतार में डाला गया — यह नीचे "AI ग्रेडिंग…" के रूप में दिखता है और कुछ सेकंड में सुझाव में बदल जाता है।',
+  'recordResp.aiSuggestsNote': 'AI सुझाव देता है, अंतिम फ़ैसला हमेशा आपका।',
+  'recordResp.queuing': 'कतार में डाला जा रहा है…',
+  'recordResp.sendToAI': 'AI ग्रेडिंग को भेजें',
+
   // ── Streak badge ─────────────────────────────────────────────────────
   'streak.days': '{count} दिन की स्ट्रीक',
   'streak.tierStarter': 'जोश में',


### PR DESCRIPTION
## Classification
**Improve** — Language Access initiative, **LA-6e** (teacher surface remainder).

## What & why
Localizes four high-traffic teacher surfaces. Chrome strings only — question text, MCQ options, math (KaTeX), AI-suggested rubric text, student responses, and sandboxed widget content all render as-is (Principle 1). **Filter/search state logic untouched.**

- **`QuestionBankPage`** — header, search placeholder, subject/difficulty/chapter filters, clear-filters, results count (sing/plural), empty states, row + footer actions, full **add-to-problem-set sheet**.
- **`QuestionPreviewPanel`** — part labels, image alt, numeric/fill-blank notes, interactive-widget note, type badge, difficulty title, default empty-state.
- **`RecordResponsePanel`** — rubric form (max marks, model answer, marking points + sum-mismatch), rubric summary, record-response form (class/student/question selects + loading/placeholder/error/success states).
- **`WidgetGalleryPanel`** — gallery heading/description, no-widgets state, answer badge, no-schema banner, Config/Preview labels, preview note, use-this-widget.
- **`questionPreviewMeta`** — new `localizedTypeLabel(t, type)` for the six question types (MCQ stays "MCQ" per Glossary).

## Legacy reference
None — legacy Django had no teacher i18n. Pure improve.

## Tests
- Added a renders-in-Hindi case to `QuestionBankPage`, `RecordResponsePanel`, `WidgetGalleryPanel` tests.
- New `QuestionPreviewPanel.test.tsx` (it had none): English empty-state + Hindi type-badge.
- Full suite green: **58 files / 362 tests**. Lint + tsc clean. Build under budget (entry 128 kB).

## Translation review — new Hindi strings
~115 keys under the LA-6e-2 sections of `hi.ts` (`qtype.*`, `qbank.*`, `addToSet.*`, `qpreview.*`, `widgetGallery.*`, `recordResp.*`). Glossary register: प्रश्न बैंक, कठिनाई, अध्याय, रूब्रिक, समस्या सेट, विषय. Parity guard enforces key + `{var}` parity.

## How to verify
Log in as a teacher, switch to हिं → open the Question Bank (title, filters, results, preview, add-to-set all in Hindi), expand "Record a response for AI grading", attach an interactive widget via the gallery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)