### PR TITLE
polish(ai): open-response grading — flag low-confidence AI suggestions

### DIFF
--- a/docs/ai-features/polish-backlog.md
+++ b/docs/ai-features/polish-backlog.md
@@ -326,6 +326,39 @@ appears, then clears on its own a few seconds later instead of sticking around.
 
 ---
 
+## 2026-06-13 — Open-response grading: low-confidence suggestions flagged
+
+**Surface:** Open-response grading (teacher `OpenResponseGradingPage` →
+`GradeCard`).
+
+**Gap (checklist #1 degradation, #3 copy/tone):**
+The AI's confidence was rendered as flat gray text (`{pct}% confident`) for
+*every* suggestion, so a 42%-confident grade looked identical to a 95%-confident
+one. The "Accept suggestion" button defaults to the AI's score and finalises in
+one click — meaning a teacher could lock in a low-confidence AI grade without any
+signal that the model was unsure and the response deserved a careful read. The
+stub path already warns ("review with extra care"), but a *real* LLM returning
+low confidence had no such nudge.
+
+**Fix:**
+- Confidence now renders as a V2 `Badge`: **amber (`attention`)** when below the
+  `LOW_CONFIDENCE = 0.6` threshold, neutral otherwise — so an uncertain
+  suggestion stands out at a glance instead of blending in as gray text.
+- Below the threshold (and only for a real LLM, not the stub — which already has
+  its own care note, so we don't stack two warnings) a `grading.lowConfidenceNote`
+  line appears: "The AI is unsure about this one — read the response and
+  double-check before accepting." Localised in en + hi.
+- Added two tests: a 0.42-confidence grade shows the amber percentage + the
+  double-check note; a confident (0.85) grade does **not** show the note
+  (checklist #8). All 12 grading-page tests + i18n parity guard pass.
+
+**Verify:** Teacher → Open-response grading queue. An AI suggestion with
+confidence < 60% shows an amber confidence badge and a "double-check before
+accepting" note above the review form; a high-confidence one shows a calm
+neutral badge and no note.
+
+---
+
 ## Remaining gaps (audit notes — updated 2026-06-13)
 
 - ✅ **Error-as-empty-state sweep complete** — `MisconceptionClustersPanel`

--- a/frontend_modern/src/features/teacher/OpenResponseGradingPage.test.tsx
+++ b/frontend_modern/src/features/teacher/OpenResponseGradingPage.test.tsx
@@ -200,6 +200,23 @@ describe('OpenResponseGradingPage', () => {
     expect(screen.queryByText('✨ AI-generated')).toBeNull();
   });
 
+  it('flags a low-confidence suggestion so the teacher double-checks before accepting', async () => {
+    mockApi([{ ...GRADE, confidence: 0.42 }]);
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Asha Rao')).toBeDefined());
+    expect(screen.getByText('42% confident')).toBeDefined();
+    expect(screen.getByText(/double-check before accepting/i)).toBeDefined();
+  });
+
+  it('does not show the low-confidence note when the AI is confident', async () => {
+    mockApi([GRADE]); // confidence 0.85
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('85% confident')).toBeDefined());
+    expect(screen.queryByText(/double-check before accepting/i)).toBeNull();
+  });
+
   it('status filter chips re-query with the status param', async () => {
     const user = userEvent.setup();
     mockApi([GRADE]);

--- a/frontend_modern/src/features/teacher/OpenResponseGradingPage.tsx
+++ b/frontend_modern/src/features/teacher/OpenResponseGradingPage.tsx
@@ -30,6 +30,10 @@ const STATUS_TONE: Record<OpenGradeStatus, 'attention' | 'brand' | 'success' | '
 const formatDate = (iso: string): string =>
   new Date(iso).toLocaleDateString('en-IN', { day: 'numeric', month: 'short' });
 
+// Below this the AI is uncertain enough that one-click "Accept" is risky — the
+// teacher should read the response before finalising, so we flag it amber.
+const LOW_CONFIDENCE = 0.6;
+
 interface ReviewFormProps {
   grade: OpenResponseGrade;
 }
@@ -111,6 +115,7 @@ const GradeCard = ({ grade }: { grade: OpenResponseGrade }) => {
   const t = useT();
   const regrade = useRegradeOpenGrade();
   const isStub = isAIStub(grade.model_used);
+  const lowConfidence = grade.confidence != null && grade.confidence < LOW_CONFIDENCE;
 
   return (
     <div className="os-card p-4 sm:p-5">
@@ -172,9 +177,9 @@ const GradeCard = ({ grade }: { grade: OpenResponseGrade }) => {
               })}
             </p>
             {grade.confidence != null && (
-              <span className="text-xs text-ink-400">
+              <Badge tone={lowConfidence ? 'attention' : 'neutral'}>
                 {t('grading.confident', { pct: Math.round(grade.confidence * 100) })}
-              </span>
+              </Badge>
             )}
             <AIBadge modelUsed={grade.model_used} stubLabel={t('grading.autoGraded')} />
           </div>
@@ -183,6 +188,14 @@ const GradeCard = ({ grade }: { grade: OpenResponseGrade }) => {
           )}
           {isStub && (
             <p className="mt-1 text-xs text-ink-400">{t('grading.stubNote')}</p>
+          )}
+          {/* A real LLM that's unsure: nudge the teacher to read before accepting.
+              When it's a stub the line above already says "review with extra
+              care", so we don't stack a second warning. */}
+          {lowConfidence && !isStub && (
+            <p className="mt-1.5 text-xs font-medium text-amber-700">
+              {t('grading.lowConfidenceNote')}
+            </p>
           )}
 
           {grade.criterion_scores.length > 0 && (

--- a/frontend_modern/src/shared/i18n/locales/en.ts
+++ b/frontend_modern/src/shared/i18n/locales/en.ts
@@ -532,6 +532,8 @@ export const en = {
   'grading.retrying': 'Retrying…',
   'grading.aiSuggests': 'AI suggests {score}/{max}',
   'grading.confident': '{pct}% confident',
+  'grading.lowConfidenceNote':
+    "The AI is unsure about this one — read the response and double-check before accepting.",
   'grading.autoGraded': 'Auto-graded',
   'grading.stubNote':
     'AI was unavailable, so this suggestion came from a keyword match against the model answer — please review with extra care.',

--- a/frontend_modern/src/shared/i18n/locales/hi.ts
+++ b/frontend_modern/src/shared/i18n/locales/hi.ts
@@ -528,6 +528,8 @@ export const hi: LocaleDict = {
   'grading.retrying': 'फिर कोशिश हो रही है…',
   'grading.aiSuggests': 'AI सुझाव: {score}/{max}',
   'grading.confident': '{pct}% आश्वस्त',
+  'grading.lowConfidenceNote':
+    'AI इस उत्तर को लेकर अनिश्चित है — स्वीकार करने से पहले उत्तर पढ़कर दोबारा जाँच लें।',
   'grading.autoGraded': 'स्वतः जाँचा',
   'grading.stubNote':
     'AI उपलब्ध नहीं था, इसलिए यह सुझाव मॉडल उत्तर से कीवर्ड मिलान पर आधारित है — कृपया अतिरिक्त सावधानी से समीक्षा करें।',


### PR DESCRIPTION
## Surface
Open-response grading queue (teacher `OpenResponseGradingPage` → `GradeCard`) — the consumer of `/ai/open-grades/`.

## Gap (polished-checklist #1 degradation, #3 copy/tone)
The AI's confidence was rendered as **flat gray text** (`{pct}% confident`) for *every* suggestion, so a 42%-confident grade looked identical to a 95%-confident one. The **"Accept suggestion"** button defaults to the AI's score and **finalises in one click** — so a teacher could lock in a low-confidence AI grade with no signal the model was unsure and the response deserved a careful read. (The stub path already warns "review with extra care"; a *real* LLM returning low confidence had no such nudge.)

## Fix
- Confidence now renders as a V2 `Badge`: **amber (`attention`)** below the `LOW_CONFIDENCE = 0.6` threshold, **neutral** otherwise — an uncertain suggestion stands out at a glance.
- Below the threshold (real LLM only — the stub already has its own care note, so we don't stack two warnings) a `grading.lowConfidenceNote` line appears above the review form: *"The AI is unsure about this one — read the response and double-check before accepting."* Localised in **en + hi**.
- Added two tests: a 0.42-confidence grade shows the amber percentage + the double-check note; a confident (0.85) grade does **not** show the note.

## Before / after
- **Before:** every confidence shown as identical gray `X% confident`; one-click accept on a 40%-confident grade with no warning.
- **After:** low-confidence → amber badge + "double-check before accepting" note; high-confidence → calm neutral badge, no note.

## Verify
Teacher → Open-response grading queue. An AI suggestion with confidence < 60% shows an amber confidence badge and the double-check note above the review form; a high-confidence one shows a neutral badge and no note.

## Checks
- `OpenResponseGradingPage.test.tsx` — 12/12 pass (2 new)
- i18n parity guard — pass
- `tsc --noEmit` + eslint — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)