### PR TITLE
feat(pwa): network-status hook + localized offline banner (MSO-2)

### DIFF
--- a/docs/changes/2026-06-14-mso2-offline-banner.md
+++ b/docs/changes/2026-06-14-mso2-offline-banner.md
@@ -1,0 +1,53 @@
+# MSO-2 — Network-status hook + offline banner
+
+**Date:** 2026-06-14
+**Classification:** New
+**Initiative:** Mobile Shell & PWA-Offline (Batch 1, PR 2)
+
+## Summary
+
+Give the app an honest, localized offline indicator. A `useOnlineStatus()` hook
+tracks browser connectivity, and a slim `OfflineBanner` rendered in `AppShell`
+appears (warm amber, `aria-live`) whenever the user is offline. Independent of
+the service worker — lands on its own.
+
+## Legacy reference
+
+None — the Django 1.11 app was server-rendered/online-only; a dropped connection
+just produced a dead page. This is a new modern-SPA capability.
+
+## What changed
+
+- **`frontend_modern/src/shared/hooks/useOnlineStatus.ts`** (new) — returns
+  `navigator.onLine`, subscribes to `window` `online`/`offline`, cleans up on
+  unmount. SSR/test-safe default (`true` when `navigator` is undefined). JSDoc
+  documents the `navigator.onLine` optimism caveat: it's fine for a banner, but
+  data fetching must **not** be gated on it (React Query owns fetch failures).
+- **`frontend_modern/src/features/layout/OfflineBanner.tsx`** (new) — renders
+  nothing when online; when offline shows a slim warm-amber banner
+  (`role="status"` + `aria-live="polite"`) with an inline wifi-off SVG and the
+  localized `connectivity.offlineBanner` copy.
+- **`frontend_modern/src/features/layout/AppShell.tsx`** — render
+  `<OfflineBanner />` between `<Navbar />` and `<main>`; skip-link target intact.
+- **i18n** — new `connectivity.` cluster (`offlineTitle`, `offlineBanner`,
+  `backOnline`) added to `en.ts` + `hi.ts` (complete locales) and `mr.ts` (pilot
+  — translated since it's a core-loop string). Parity guard green.
+
+## Tests
+
+- `useOnlineStatus.test.ts` — mount reflects `navigator.onLine`; flips on
+  `offline`/`online` events; unsubscribes listeners on unmount. (3)
+- `OfflineBanner.test.tsx` — nothing when online; polite status banner when
+  offline; appears/disappears across connectivity changes. (3)
+- Full gate: `npx tsc --noEmit` clean, `npm run lint` clean, `npx vitest run`
+  408 passing, `npm run build` ok, bundle budget green (138 kB vs 160 kB).
+
+## Migration notes
+
+None — frontend-only, additive.
+
+## Next steps
+
+- MSO-3: service worker so the precached shell can boot offline (then the banner
+  shows over actually-usable saved content).
+- MSO-5 reuses this slim-banner pattern for the "new version available" prompt.

--- a/frontend_modern/src/features/layout/AppShell.tsx
+++ b/frontend_modern/src/features/layout/AppShell.tsx
@@ -1,5 +1,6 @@
 import { BottomNav } from './BottomNav';
 import { Navbar } from './Navbar';
+import { OfflineBanner } from './OfflineBanner';
 
 interface AppShellProps {
   children: React.ReactNode;
@@ -16,6 +17,7 @@ export const AppShell = ({ children }: AppShellProps) => (
       Skip to main content
     </a>
     <Navbar />
+    <OfflineBanner />
     <main
       id="main-content"
       tabIndex={-1}

--- a/frontend_modern/src/features/layout/OfflineBanner.test.tsx
+++ b/frontend_modern/src/features/layout/OfflineBanner.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, act } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { OfflineBanner } from './OfflineBanner';
+import { I18nProvider } from '@/shared/i18n/I18nProvider';
+
+const setOnLine = (value: boolean) => {
+  Object.defineProperty(navigator, 'onLine', { configurable: true, value });
+};
+
+const renderBanner = () =>
+  render(
+    <I18nProvider initialLocale="en">
+      <OfflineBanner />
+    </I18nProvider>,
+  );
+
+afterEach(() => {
+  setOnLine(true);
+  vi.restoreAllMocks();
+});
+
+describe('<OfflineBanner />', () => {
+  it('renders nothing when online', () => {
+    setOnLine(true);
+    const { container } = renderBanner();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows a polite status banner when offline', () => {
+    setOnLine(false);
+    renderBanner();
+    const banner = screen.getByRole('status');
+    expect(banner).toHaveAttribute('aria-live', 'polite');
+    expect(banner).toHaveTextContent(/offline/i);
+  });
+
+  it('appears and disappears as connectivity changes', () => {
+    setOnLine(true);
+    renderBanner();
+    expect(screen.queryByRole('status')).toBeNull();
+
+    act(() => {
+      setOnLine(false);
+      window.dispatchEvent(new Event('offline'));
+    });
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    act(() => {
+      setOnLine(true);
+      window.dispatchEvent(new Event('online'));
+    });
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+});

--- a/frontend_modern/src/features/layout/OfflineBanner.tsx
+++ b/frontend_modern/src/features/layout/OfflineBanner.tsx
@@ -1,0 +1,44 @@
+import { useOnlineStatus } from '@/shared/hooks/useOnlineStatus';
+import { useT } from '@/shared/i18n/useT';
+
+/**
+ * Slim, informational banner shown only while the browser is offline (MSO-2).
+ *
+ * Warm amber — not a harsh error red: being offline is an honest state, not a
+ * failure. `role="status"` + `aria-live="polite"` so screen readers announce
+ * the change without interrupting. Renders nothing when online.
+ */
+export const OfflineBanner = () => {
+  const online = useOnlineStatus();
+  const t = useT();
+
+  if (online) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-center justify-center gap-2 bg-amber-100 px-4 py-2 text-center text-sm font-medium text-amber-900"
+    >
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="h-4 w-4 shrink-0"
+      >
+        <path d="m2 2 20 20" />
+        <path d="M8.5 16.5a5 5 0 0 1 7 0" />
+        <path d="M2 8.82a15 15 0 0 1 4.17-2.65" />
+        <path d="M10.66 5c4.01-.36 8.14.9 11.34 3.76" />
+        <path d="M16.85 11.25a10 10 0 0 1 2.22 1.68" />
+        <path d="M5 13a10 10 0 0 1 5.24-2.76" />
+        <line x1="12" y1="20" x2="12.01" y2="20" />
+      </svg>
+      <span>{t('connectivity.offlineBanner')}</span>
+    </div>
+  );
+};

--- a/frontend_modern/src/shared/hooks/useOnlineStatus.test.ts
+++ b/frontend_modern/src/shared/hooks/useOnlineStatus.test.ts
@@ -1,0 +1,46 @@
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { useOnlineStatus } from './useOnlineStatus';
+
+const setOnLine = (value: boolean) => {
+  Object.defineProperty(navigator, 'onLine', { configurable: true, value });
+};
+
+afterEach(() => {
+  setOnLine(true);
+  vi.restoreAllMocks();
+});
+
+describe('useOnlineStatus', () => {
+  it('reflects navigator.onLine on mount', () => {
+    setOnLine(false);
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(false);
+  });
+
+  it('flips to false on an offline event and back on online', () => {
+    setOnLine(true);
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(true);
+
+    act(() => {
+      setOnLine(false);
+      window.dispatchEvent(new Event('offline'));
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      setOnLine(true);
+      window.dispatchEvent(new Event('online'));
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('unsubscribes its window listeners on unmount', () => {
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    const { unmount } = renderHook(() => useOnlineStatus());
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith('online', expect.any(Function));
+    expect(removeSpy).toHaveBeenCalledWith('offline', expect.any(Function));
+  });
+});

--- a/frontend_modern/src/shared/hooks/useOnlineStatus.ts
+++ b/frontend_modern/src/shared/hooks/useOnlineStatus.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Tracks browser connectivity via `navigator.onLine` + the `online`/`offline`
+ * window events. Returns `true` when online.
+ *
+ * Caveat: `navigator.onLine` is optimistic — it reports `true` whenever there's
+ * *any* network interface, even behind a captive portal that can't reach our
+ * API. So this is fine for an informational banner, but do **not** gate data
+ * fetching on it: React Query already handles real fetch failures. (MSO-2)
+ *
+ * SSR/test-safe: defaults to `true` when `navigator` is undefined.
+ */
+export const useOnlineStatus = (): boolean => {
+  const [online, setOnline] = useState<boolean>(() =>
+    typeof navigator === 'undefined' ? true : navigator.onLine,
+  );
+
+  useEffect(() => {
+    const goOnline = () => setOnline(true);
+    const goOffline = () => setOnline(false);
+    window.addEventListener('online', goOnline);
+    window.addEventListener('offline', goOffline);
+    return () => {
+      window.removeEventListener('online', goOnline);
+      window.removeEventListener('offline', goOffline);
+    };
+  }, []);
+
+  return online;
+};

--- a/frontend_modern/src/shared/i18n/locales/en.ts
+++ b/frontend_modern/src/shared/i18n/locales/en.ts
@@ -933,6 +933,11 @@ export const en = {
   'streak.best': 'best: {count}',
   'streak.grace': 'grace ✓',
   'streak.graceTitle': 'Grace day used — streak preserved through one missed day',
+
+  // ── Connectivity (PWA offline indicator) ─────────────────────────────
+  'connectivity.offlineTitle': "You're offline",
+  'connectivity.offlineBanner': "You're offline — showing saved work.",
+  'connectivity.backOnline': 'Back online.',
 } as const;
 
 /** Every valid i18n key. Derived from the English dictionary. */

--- a/frontend_modern/src/shared/i18n/locales/hi.ts
+++ b/frontend_modern/src/shared/i18n/locales/hi.ts
@@ -928,4 +928,9 @@ export const hi: LocaleDict = {
   'streak.best': 'सर्वश्रेष्ठ: {count}',
   'streak.grace': 'ग्रेस ✓',
   'streak.graceTitle': 'ग्रेस दिन इस्तेमाल हुआ — एक दिन छूटने पर भी स्ट्रीक बनी रही',
+
+  // ── Connectivity (PWA offline indicator) ─────────────────────────────
+  'connectivity.offlineTitle': 'आप ऑफ़लाइन हैं',
+  'connectivity.offlineBanner': 'आप ऑफ़लाइन हैं — सहेजा हुआ काम दिखाया जा रहा है।',
+  'connectivity.backOnline': 'फिर से ऑनलाइन।',
 };

--- a/frontend_modern/src/shared/i18n/locales/mr.ts
+++ b/frontend_modern/src/shared/i18n/locales/mr.ts
@@ -193,4 +193,9 @@ export const mr = {
   'parent.statusPending': 'प्रलंबित',
   'parent.overdueOn': 'मुदत संपली — {date}',
   'parent.dueOn': 'मुदत {date}',
+
+  // ── Connectivity (PWA offline indicator) — core-loop string ──────────
+  'connectivity.offlineTitle': 'तुम्ही ऑफलाइन आहात',
+  'connectivity.offlineBanner': 'तुम्ही ऑफलाइन आहात — जतन केलेले काम दाखवत आहोत.',
+  'connectivity.backOnline': 'पुन्हा ऑनलाइन.',
 } satisfies Partial<LocaleDict>;


### PR DESCRIPTION
## What & why

Second PR of the **Mobile Shell & PWA-Offline** Batch 1. Gives the app an honest, localized offline indicator. Independent of the service worker — lands on its own.

**Classification:** New. No legacy equivalent — Django 1.11 was server-rendered/online-only.

## Changes

- `shared/hooks/useOnlineStatus.ts` — `navigator.onLine` + `online`/`offline` events, cleanup on unmount, SSR/test-safe default. JSDoc documents the `navigator.onLine` optimism caveat (fine for a banner; never gate fetching on it — React Query owns fetch failures).
- `features/layout/OfflineBanner.tsx` — slim warm-amber banner, `role="status"` + `aria-live="polite"`, inline wifi-off SVG, localized copy. Renders nothing when online.
- `features/layout/AppShell.tsx` — `<OfflineBanner />` between Navbar and `<main>`; skip-link intact.
- i18n — new `connectivity.` cluster in `en`/`hi` (complete) + `mr` (pilot; core-loop string). Parity guard green.

## Tests / verify

- `useOnlineStatus.test.ts` (3) + `OfflineBanner.test.tsx` (3).
- Full gate: `tsc --noEmit` clean · `lint` clean · `vitest run` **408 passing** · `build` ok · bundle budget green (138 kB vs 160 kB).
- Manual: DevTools → Network → Offline → banner appears; back online → it hides; switch to हिं/मराठी → localized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
