### PR TITLE
ci(deps): auto-merge minor/patch Dependabot PRs once CI is green

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -1,0 +1,74 @@
+name: Dependabot auto-merge
+# Auto-approves and enables auto-merge for Dependabot version-update PRs that
+# are *minor* or *patch* bumps. Majors (e.g. django 4.2 → 6.0, eslint 8 → 10)
+# are runtime/API upgrades that need a human to review against CI and mypy, so
+# they are deliberately left for manual handling — this workflow takes no
+# action on them.
+#
+# Why this exists: the dependabot config (.github/dependabot.yml) groups routine
+# minor/patch bumps, but they still pile up unattended (20+ open at one point).
+# Every PR already runs the full CI gate (lint, typecheck, security, test,
+# frontend, e2e, dependency-review) plus branch protection, so a green
+# minor/patch bump is safe to land without manual clicks. Auto-merge only
+# completes once those required checks pass — this workflow just queues it.
+#
+# ── Prerequisites (configured once by a repo admin) ──────────────────────────
+#   1. Settings → General → "Allow auto-merge"  → enabled.
+#   2. Settings → Actions → General → "Allow GitHub Actions to create and
+#      approve pull requests" → enabled (so the auto-approve step below
+#      satisfies the "Require approvals: 1" branch-protection rule — see
+#      docs/infra/branch-protection.md).
+#   3. Branch protection on `modernization` with required status checks (already
+#      documented). Without required checks, `--auto` merges immediately rather
+#      than waiting for CI.
+#
+# This is a separate workflow from ci-cd.yaml because it must trigger on the
+# `pull_request` event (ci-cd.yaml is push-triggered) and is scoped to the
+# Dependabot actor.
+
+on: pull_request
+
+# Least-privilege: only what's needed to approve and queue the merge.
+permissions:
+    contents: write
+    pull-requests: write
+
+jobs:
+    dependabot-automerge:
+        name: Approve + enable auto-merge (minor/patch)
+        runs-on: ubuntu-latest
+        # Only act on Dependabot-authored PRs. For these runs GitHub grants the
+        # GITHUB_TOKEN the permissions declared above (no repo secrets are
+        # exposed), which is enough to approve and enable auto-merge.
+        if: github.actor == 'dependabot[bot]'
+        steps:
+            - name: Fetch Dependabot metadata
+              # Exposes the semver update-type and other facts about the bump
+              # without parsing the PR title ourselves.
+              id: metadata
+              uses: dependabot/fetch-metadata@v2
+              with:
+                github-token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Approve the PR
+              # Satisfies the "Require approvals: 1" rule so auto-merge can
+              # complete once checks are green. Scoped to minor/patch only.
+              if: |
+                steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+                steps.metadata.outputs.update-type == 'version-update:semver-patch'
+              env:
+                PR_URL: ${{ github.event.pull_request.html_url }}
+                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: gh pr review --approve "$PR_URL"
+
+            - name: Enable auto-merge for minor/patch updates
+              # `--auto` queues the merge; GitHub completes it only after all
+              # required status checks pass. `--squash` keeps the dep history to
+              # a single commit per bump.
+              if: |
+                steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+                steps.metadata.outputs.update-type == 'version-update:semver-patch'
+              env:
+                PR_URL: ${{ github.event.pull_request.html_url }}
+                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: gh pr merge --auto --squash "$PR_URL"

--- a/docs/infra/branch-protection.md
+++ b/docs/infra/branch-protection.md
@@ -43,6 +43,15 @@ In **Settings → Branches → Add branch protection rule**, set the branch name
 | Block force-push and deletion | `modernization` and `qa` are shared history — losing commits or rewriting history breaks everyone's clones. |
 | Apply to admins ("Do not allow bypassing") | Self-explanatory; the rules are worthless if the most active committers can skip them. |
 
+## Repo-level settings for Dependabot auto-merge
+
+The [`Dependabot auto-merge`](../../.github/workflows/dependabot-automerge.yaml) workflow approves and queues minor/patch dependency bumps once CI is green. For it to actually complete a merge, two repo-level settings (outside branch protection) must be enabled:
+
+- **Settings → General → Pull Requests → ☑ Allow auto-merge** — without this, `gh pr merge --auto` errors.
+- **Settings → Actions → General → Workflow permissions → ☑ Allow GitHub Actions to create and approve pull requests** — lets the workflow's auto-approve step satisfy the "Require approvals: 1" rule above. Without it, minor/patch PRs queue but never merge because they sit unapproved.
+
+Majors are intentionally excluded from auto-merge and always need a manual review + approval.
+
 ## Verifying the configuration
 
 After applying, the easiest sanity check is to open a draft PR with a deliberately failing test or lint error and confirm GitHub blocks the merge button until the check passes.


### PR DESCRIPTION
## What

Adds `.github/workflows/dependabot-automerge.yaml` — a `pull_request`-triggered workflow that, for **Dependabot-authored** PRs, auto-approves and enables GitHub **auto-merge (squash)** on **semver-minor** and **semver-patch** bumps. **Major** bumps are deliberately untouched and still need a human.

## Why

Dependabot PRs pile up unattended (**20+ open** at the time of writing — e.g. #327–#346). The repo already has a comprehensive gate on every PR:

- ci-cd.yaml jobs: `Lint`, `Type Check (mypy)`, `Security Audit`, `Test`, `Frontend (Lint, Types, Tests)`, Playwright e2e
- `dependency-review.yaml` (CVE/license diff gate)
- branch protection (required checks + 1 approval)

So a **green minor/patch bump is safe to land without manual clicks**. `gh pr merge --auto` only completes once the required checks pass — this workflow just queues it. Majors (e.g. `django 4.2 → 6.0`, `eslint 8 → 10`, `mypy 1 → 2`) are runtime/API upgrades that keep getting human review.

## Prerequisites (one-time repo admin settings)

Documented in `docs/infra/branch-protection.md` (updated here):

1. **Settings → General → Allow auto-merge** — enabled.
2. **Settings → Actions → General → Allow GitHub Actions to create and approve pull requests** — enabled, so the auto-approve step satisfies the existing "Require approvals: 1" rule.

Without these, minor/patch PRs queue but don't merge; nothing breaks for majors either way.

## Validation

- `actionlint` clean (matches the `workflow-lint` CI job)
- YAML parses; least-privilege `permissions` (`contents: write`, `pull-requests: write`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)