### PR TITLE
test(e2e): mobile-form-factor smoke for public surfaces

### DIFF
--- a/docs/changes/2026-06-14-mobile-overflow-smoke.md
+++ b/docs/changes/2026-06-14-mobile-overflow-smoke.md
@@ -1,0 +1,37 @@
+# Mobile-form-factor e2e smoke (Pixel 5) for public surfaces
+
+**Classification:** New (test infrastructure).
+
+## Summary
+Add a Playwright smoke spec that exercises the public, backend-free routes —
+`/`, `/login`, `/enquire`, `/design` — on an emulated handset (Pixel 5:
+393×851, DPR 2.75, touch, mobile UA), and fails CI on the two cheapest,
+highest-signal mobile regressions:
+
+1. **Horizontal overflow** — `documentElement.scrollWidth` exceeding the layout
+   viewport (with 1px slack). This is the single most common mobile layout bug
+   and is invisible to the existing `Desktop Chrome`-only e2e project.
+2. **Console / page errors** — a paint that throws only on mobile (a
+   `matchMedia`/`ResizeObserver` path, etc.) that the desktop smoke would miss.
+
+Directly supports the now-active **Mobile Shell & PWA-Offline** initiative
+(docs/initiatives/2026-mobile-shell-pwa-offline.md): OpenShiksha targets K-12
+students in India on phones, yet until now nothing in CI ran at phone width.
+
+## Files changed
+- **New** `frontend_modern/e2e/mobile.spec.ts` — 4 public routes, each asserting
+  no horizontal overflow + no console errors at Pixel 5 emulation.
+
+## Design notes
+- Uses `test.use({ ...devices['Pixel 5'] })` at the file level rather than a
+  second `playwright.config.ts` project, so it overrides only this spec's device
+  instead of re-running every other spec (a11y, design, visual) at phone width.
+- Runs under the existing `frontend-e2e` CI job + `vite preview` web server —
+  **no CI YAML change** and no new dependency.
+- Scope contract matches `visual.spec.ts`: public routes only. Authenticated
+  mobile chrome (the M5-01 bottom tabs, the upcoming MSO-2 offline banner) needs
+  the Docker stack + seeded DB and belongs in a future backend-attached project.
+
+## Verification
+Run locally (Windows, chromium): `npm run test:e2e -- mobile.spec.ts` — 4
+passed. Type-check (`tsc --noEmit`) and ESLint both clean.

--- a/frontend_modern/e2e/mobile.spec.ts
+++ b/frontend_modern/e2e/mobile.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect, devices, type ConsoleMessage } from '@playwright/test';
+
+// Mobile-form-factor smoke for the public surfaces.
+//
+// Context (2026-06-14): the **Mobile Shell & PWA-Offline** initiative is the
+// active top bet (docs/initiatives/2026-mobile-shell-pwa-offline.md).
+// OpenShiksha targets K-12 students in India on phones, but every e2e project
+// so far runs only `Desktop Chrome` — so a layout that quietly breaks at phone
+// width (the single most common mobile regression) sails through CI green.
+//
+// This spec emulates a real handset (Pixel 5: 393×851, DPR 2.75, touch, mobile
+// UA) and guards the two cheapest, highest-signal mobile failures on the
+// public, backend-free routes:
+//
+//   1. **Horizontal overflow** — content wider than the viewport forces an
+//      ugly left/right scroll and is almost always an unconstrained element
+//      (a fixed width, an un-wrapped fl/grid row, an image without max-width).
+//   2. **Console / page errors** — a paint that throws on mobile but not
+//      desktop (e.g. a `matchMedia`/`ResizeObserver` path) would otherwise be
+//      invisible to the desktop smoke.
+//
+// Only public routes that render their first paint without an API call are
+// covered — same scope contract as visual.spec.ts. Authenticated mobile chrome
+// (the M5-01 bottom tabs, the upcoming MSO-2 offline banner) needs the Docker
+// stack and belongs to a future backend-attached project in
+// playwright.config.ts.
+
+// Emulate a representative Android handset for this file only. This overrides
+// the config's single `Desktop Chrome` project without adding a second project
+// (which would re-run every other spec at phone width for no benefit).
+test.use({ ...devices['Pixel 5'] });
+
+// A 1px slack absorbs sub-pixel rounding of scrollWidth vs. the layout
+// viewport; anything wider is a genuine overflow.
+const OVERFLOW_SLACK = 1;
+
+interface PublicRoute {
+  /** Human-readable name for the test title. */
+  name: string;
+  /** Route to navigate to. */
+  path: string;
+  /** A locator that, once visible, indicates the page has painted. */
+  ready: string;
+}
+
+const PUBLIC_ROUTES: PublicRoute[] = [
+  { name: 'home', path: '/', ready: 'h1' },
+  { name: 'login', path: '/login', ready: 'h1' },
+  { name: 'enquire', path: '/enquire', ready: 'h1' },
+  { name: 'design showcase', path: '/design', ready: 'h1' },
+];
+
+test.describe('mobile smoke — public surfaces (Pixel 5)', () => {
+  for (const route of PUBLIC_ROUTES) {
+    test(`${route.name} paints with no overflow or console errors`, async ({ page }) => {
+      const consoleErrors: string[] = [];
+      page.on('console', (msg: ConsoleMessage) => {
+        if (msg.type() === 'error') consoleErrors.push(msg.text());
+      });
+      page.on('pageerror', (err) => consoleErrors.push(err.message));
+
+      const response = await page.goto(route.path);
+      expect(response?.ok(), `GET ${route.path} should return 2xx`).toBeTruthy();
+
+      await expect(page.locator(route.ready).first()).toBeVisible();
+      // Let webfonts settle so a late-loading glyph can't widen the layout
+      // after we measure.
+      await page.evaluate(() => document.fonts.ready);
+
+      const overflow = await page.evaluate(() => {
+        const doc = document.documentElement;
+        return {
+          scrollWidth: doc.scrollWidth,
+          clientWidth: doc.clientWidth,
+        };
+      });
+      expect(
+        overflow.scrollWidth,
+        `${route.path} overflows horizontally at phone width ` +
+          `(scrollWidth ${overflow.scrollWidth} > clientWidth ${overflow.clientWidth})`,
+      ).toBeLessThanOrEqual(overflow.clientWidth + OVERFLOW_SLACK);
+
+      expect(
+        consoleErrors,
+        `console errors on ${route.path} (mobile):\n${consoleErrors.join('\n')}`,
+      ).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## What

Adds `frontend_modern/e2e/mobile.spec.ts` — a Playwright smoke spec that runs the public, backend-free routes (`/`, `/login`, `/enquire`, `/design`) on an **emulated Pixel 5** (393×851, DPR 2.75, touch, mobile UA) and fails CI on the two highest-signal mobile regressions:

1. **Horizontal overflow** — `documentElement.scrollWidth` exceeding the layout viewport (1px slack). The most common mobile layout bug, completely invisible to the current `Desktop Chrome`-only e2e project.
2. **Console / page errors** — a paint that throws only on mobile (`matchMedia`/`ResizeObserver` paths, etc.) the desktop smoke can't see.

## Why

Supports the now-active **Mobile Shell & PWA-Offline** initiative ([doc](docs/initiatives/2026-mobile-shell-pwa-offline.md)). OpenShiksha targets K-12 students in India on phones, yet until now *nothing in CI ran at phone width* — a layout that breaks at 393px sails through green.

## Design notes

- Uses `test.use({ ...devices['Pixel 5'] })` at the **file level** instead of a second `playwright.config.ts` project, so it overrides only this spec's device rather than re-running a11y/design/visual specs at phone width for no benefit.
- Runs under the existing `frontend-e2e` job + `vite preview` web server — **no CI YAML change, no new dependency**.
- Scope contract matches `visual.spec.ts`: public routes only. Authenticated mobile chrome (M5-01 bottom tabs, the upcoming MSO-2 offline banner) needs the Docker stack and belongs in a future backend-attached project.

## Verification

- `npm run test:e2e -- mobile.spec.ts` → **4 passed** (local, Windows/chromium).
- `tsc --noEmit` and ESLint both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)