### PR TITLE
feat(i18n): LA-9a — N-locale registry + pilot-coverage parity

### DIFF
--- a/docs/changes/2026-06-13-la9a-locale-registry.md
+++ b/docs/changes/2026-06-13-la9a-locale-registry.md
@@ -1,0 +1,65 @@
+# LA-9a — N-locale framework + pilot-coverage parity model
+
+**Date:** 2026-06-13
+**Classification:** New / hardening (foundation for LA-9 third-language pilot)
+**Initiative:** Language Access (`docs/initiatives/2026-language-access.md`)
+
+## Summary
+
+Generalized the hardcoded binary `en | hi` i18n machine into an N-locale
+**registry** that every consumer reads from, and replaced the all-or-nothing
+parity guard with a **pilot-coverage** contract. This pays the engineering tax
+once so that adding a third language (Marathi, LA-9b+) is a pure content task —
+the initiative North Star's "a third language must be a content task, not an
+engineering task."
+
+**Zero behavior change for en/hi:** every pre-existing i18n test
+(`i18n.test.tsx`, `format.test.ts`, the switcher test) passes **unedited**, the
+`hi` dictionary still splits into its own lazy chunk (75 kB), and the entry
+chunk is unchanged at 140 kB (160 kB budget holds).
+
+## What changed
+
+- **New `frontend_modern/src/shared/i18n/locales/registry.ts`** — the single
+  source of truth: `LOCALES` (per-locale `label`, `nativeName`, `htmlLang`,
+  `intlLocale`, `coverage`), `localeMeta()`, `isLocale()`, `localeLoaders` (lazy
+  dict loaders; English is eager and intentionally absent), and `DEFAULT_LOCALE`.
+  Registers only `en` + `hi`, both `complete` — the empty third seat is the
+  proof that a new language is now additive.
+- **`i18nContext.ts`** — `Locale` and `isLocale` now come from the registry
+  (re-exported for back-compat); `resolveInitialLocale` falls back to
+  `DEFAULT_LOCALE`.
+- **`I18nProvider.tsx`** — single `hiDictCache` + hardcoded `import('./locales/hi')`
+  replaced with a `Map<Locale, LoadedDict>` cache and a generic loader driven by
+  `localeLoaders[locale]`. Loaded dicts are typed as a `Partial` of the English
+  key set so a **pilot** locale can be a subset (English fills gaps in `t()`).
+  `<html lang>` syncs from `localeMeta(locale).htmlLang`.
+- **`format.ts`** — `intlLocale` ternary replaced with `localeMeta(locale).intlLocale`.
+- **`dateFnsLocale.ts`** — `locale === 'hi'` branch replaced with a
+  `Partial<Record<Locale, DateFnsLocale>>` map (append one line per locale).
+- **`LanguageSwitcher.tsx`** — renders `LOCALES.map(...)` instead of two literal
+  buttons, so a new registry entry appears in the switcher automatically. With
+  only en/hi registered the rendered output is identical to before.
+- **`parity.test.ts`** — rewritten as a registry-driven pilot-coverage contract:
+  `complete` locales require exact key parity + no blanks; `pilot` locales may be
+  a subset but every defined key must exist in English, match its `{var}`
+  placeholders, and be non-blank.
+- **New `registry.test.ts`** — asserts every entry has non-empty metadata,
+  unique codes, English is the default + complete, `localeMeta` round-trips and
+  falls back, `isLocale` accepts only registered codes, and loaders exist for
+  every non-English locale.
+
+## Tests
+
+- `npx tsc --noEmit` — clean
+- `npx eslint src/shared/i18n/` — clean
+- `npx vitest run src/shared/i18n/` — 29 passed (4 files), all pre-existing tests
+  unedited
+- `npm run build` — `hi-*.js` chunk splits out (75 kB), entry chunk 140 kB
+  (under 160 kB budget)
+
+## Next steps
+
+LA-9b: register `mr` (Marathi) + backend `preferred_language` choice + a
+`locales/mr.ts` pilot subset covering the anonymous journey. After 9a, that's a
+one-line registry edit + a union widening + content.

--- a/frontend_modern/src/shared/i18n/I18nProvider.tsx
+++ b/frontend_modern/src/shared/i18n/I18nProvider.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
-import { en, type LocaleKey, type LocaleDict } from './locales/en';
+import { en, type LocaleKey } from './locales/en';
+import { localeLoaders, localeMeta, DEFAULT_LOCALE } from './locales/registry';
 import {
   I18nContext,
   interpolate,
@@ -9,9 +10,16 @@ import {
   type Translate,
 } from './i18nContext';
 
-// Module-level cache: after the first dynamic import, locale switches are
-// synchronous for the rest of the session.
-let hiDictCache: LocaleDict | null = null;
+/**
+ * A loaded locale dictionary may be a complete (`hi`) or a pilot subset (`mr`)
+ * of the English key set — English fills any gaps in `t()`.
+ */
+type LoadedDict = Partial<Record<LocaleKey, string>>;
+
+// Module-level cache keyed by locale: after the first dynamic import, switching
+// back to a locale is synchronous for the rest of the session. English is the
+// eager fallback and never goes through the loader, so it's absent here.
+const dictCache = new Map<Locale, LoadedDict>();
 
 interface I18nProviderProps {
   children: ReactNode;
@@ -37,7 +45,12 @@ export const I18nProvider = ({
   onLocaleChange,
 }: I18nProviderProps) => {
   const [locale, setLocaleState] = useState<Locale>(() => initialLocale ?? resolveInitialLocale());
-  const [hiDict, setHiDict] = useState<LocaleDict | null>(hiDictCache);
+  // Loaded non-English dictionaries this session. Seeded from the module cache
+  // so a re-mount doesn't re-fetch; only ever grown asynchronously (after a
+  // dynamic import resolves), never mutated synchronously inside an effect.
+  const [loadedDicts, setLoadedDicts] = useState<Map<Locale, LoadedDict>>(
+    () => new Map(dictCache),
+  );
 
   // Ref so setLocale stays referentially stable across handler re-creations.
   const onLocaleChangeRef = useRef(onLocaleChange);
@@ -60,25 +73,34 @@ export const I18nProvider = ({
     if (!hasDeviceOverride) setLocaleState(profileLocale);
   }
 
-  // Fetch the Hindi dictionary on demand (keeps it out of the entry chunk).
-  // Until it arrives, t() serves the English fallback — never a blank
-  // (initiative principle 3).
+  // Fetch the active locale's dictionary on demand (keeps every non-English
+  // locale out of the entry chunk). English needs no fetch; until a fetched
+  // dict arrives, t() serves the English fallback — never a blank (principle 3).
   useEffect(() => {
-    if (locale !== 'hi' || hiDict) return;
+    // English needs no fetch; an already-loaded dict is reused (no setState).
+    if (locale === DEFAULT_LOCALE || loadedDicts.has(locale)) return;
+    const load = localeLoaders[locale];
+    if (!load) return; // No loader registered — stay on the English fallback.
     let cancelled = false;
-    void import('./locales/hi').then((module) => {
-      hiDictCache = module.hi;
-      if (!cancelled) setHiDict(module.hi);
+    void load().then((module) => {
+      // The dictionary is exported under the locale code (e.g. `hi`, `mr`).
+      const dict = ((module as Record<string, LoadedDict | undefined>)[locale] ??
+        (module.default as LoadedDict | undefined)) as LoadedDict | undefined;
+      if (!dict) return;
+      dictCache.set(locale, dict);
+      if (cancelled) return;
+      setLoadedDicts((prev) => new Map(prev).set(locale, dict));
     });
     return () => {
       cancelled = true;
     };
-  }, [locale, hiDict]);
+  }, [locale, loadedDicts]);
 
   // Keep <html lang> in sync — screen readers and the Devanagari font stack
-  // both key off it.
+  // both key off it. Use the registry's htmlLang so a locale can map to a
+  // different document language tag than its registry code if needed.
   useEffect(() => {
-    document.documentElement.lang = locale;
+    document.documentElement.lang = localeMeta(locale).htmlLang;
   }, [locale]);
 
   const setLocale = useCallback((next: Locale) => {
@@ -93,10 +115,11 @@ export const I18nProvider = ({
 
   const t = useCallback<Translate>(
     (key, vars) => {
-      // Partial view: key parity is tsc-enforced, but the runtime fallback
-      // stays honest if a locale file ever drifts (e.g. hand-edited build).
+      // English (the default + fallback) is always the eager `en`. A non-English
+      // locale uses its loaded dict if present, else the English fallback while
+      // it streams in or for any key a pilot locale doesn't define (principle 3).
       const active: Partial<Record<LocaleKey, string>> =
-        locale === 'hi' && hiDict ? hiDict : en;
+        locale === DEFAULT_LOCALE ? en : (loadedDicts.get(locale) ?? en);
       const template = active[key];
       if (template === undefined) {
         if (import.meta.env.DEV) {
@@ -106,7 +129,7 @@ export const I18nProvider = ({
       }
       return interpolate(template, vars);
     },
-    [locale, hiDict],
+    [locale, loadedDicts],
   );
 
   return <I18nContext.Provider value={{ locale, setLocale, t }}>{children}</I18nContext.Provider>;

--- a/frontend_modern/src/shared/i18n/LanguageSwitcher.tsx
+++ b/frontend_modern/src/shared/i18n/LanguageSwitcher.tsx
@@ -1,9 +1,12 @@
 import { useI18n } from './i18nContext';
+import { LOCALES } from './locales/registry';
 
 /**
- * Compact "EN | हिं" segmented toggle. One tap switches the whole UI locale
- * (initiative North Star). Lives in the navbar (desktop), the mobile account
- * sheet, and the auth pages.
+ * Compact segmented locale toggle ("EN | हिं | …"). One tap switches the whole
+ * UI locale (initiative North Star). Renders one button per registered locale
+ * (LA-9a), so adding a language to the registry shows it here automatically —
+ * no switcher edit. Lives in the navbar (desktop), the mobile account sheet,
+ * and the auth pages.
  */
 export const LanguageSwitcher = ({ className = '' }: { className?: string }) => {
   const { locale, setLocale, t } = useI18n();
@@ -19,25 +22,19 @@ export const LanguageSwitcher = ({ className = '' }: { className?: string }) => 
       aria-label={t('common.language')}
       className={`inline-flex items-center gap-0.5 rounded-lg border border-ink-200 bg-white p-0.5 ${className}`}
     >
-      <button
-        type="button"
-        onClick={() => setLocale('en')}
-        aria-pressed={locale === 'en'}
-        aria-label={t('common.languageSwitchTo', { language: 'English' })}
-        className={segment(locale === 'en')}
-      >
-        EN
-      </button>
-      <button
-        type="button"
-        lang="hi"
-        onClick={() => setLocale('hi')}
-        aria-pressed={locale === 'hi'}
-        aria-label={t('common.languageSwitchTo', { language: 'हिंदी' })}
-        className={segment(locale === 'hi')}
-      >
-        हिं
-      </button>
+      {LOCALES.map((meta) => (
+        <button
+          key={meta.code}
+          type="button"
+          lang={meta.htmlLang}
+          onClick={() => setLocale(meta.code)}
+          aria-pressed={locale === meta.code}
+          aria-label={t('common.languageSwitchTo', { language: meta.nativeName })}
+          className={segment(locale === meta.code)}
+        >
+          {meta.label}
+        </button>
+      ))}
     </div>
   );
 };

--- a/frontend_modern/src/shared/i18n/dateFnsLocale.ts
+++ b/frontend_modern/src/shared/i18n/dateFnsLocale.ts
@@ -4,12 +4,20 @@ import type { Locale } from './i18nContext';
 
 /**
  * date-fns locale for relative-time strings ("3 दिन में" instead of
- * "in 3 days") when the UI is in Hindi. `undefined` keeps date-fns's
- * built-in English default.
+ * "in 3 days"). `undefined` keeps date-fns's built-in English default, used
+ * for English and for any locale without a date-fns mapping (it still gets
+ * localized chrome + `Intl` absolute dates — only relative phrasing falls back).
  *
- * Deliberately NOT re-exported from the i18n barrel: the barrel is imported
- * by App (the entry chunk) and the Hindi date locale should only ship inside
- * the lazy page chunks that format dates. Import this module directly.
+ * One entry per locale that has a date-fns locale (LA-9a registry model):
+ * append a line as each language lands its student-loop chrome (mr in LA-9c).
+ *
+ * Deliberately NOT re-exported from the i18n barrel: the barrel is imported by
+ * App (the entry chunk) and these date locales should only ship inside the lazy
+ * page chunks that format relative dates. Import this module directly.
  */
+const DATE_FNS_LOCALES: Partial<Record<Locale, DateFnsLocale>> = {
+  hi: hiDateLocale,
+};
+
 export const dateFnsLocaleFor = (locale: Locale): DateFnsLocale | undefined =>
-  locale === 'hi' ? hiDateLocale : undefined;
+  DATE_FNS_LOCALES[locale];

--- a/frontend_modern/src/shared/i18n/format.ts
+++ b/frontend_modern/src/shared/i18n/format.ts
@@ -1,4 +1,5 @@
 import { useI18n, type Locale } from './i18nContext';
+import { localeMeta } from './locales/registry';
 
 /**
  * LA-8 — locale-aware date/number formatting via the platform `Intl` API.
@@ -13,7 +14,7 @@ import { useI18n, type Locale } from './i18nContext';
  * See docs/initiatives/2026-language-access.md.
  */
 
-const intlLocale = (locale: Locale): string => (locale === 'hi' ? 'hi-IN' : 'en-IN');
+const intlLocale = (locale: Locale): string => localeMeta(locale).intlLocale;
 
 /** Indian convention: "27 May 2026" / "27 मई 2026" (day-first, no comma). */
 const DEFAULT_DATE_OPTS: Intl.DateTimeFormatOptions = {

--- a/frontend_modern/src/shared/i18n/i18nContext.ts
+++ b/frontend_modern/src/shared/i18n/i18nContext.ts
@@ -1,23 +1,25 @@
 import { createContext, useContext } from 'react';
 import { en, type LocaleKey } from './locales/en';
+import { DEFAULT_LOCALE, isLocale, type Locale } from './locales/registry';
 
 /**
  * OpenShiksha i18n — a deliberately tiny in-house module (no i18next).
  *
- * Two locales with `{var}` interpolation don't justify a 45 kB dependency
- * against a 160 kB entry-chunk budget; see
- * docs/initiatives/2026-language-access.md, principle 2. English is bundled
- * eagerly (it's the fallback and the default); Hindi is fetched with a
- * dynamic import the first time the user switches, so the entry chunk does
- * not grow.
+ * The set of locales lives in `locales/registry.ts` (LA-9a): one entry per
+ * language drives the switcher, `Intl` formatting, the dict loader, and the
+ * parity guard, so a new language is a content task, not an engineering one
+ * (docs/initiatives/2026-language-access.md, North Star). An in-house module is
+ * still the right call against a 160 kB entry-chunk budget (principle 2):
+ * English is bundled eagerly (default + fallback); every other locale is
+ * fetched with a dynamic import on first switch, so the entry chunk doesn't
+ * grow with the language count.
  */
 
-export type Locale = 'en' | 'hi';
+export type { Locale };
+export { isLocale };
 
 /** localStorage key for the per-device language override. */
 export const LOCALE_STORAGE_KEY = 'os_lang';
-
-export const isLocale = (value: unknown): value is Locale => value === 'en' || value === 'hi';
 
 /**
  * Precedence contract for the boot locale (LA-2 adds the profile layer):
@@ -30,7 +32,7 @@ export const resolveInitialLocale = (): Locale => {
   } catch {
     // Storage unavailable (private mode, SSR) — fall through to default.
   }
-  return 'en';
+  return DEFAULT_LOCALE;
 };
 
 export type TranslateVars = Record<string, string | number>;
@@ -53,7 +55,7 @@ export const interpolate = (template: string, vars?: TranslateVars): string => {
 // degrades to a working English-only translator instead of throwing —
 // principle 3: English is the fallback, never a blank.
 const defaultI18nValue: I18nContextValue = {
-  locale: 'en',
+  locale: DEFAULT_LOCALE,
   setLocale: () => {
     if (import.meta.env.DEV) {
       console.warn('[i18n] setLocale called outside <I18nProvider> — ignored');

--- a/frontend_modern/src/shared/i18n/locales/registry.ts
+++ b/frontend_modern/src/shared/i18n/locales/registry.ts
@@ -1,0 +1,86 @@
+import type { LocaleDict } from './en';
+
+/**
+ * LA-9a — the locale registry: the single source of truth for "what locales
+ * exist" and everything per-locale that used to be hardcoded across six files
+ * (`i18nContext`, `I18nProvider`, `LanguageSwitcher`, `format`, `dateFnsLocale`,
+ * the parity guard).
+ *
+ * The initiative North Star demands a third language be **a content task, not
+ * an engineering task** (docs/initiatives/2026-language-access.md). Adding a
+ * locale is now: append one `LOCALES` entry, widen the `Locale` union, register
+ * a lazy `loader`, drop in a `locales/<code>.ts` dictionary. No consumer edits.
+ *
+ * Coverage model:
+ * - `complete` ⇒ full key parity with English + no blanks (en, hi).
+ * - `pilot`    ⇒ a *subset* is allowed; English fills the gaps at runtime
+ *               (principle 3 — English is the fallback, never a blank). A new
+ *               regional language can ship surface-by-surface this way.
+ */
+
+/**
+ * Every supported UI locale. A string-literal union (not derived from the
+ * array) so `t()` keys and locale params stay statically checked; the
+ * `satisfies` below keeps the union and the registry honest about each other.
+ */
+export type Locale = 'en' | 'hi';
+
+export interface LocaleMeta {
+  /** Registry key — matches a `locales/<code>.ts` module. */
+  code: Locale;
+  /** Compact switcher glyph, e.g. 'EN', 'हिं'. */
+  label: string;
+  /** Endonym for aria-labels / a11y, e.g. 'English', 'हिंदी'. */
+  nativeName: string;
+  /** `document.documentElement.lang` value (font stack + screen readers). */
+  htmlLang: string;
+  /** BCP-47 tag for `Intl` (dates/numbers) and date-fns mapping. */
+  intlLocale: string;
+  /** `complete` ⇒ full parity required; `pilot` ⇒ subset allowed. */
+  coverage: 'complete' | 'pilot';
+}
+
+/**
+ * Lazy dictionary loaders. English is bundled eagerly (it's the default and the
+ * fallback) so it is intentionally absent here; every other locale ships in its
+ * own chunk fetched on first switch. An explicit map — rather than a template
+ * `import(`./locales/${code}`)` — keeps Vite's static chunk analysis reliable
+ * and the entry chunk untouched.
+ */
+export const localeLoaders: Partial<
+  Record<Locale, () => Promise<{ default?: LocaleDict } & Record<string, unknown>>>
+> = {
+  hi: () => import('./hi'),
+};
+
+export const LOCALES = [
+  {
+    code: 'en',
+    label: 'EN',
+    nativeName: 'English',
+    htmlLang: 'en',
+    intlLocale: 'en-IN',
+    coverage: 'complete',
+  },
+  {
+    code: 'hi',
+    label: 'हिं',
+    nativeName: 'हिंदी',
+    htmlLang: 'hi',
+    intlLocale: 'hi-IN',
+    coverage: 'complete',
+  },
+] as const satisfies readonly LocaleMeta[];
+
+/** Default + fallback locale. */
+export const DEFAULT_LOCALE: Locale = 'en';
+
+const byCode = new Map<Locale, LocaleMeta>(LOCALES.map((l) => [l.code, l]));
+
+/** Registry lookup. Falls back to English metadata for an unknown code. */
+export const localeMeta = (code: Locale): LocaleMeta =>
+  byCode.get(code) ?? byCode.get(DEFAULT_LOCALE)!;
+
+/** Type guard used by `resolveInitialLocale` and the switcher. */
+export const isLocale = (value: unknown): value is Locale =>
+  typeof value === 'string' && byCode.has(value as Locale);

--- a/frontend_modern/src/shared/i18n/parity.test.ts
+++ b/frontend_modern/src/shared/i18n/parity.test.ts
@@ -1,49 +1,93 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { en } from './locales/en';
-import { hi } from './locales/hi';
+import { LOCALES, localeLoaders, type Locale } from './locales/registry';
 
 /**
- * LA-5 key-parity guard. Key parity is already tsc-enforced (`LocaleDict`),
- * but this runtime test fails with a readable list of the drifted keys and
- * also checks what the type system can't: that the `{var}` interpolation
- * placeholders match between locales, and that no translation is blank.
+ * LA-5 → LA-9a parity guard, now registry-driven with a pilot-coverage model.
+ *
+ * For every registered non-English locale we load its dictionary and apply a
+ * contract that depends on its declared `coverage`:
+ *
+ * - `complete` (en, hi): exact key-set parity with English — no missing keys,
+ *   no extra keys — and no blank strings.
+ * - `pilot` (e.g. mr): a *subset* is allowed (English fills the gaps at
+ *   runtime, principle 3), but every key it *does* define must (i) exist in
+ *   English and (ii) match English's `{var}` placeholders, and never be blank.
+ *
+ * Key parity for `complete` locales is also tsc-enforced (`LocaleDict`); this
+ * runtime test fails with a readable list of the drifted keys and checks what
+ * the type system can't (placeholder drift, blanks, pilot subset validity).
  * Runs in the normal vitest gate — no CI pipeline changes.
  */
 
 const placeholdersOf = (template: string): string[] =>
   [...template.matchAll(/\{(\w+)\}/g)].map((m) => m[1]).sort();
 
-describe('locale key parity (en ↔ hi)', () => {
-  it('en and hi have identical key sets', () => {
-    const enKeys = Object.keys(en);
-    const hiKeys = Object.keys(hi);
-    const missingInHi = enKeys.filter((k) => !(k in hi));
-    const extraInHi = hiKeys.filter((k) => !(k in en));
+const enKeys = Object.keys(en);
+const enKeySet = new Set(enKeys);
 
-    expect(missingInHi, `keys missing from hi.ts: ${missingInHi.join(', ')}`).toEqual([]);
-    expect(extraInHi, `keys in hi.ts but not en.ts: ${extraInHi.join(', ')}`).toEqual([]);
-  });
+type Dict = Partial<Record<string, string>>;
 
-  it('no locale string is blank', () => {
-    const blankEn = Object.entries(en).filter(([, v]) => v.trim() === '');
-    const blankHi = Object.entries(hi).filter(([, v]) => v.trim() === '');
-    expect(blankEn.map(([k]) => k)).toEqual([]);
-    expect(blankHi.map(([k]) => k)).toEqual([]);
-  });
+// Load every non-English dictionary once (en is the eager source of truth).
+const dicts: Partial<Record<Locale, Dict>> = { en };
 
-  it('interpolation placeholders match between locales', () => {
-    const mismatches = Object.keys(en)
-      .filter((k) => k in hi)
-      .map((k) => ({
-        key: k,
-        en: placeholdersOf(en[k as keyof typeof en]),
-        hi: placeholdersOf(hi[k as keyof typeof hi]),
-      }))
-      .filter(({ en: a, hi: b }) => JSON.stringify(a) !== JSON.stringify(b));
+beforeAll(async () => {
+  for (const meta of LOCALES) {
+    if (meta.code === 'en') continue;
+    const load = localeLoaders[meta.code];
+    expect(load, `locale "${meta.code}" is registered but has no loader`).toBeTruthy();
+    const module = (await load!()) as Record<string, Dict | undefined>;
+    const dict = module[meta.code] ?? (module.default as Dict | undefined);
+    expect(dict, `loader for "${meta.code}" must export a dictionary`).toBeTruthy();
+    dicts[meta.code] = dict!;
+  }
+});
 
-    expect(
-      mismatches,
-      `placeholder drift: ${mismatches.map((m) => `${m.key} (en: {${m.en}} vs hi: {${m.hi}})`).join('; ')}`,
-    ).toEqual([]);
-  });
+describe('locale key parity (registry-driven, pilot-coverage)', () => {
+  for (const meta of LOCALES) {
+    if (meta.code === 'en') continue;
+
+    describe(`${meta.code} (${meta.coverage})`, () => {
+      it('defines only keys that exist in English', () => {
+        const extra = Object.keys(dicts[meta.code]!).filter((k) => !enKeySet.has(k));
+        expect(extra, `keys in ${meta.code}.ts but not en.ts: ${extra.join(', ')}`).toEqual([]);
+      });
+
+      it('has no blank strings', () => {
+        const blank = Object.entries(dicts[meta.code]!)
+          .filter(([, v]) => (v ?? '').trim() === '')
+          .map(([k]) => k);
+        expect(blank, `blank strings in ${meta.code}.ts: ${blank.join(', ')}`).toEqual([]);
+      });
+
+      it('matches English interpolation placeholders for every key it defines', () => {
+        const dict = dicts[meta.code]!;
+        const mismatches = Object.keys(dict)
+          .filter((k) => enKeySet.has(k))
+          .map((k) => ({
+            key: k,
+            en: placeholdersOf(en[k as keyof typeof en]),
+            loc: placeholdersOf(dict[k] as string),
+          }))
+          .filter(({ en: a, loc: b }) => JSON.stringify(a) !== JSON.stringify(b));
+
+        expect(
+          mismatches,
+          `placeholder drift in ${meta.code}: ${mismatches
+            .map((m) => `${m.key} (en: {${m.en}} vs ${meta.code}: {${m.loc}})`)
+            .join('; ')}`,
+        ).toEqual([]);
+      });
+
+      if (meta.coverage === 'complete') {
+        it('has exact key-set parity with English (complete coverage)', () => {
+          const missing = enKeys.filter((k) => !(k in dicts[meta.code]!));
+          expect(
+            missing,
+            `keys missing from ${meta.code}.ts: ${missing.join(', ')}`,
+          ).toEqual([]);
+        });
+      }
+    });
+  }
 });

--- a/frontend_modern/src/shared/i18n/registry.test.ts
+++ b/frontend_modern/src/shared/i18n/registry.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import {
+  LOCALES,
+  localeMeta,
+  isLocale,
+  localeLoaders,
+  DEFAULT_LOCALE,
+} from './locales/registry';
+
+/**
+ * LA-9a — guards the locale registry, the single source of truth that the
+ * switcher, dict loader, `Intl` formatting, and the parity guard all read from.
+ * If these hold, adding a language is a content task (new entry + dictionary),
+ * not an engineering one.
+ */
+describe('locale registry', () => {
+  it('every entry has non-empty metadata fields', () => {
+    for (const meta of LOCALES) {
+      expect(meta.code, 'code').toBeTruthy();
+      expect(meta.label.trim(), `label for ${meta.code}`).not.toBe('');
+      expect(meta.nativeName.trim(), `nativeName for ${meta.code}`).not.toBe('');
+      expect(meta.htmlLang.trim(), `htmlLang for ${meta.code}`).not.toBe('');
+      expect(meta.intlLocale, `intlLocale for ${meta.code}`).toMatch(/^[a-z]{2}(-[A-Z]{2})?$/);
+      expect(['complete', 'pilot']).toContain(meta.coverage);
+    }
+  });
+
+  it('codes are unique', () => {
+    const codes = LOCALES.map((l) => l.code);
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+
+  it('English is registered, the default, and complete', () => {
+    expect(DEFAULT_LOCALE).toBe('en');
+    const en = LOCALES.find((l) => l.code === 'en');
+    expect(en).toBeDefined();
+    expect(en!.coverage).toBe('complete');
+  });
+
+  it('localeMeta round-trips every registered code', () => {
+    for (const meta of LOCALES) {
+      expect(localeMeta(meta.code)).toEqual(meta);
+    }
+  });
+
+  it('localeMeta falls back to the default for an unknown code', () => {
+    // @ts-expect-error — exercising the runtime fallback with an invalid code.
+    expect(localeMeta('zz').code).toBe(DEFAULT_LOCALE);
+  });
+
+  it('isLocale accepts registered codes and rejects everything else', () => {
+    for (const meta of LOCALES) expect(isLocale(meta.code)).toBe(true);
+    expect(isLocale('zz')).toBe(false);
+    expect(isLocale(null)).toBe(false);
+    expect(isLocale(42)).toBe(false);
+  });
+
+  it('English has no loader (eager) and every other locale does', () => {
+    expect(localeLoaders.en).toBeUndefined();
+    for (const meta of LOCALES) {
+      if (meta.code === 'en') continue;
+      expect(localeLoaders[meta.code], `loader for ${meta.code}`).toBeTypeOf('function');
+    }
+  });
+});


### PR DESCRIPTION
## Classification
New / hardening — foundation for the LA-9 third-language (Marathi) pilot.

## What & why
Generalizes the hardcoded binary `en | hi` i18n machine into a single **locale registry** that the switcher, dict loader, `Intl` formatting, and the parity guard all read from, and replaces the all-or-nothing parity guard with a **pilot-coverage** contract. This pays the engineering tax once so a third language is a *content task, not an engineering task* (initiative North Star).

- **New `locales/registry.ts`** — `LOCALES` (per-locale `label`/`nativeName`/`htmlLang`/`intlLocale`/`coverage`), `localeMeta()`, `isLocale()`, lazy `localeLoaders` (English eager, intentionally absent), `DEFAULT_LOCALE`. Registers only `en` + `hi` (both `complete`).
- **`I18nProvider`** — single `hiDictCache` + hardcoded `import('./locales/hi')` → `Map<Locale, LoadedDict>` cache + generic loader. Loaded dicts typed as a `Partial` of the English key set so a **pilot** locale can be a subset (English fills gaps in `t()`).
- **`LanguageSwitcher`** — renders `LOCALES.map(...)`; a new registry entry shows up automatically.
- **`format.ts` / `dateFnsLocale.ts`** — read `intlLocale` / a date-fns map from the registry.
- **`parity.test.ts`** — registry-driven: `complete` ⇒ exact parity + no blanks; `pilot` ⇒ subset allowed, but defined keys must exist in en, match `{var}` placeholders, be non-blank.
- **New `registry.test.ts`**.

## Zero behavior change for en/hi
Every pre-existing i18n test passes **unedited**. `hi` still splits into its own lazy chunk (75 kB); entry chunk unchanged at 140 kB (160 kB budget holds).

## Tests
- `tsc --noEmit` clean · `eslint src/shared/i18n/` clean
- `vitest run src/shared/i18n/` → 29 passed (4 files)
- `npm run build` → `hi-*.js` chunk splits out, entry 140 kB

## Legacy reference
Legacy Django 1.11 had no i18n — pure new/hardening work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)