### PR TITLE
ci(perf): PERF-07 — Lighthouse CI runtime-perf budget

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -293,6 +293,38 @@ jobs:
                 path: frontend_modern/axe-report
                 retention-days: 14
 
+    lighthouse:
+        name: Lighthouse (runtime perf budget)
+        timeout-minutes: 20
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: frontend_modern
+        steps:
+            - name: Check out the repo
+              uses: actions/checkout@v4
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                node-version: '20'
+                cache: 'npm'
+                cache-dependency-path: frontend_modern/package-lock.json
+            - name: Install dependencies
+              run: npm ci
+            - name: Build
+              run: npm run build
+            - name: Run Lighthouse CI
+              # PERF-07 — runtime-perf budget. Complements the static bundle-size
+              # budget (PERF-06, check:budget) with real throttled-mobile metrics
+              # (LCP / TBT / CLS) that bundle bytes can't capture. Audits the
+              # public, backend-free /design showcase via `vite preview`, the same
+              # build users get. Assertions in lighthouserc.json are `warn`-level
+              # by design (Lighthouse scores vary run-to-run); the job only fails
+              # if collection itself breaks — i.e. a build that won't boot or a
+              # crashing /design route. See docs/perf/lighthouse.md for the
+              # tighten-to-error protocol.
+              run: npm run lighthouse
+
     # ─── Build & publish the MODERN stack ────────────────────────────────────
     # Two images go to ghcr.io: backend (Django 4.2 + daphne) and frontend
     # (multi-stage build → nginx). The legacy root Dockerfile is intentionally

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ frontend_modern/test-results/
 frontend_modern/playwright-report/
 frontend_modern/playwright/.cache/
 frontend_modern/axe-report/
+frontend_modern/.lighthouseci/
 
 # Backend (Python / Django)
 backend/__pycache__/

--- a/docs/perf/budget.md
+++ b/docs/perf/budget.md
@@ -4,6 +4,10 @@ This budget is a *contract*. Every PR that ships frontend code must keep the
 entry JS chunk under the ceiling, otherwise CI fails. The whole point is to
 prevent silent regression of the cuts landed in PERF-01..PERF-04.
 
+> This guards *static bytes*. For the *runtime* side — LCP / TBT / CLS on a
+> throttled mobile profile — see the [Lighthouse CI budget](lighthouse.md)
+> (PERF-07).
+
 ## Current ceiling
 
 | Asset                  | Ceiling | Measured (post-PERF-04) |

--- a/docs/perf/lighthouse.md
+++ b/docs/perf/lighthouse.md
@@ -1,0 +1,75 @@
+# Frontend runtime-perf budget — Lighthouse CI (PERF-07)
+
+The [bundle-size budget](budget.md) (PERF-06) guards *static* bytes. It cannot
+see what those bytes actually do at runtime: hydration cost, main-thread
+blocking, layout shift, time-to-paint. Lighthouse CI fills that gap by running a
+throttled-mobile audit on every push and reporting the real metrics.
+
+This matters most for the **Mobile Shell / PWA-Offline** initiative — the whole
+point of that work is a fast, installable experience on a mid-range phone, which
+is exactly the device class Lighthouse's mobile preset emulates.
+
+## What it audits
+
+| Setting | Value |
+| ------- | ----- |
+| Route   | `/design` (the only public, backend-free route — same one the e2e smoke trusts) |
+| Server  | `vite preview` on `:4173` (the production build, not the dev server) |
+| Runs    | 3 (Lighthouse reports the median to damp run-to-run noise) |
+| Profile | Lighthouse default: emulated mid-tier mobile + 4× CPU / slow-4G throttling |
+
+Config lives in [`frontend_modern/lighthouserc.json`](../../frontend_modern/lighthouserc.json).
+Reports are uploaded to Lighthouse's temporary public storage; the run log
+prints a URL where you can open the full report for that commit.
+
+## How CI runs it
+
+The `lighthouse` job in [`.github/workflows/ci-cd.yaml`](../../.github/workflows/ci-cd.yaml)
+does `npm ci` → `npm run build` → `npm run lighthouse` (which is
+`lhci autorun`). It is **not** in the `build-publish` dependency list, so it
+never blocks a deploy.
+
+## Why every assertion is `warn` (for now)
+
+Lighthouse scores are noisy — the same commit can swing several points between
+runs depending on the runner's CPU contention. If we gated merges on an `error`
+threshold from day one, CI would flake red on green code, and the team would
+learn to ignore it. So the job launches as a **visibility tool**:
+
+- Every assertion in `lighthouserc.json` is `warn`. Regressions show up in the
+  log and the uploaded report, but don't fail the job.
+- The job *does* still fail if collection breaks — e.g. the build won't boot or
+  `/design` crashes — so it doubles as a build-smoke check.
+
+## Tighten-to-error protocol
+
+The inverse of the budget's raise-the-ceiling protocol. Once a metric has a
+stable baseline worth defending:
+
+1. Watch the `warn` output across a handful of merged PRs and note the metric's
+   real spread (min/median/max) on CI.
+2. Pick an `error` threshold with comfortable headroom **below** the worst good
+   run (for scores) or **above** the worst good run (for `maxNumericValue`
+   timings) — enough that normal noise won't trip it.
+3. Flip that one line in `lighthouserc.json` from `"warn"` to `"error"` and add
+   a row to the **history** section below with the date, the metric, the
+   threshold, and the observed baseline that justifies it.
+4. Ship the tightening in its own small PR so reviewers see exactly which gate
+   went hard and why. Promote one metric at a time.
+
+## Running it locally
+
+```bash
+cd frontend_modern
+npm run build
+npm run lighthouse          # builds the preview server, runs 3 audits, prints a report URL
+```
+
+Local numbers run on your unthrottled-relative-to-CI machine, so treat them as
+directional. The CI run is the source of truth for the baseline.
+
+## History
+
+| Date       | Change                                                        |
+| ---------- | ------------------------------------------------------------- |
+| 2026-06-15 | PERF-07 introduced. All assertions `warn`; collecting a baseline before promoting any metric to `error`. |

--- a/frontend_modern/lighthouserc.json
+++ b/frontend_modern/lighthouserc.json
@@ -1,0 +1,26 @@
+{
+  "ci": {
+    "collect": {
+      "startServerCommand": "npm run preview -- --port 4173 --strictPort",
+      "startServerReadyPattern": "Local",
+      "startServerReadyTimeout": 60000,
+      "url": ["http://localhost:4173/design"],
+      "numberOfRuns": 3
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["warn", { "minScore": 0.8 }],
+        "categories:accessibility": ["warn", { "minScore": 0.9 }],
+        "categories:best-practices": ["warn", { "minScore": 0.9 }],
+        "categories:seo": ["warn", { "minScore": 0.9 }],
+        "first-contentful-paint": ["warn", { "maxNumericValue": 3000 }],
+        "largest-contentful-paint": ["warn", { "maxNumericValue": 4000 }],
+        "total-blocking-time": ["warn", { "maxNumericValue": 600 }],
+        "cumulative-layout-shift": ["warn", { "maxNumericValue": 0.1 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/frontend_modern/package.json
+++ b/frontend_modern/package.json
@@ -18,6 +18,7 @@
     "test:coverage": "vitest --coverage",
     "test:e2e": "playwright test",
     "test:e2e:update-snapshots": "playwright test --update-snapshots",
+    "lighthouse": "npx --yes @lhci/cli@0.14.0 autorun",
     "widget:new": "node scripts/create-widget.mjs",
     "widget:dev": "node scripts/widget-dev.mjs"
   },


### PR DESCRIPTION
@
## What

Adds a **Lighthouse CI** job that audits runtime performance on every push — the runtime counterpart to the existing static bundle-size budget (PERF-06).

The bundle budget guards *bytes*; it cant see hydration cost, main-thread blocking, layout shift, or time-to-paint. This job runs a throttled-mobile Lighthouse audit (3 runs, median) on the public, backend-free `/design` showcase — the same route the e2e smoke trusts — and reports FCP / LCP / TBT / CLS plus category scores.

This directly supports the active **Mobile Shell / PWA-Offline** initiative, whose whole premise is a fast, installable experience on a mid-range phone (exactly Lighthouses mobile emulation profile).

## Why warn-level, not a hard gate (yet)

Lighthouse scores are noisy run-to-run. Gating merges on an `error` threshold from day one would flake red on green code and train everyone to ignore it. So every assertion in `lighthouserc.json` is `warn`: regressions surface in the log + uploaded report, but dont fail the job. The job **does** still fail if collection breaks (build wont boot / `/design` crashes), so it doubles as a build-smoke check. It is **not** in the `build-publish` dependency list — it never blocks a deploy.

`docs/perf/lighthouse.md` documents the **tighten-to-error protocol**: once a metric has a stable observed baseline, flip that one line to `error` in its own small PR.

## Verified locally

`npm run lighthouse` → builds, boots `vite preview`, runs 3 audits, uploads a report, **exits 0**. Baseline captured (throttled mobile, heavy showcase):

| Metric | Median | Threshold (warn) |
| --- | --- | --- |
| performance | 0.76 | ≥ 0.8 |
| FCP | ~3.9s | ≤ 3.0s |
| LCP | ~4.4s | ≤ 4.0s |
| TBT / CLS | within budget | — |

These are the first datapoints toward the baseline; warns only, CI stays green.

## Changes

- `frontend_modern/lighthouserc.json` — lhci config (preview `/design`, 3 runs, warn assertions, `temporary-public-storage` upload)
- `npm run lighthouse` — local parity via `npx @lhci/cli`
- new `lighthouse` CI job in `ci-cd.yaml`
- `docs/perf/lighthouse.md` + cross-link from `budget.md`
- `.gitignore`: `frontend_modern/.lighthouseci/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@