### PR TITLE
feat(pwa-offline): MSO-6 — replay-safe / idempotent submission writes

### DIFF
--- a/backend/openshiksha/apps/api/serializers/core.py
+++ b/backend/openshiksha/apps/api/serializers/core.py
@@ -867,6 +867,14 @@ class SubmissionSerializer(serializers.ModelSerializer):
         if user.role not in [UserRole.STUDENT, UserRole.OPEN_STUDENT]:
             raise serializers.ValidationError("Only students can submit answers.")
 
+        # MSO-6: a submission is immutable once submitted. Any further write — a
+        # replayed offline auto-save, or a duplicate submit that was queued offline
+        # then also sent online — must be a harmless idempotent no-op rather than a
+        # 400 or a re-grade. Skip the create/closed validations here so the replay
+        # returns 200 with the existing record; update() short-circuits the save.
+        if self.instance is not None and self.instance.submitted_at is not None:
+            return attrs
+
         # On create: check no existing submission
         if self.instance is None:
             assignment = attrs.get("assignment")
@@ -887,6 +895,15 @@ class SubmissionSerializer(serializers.ModelSerializer):
         request = self.context.get("request")
         validated_data["student"] = request.user
         return super().create(validated_data)
+
+    def update(self, instance, validated_data):
+        # MSO-6: a submitted submission is immutable. Short-circuit the save so a
+        # replayed/duplicate write never re-fires the grading signal (defense in
+        # depth alongside the signal's ``score is None`` gate) and never mutates the
+        # graded snapshot. Returns the existing instance → HTTP 200 with current data.
+        if instance.submitted_at is not None:
+            return instance
+        return super().update(instance, validated_data)
 
 
 class ProblemSetWriteSerializer(serializers.ModelSerializer):

--- a/backend/openshiksha/apps/api/tests/test_submission_replay.py
+++ b/backend/openshiksha/apps/api/tests/test_submission_replay.py
@@ -1,0 +1,225 @@
+"""
+MSO-6 — replay-safe / idempotent submission writes.
+
+An offline mutation queue replays writes onto the server at-least-once. These
+tests pin the server contract that makes that safe:
+
+- The first submit grades exactly once.
+- A replayed (duplicate) submit is an idempotent 200 no-op — never a re-grade,
+  never a 400, and never a mutation of the graded snapshot.
+- A stale auto-save PATCH that lands after submission is a harmless no-op — the
+  answers are immutable post-submit and no grading is triggered.
+- The normal first-submit path is unchanged.
+
+Both layers are exercised: the serializer's no-op-on-resubmit guard and the
+``trigger_grading_on_submit`` signal's ``score is None`` gate.
+"""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from openshiksha.apps.core.models import (
+    Assignment,
+    Board,
+    Chapter,
+    ClassRoom,
+    ProblemSet,
+    Question,
+    School,
+    Standard,
+    Subject,
+    SubjectRoom,
+    Submission,
+    User,
+    UserRole,
+)
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def board(db):
+    return Board.objects.create(name="CBSE")
+
+
+@pytest.fixture
+def school(db, board):
+    return School.objects.create(name="Replay School", board=board)
+
+
+@pytest.fixture
+def standard(db):
+    return Standard.objects.create(number=10)
+
+
+@pytest.fixture
+def subject(db):
+    return Subject.objects.create(name="Physics")
+
+
+@pytest.fixture
+def chapter(db, subject, standard):
+    return Chapter.objects.create(name="Kinematics", subject=subject, standard=standard, order=1)
+
+
+@pytest.fixture
+def classroom(db, school, standard):
+    return ClassRoom.objects.create(school=school, standard=standard, division="R", academic_year="2025-26")
+
+
+@pytest.fixture
+def teacher(db, school):
+    return User.objects.create_user(username="teacher_replay", password="pass", role=UserRole.TEACHER, school=school)
+
+
+@pytest.fixture
+def student(db, school):
+    return User.objects.create_user(username="student_replay", password="pass", role=UserRole.STUDENT, school=school)
+
+
+@pytest.fixture
+def subject_room(db, classroom, subject, teacher, student):
+    room = SubjectRoom.objects.create(classroom=classroom, subject=subject, teacher=teacher)
+    room.students.add(student)
+    return room
+
+
+@pytest.fixture
+def question(db, school, standard, subject, chapter):
+    return Question.objects.create(school=school, standard=standard, subject=subject, chapter=chapter)
+
+
+@pytest.fixture
+def problem_set(db, school, standard, subject, chapter, question):
+    ps = ProblemSet.objects.create(
+        school=school,
+        standard=standard,
+        subject=subject,
+        chapter=chapter,
+        title="Replay Practice",
+        number=1,
+    )
+    ps.questions.add(question)
+    return ps
+
+
+@pytest.fixture
+def assignment(db, subject_room, problem_set, teacher):
+    return Assignment.objects.create(
+        subject_room=subject_room,
+        problem_set=problem_set,
+        assigned_by=teacher,
+        due_at=timezone.now() + timedelta(days=7),
+    )
+
+
+@pytest.fixture
+def submission(db, assignment, student):
+    """An in-progress (not yet submitted) submission, created online on first open."""
+    return Submission.objects.create(assignment=assignment, student=student, answers={"1": 1}, completion=0.5)
+
+
+class TestSubmissionReplaySafety:
+    def test_first_submit_grades_exactly_once(self, api_client, student, submission):
+        """(a) PATCH submitted_at once → grade_submission queued exactly once."""
+        api_client.force_authenticate(user=student)
+        url = reverse("submission-detail", kwargs={"pk": submission.pk})
+        with patch("openshiksha.apps.core.tasks.grade_submission.delay") as mock_grade:
+            response = api_client.patch(url, {"submitted_at": timezone.now().isoformat()}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert mock_grade.call_count == 1
+        mock_grade.assert_called_once_with(submission.pk)
+
+    def test_replayed_submit_does_not_regrade(self, api_client, student, submission):
+        """(b) A duplicate submit replayed after grading → 200, no second grade, same score."""
+        # First submit, then simulate grading having run (score populated).
+        submission.submitted_at = timezone.now()
+        submission.score = 0.75
+        submission.save(update_fields=["submitted_at", "score"])
+
+        api_client.force_authenticate(user=student)
+        url = reverse("submission-detail", kwargs={"pk": submission.pk})
+        with patch("openshiksha.apps.core.tasks.grade_submission.delay") as mock_grade:
+            response = api_client.patch(url, {"submitted_at": timezone.now().isoformat()}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert mock_grade.call_count == 0
+        assert response.data["score"] == 0.75
+        submission.refresh_from_db()
+        assert submission.score == 0.75
+
+    def test_replayed_submit_before_grading_completes_is_noop(self, api_client, student, submission):
+        """A submit replayed while the first grade is still pending (score is None) is a no-op.
+
+        Guards against the async double-grade race: the serializer short-circuits
+        the save so the signal never re-fires even though score is not yet set.
+        """
+        submission.submitted_at = timezone.now()
+        submission.save(update_fields=["submitted_at"])
+        assert submission.score is None
+
+        api_client.force_authenticate(user=student)
+        url = reverse("submission-detail", kwargs={"pk": submission.pk})
+        with patch("openshiksha.apps.core.tasks.grade_submission.delay") as mock_grade:
+            response = api_client.patch(url, {"submitted_at": timezone.now().isoformat()}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert mock_grade.call_count == 0
+
+    def test_stale_autosave_after_submit_is_noop(self, api_client, student, submission):
+        """(c) An answers PATCH that lands after submission → 200, answers unchanged, no grade."""
+        submission.submitted_at = timezone.now()
+        submission.score = 0.6
+        submission.answers = {"1": 2}
+        submission.save(update_fields=["submitted_at", "score", "answers"])
+
+        api_client.force_authenticate(user=student)
+        url = reverse("submission-detail", kwargs={"pk": submission.pk})
+        with patch("openshiksha.apps.core.tasks.grade_submission.delay") as mock_grade:
+            response = api_client.patch(url, {"answers": {"1": 4}, "completion": 1.0}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert mock_grade.call_count == 0
+        submission.refresh_from_db()
+        assert submission.answers == {"1": 2}  # immutable post-submit
+        assert submission.score == 0.6
+
+    def test_normal_in_progress_autosave_still_works(self, api_client, student, submission):
+        """(d) The normal pre-submit auto-save path is unchanged — answers update, no grade."""
+        api_client.force_authenticate(user=student)
+        url = reverse("submission-detail", kwargs={"pk": submission.pk})
+        with patch("openshiksha.apps.core.tasks.grade_submission.delay") as mock_grade:
+            response = api_client.patch(url, {"answers": {"1": 3}, "completion": 0.8}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert mock_grade.call_count == 0
+        submission.refresh_from_db()
+        assert submission.answers == {"1": 3}
+        assert submission.completion == 0.8
+
+
+class TestGradeSignalScoreGate:
+    """Direct unit coverage of the signal's MSO-6 ``score is None`` gate."""
+
+    def test_resave_of_graded_submission_does_not_regrade(self, submission):
+        submission.submitted_at = timezone.now()
+        submission.score = 0.9
+        submission.save(update_fields=["submitted_at", "score"])
+
+        with patch("openshiksha.apps.core.tasks.grade_submission.delay") as mock_grade:
+            # A full save() (update_fields=None) carrying submitted_at on an
+            # already-graded submission must not trigger grading.
+            submission.save()
+        assert mock_grade.call_count == 0
+
+    def test_first_submit_save_triggers_grade(self, submission):
+        with patch("openshiksha.apps.core.tasks.grade_submission.delay") as mock_grade:
+            submission.submitted_at = timezone.now()
+            submission.save(update_fields=["submitted_at"])
+        mock_grade.assert_called_once_with(submission.pk)

--- a/backend/openshiksha/apps/core/signals.py
+++ b/backend/openshiksha/apps/core/signals.py
@@ -20,12 +20,22 @@ def trigger_grading_on_submit(sender, instance, created, update_fields, **kwargs
     - Only fires when update_fields includes 'submitted_at' (explicit save) OR
       on initial create if submitted_at is already set
     - Does NOT re-grade if the submission is simply updated for other fields
+    - MSO-6: Does NOT re-grade an already-graded submission. A replayed/duplicate
+      submit (e.g. an offline mutation queue replaying onto the server) must not
+      re-fire grading. The explicit resync re-grade path queues grade_submission
+      directly, bypassing this signal, so it is unaffected.
     """
     if not instance.submitted_at:
         return
 
     # If update_fields is specified, only trigger when submitted_at was explicitly saved
     if update_fields is not None and "submitted_at" not in update_fields:
+        return
+
+    # MSO-6: only grade an ungraded submission. Once a score exists, the submission
+    # has been graded; a later save that still carries submitted_at (a replayed
+    # offline submit, or any non-grading re-save) must not trigger a second grade.
+    if instance.score is not None:
         return
 
     # On create with submitted_at already set, or on explicit submitted_at update

--- a/docs/changes/2026-06-15-mso6-replay-safe-submission.md
+++ b/docs/changes/2026-06-15-mso6-replay-safe-submission.md
@@ -1,0 +1,76 @@
+# MSO-6 — Replay-safe / idempotent submission writes
+
+**Date:** 2026-06-15
+**Initiative:** Mobile Shell & PWA-Offline — Batch 2 (offline write-tolerance)
+**Classification:** Improve (hardens a latent re-grade hazard in the grading signal)
+
+## Summary
+
+Hardens the submission write path so a replayed PATCH can never double-grade or
+re-grade an already-submitted submission, and a duplicate submit returns the
+existing record/score (HTTP 200) instead of erroring. This must land **before**
+the client-side offline mutation queue (MSO-7) exists, because an at-least-once
+replay queue would otherwise expose a real double-grade hazard.
+
+## The hazard
+
+Grading is triggered by a `post_save` signal
+([core/signals.py](../../backend/openshiksha/apps/core/signals.py)):
+`grade_submission.delay()` fires whenever `submitted_at` is non-null **and**
+(`update_fields is None` **or** `'submitted_at' in update_fields`). DRF's
+`ModelSerializer.update()` calls `instance.save()` **without** `update_fields`,
+so `update_fields is None` on every PATCH — meaning **any** PATCH to an
+already-submitted submission re-fired grading. The frontend hid this by blocking
+edits post-submit, but an offline replay queue removes that guarantee.
+
+## What changed
+
+Two independent layers (defense in depth):
+
+1. **Serializer** ([api/serializers/core.py](../../backend/openshiksha/apps/api/serializers/core.py) `SubmissionSerializer`):
+   - `validate()` — when the instance is already submitted (`submitted_at is not
+     None`), short-circuit before the create/closed-assignment validations so a
+     replay returns 200 rather than a 400.
+   - `update()` — when the instance is already submitted, return the instance
+     **without saving**. A replayed auto-save or duplicate submit becomes a
+     harmless idempotent no-op: no signal re-fire, no snapshot mutation. This also
+     closes the async double-grade race (a replay arriving while the first grade is
+     still pending — `score` still `None` — never re-saves).
+
+2. **Signal** ([core/signals.py](../../backend/openshiksha/apps/core/signals.py)
+   `trigger_grading_on_submit`):
+   - Added a `score is None` gate: only grade an ungraded submission. A save that
+     still carries `submitted_at` on an already-graded submission no longer
+     re-grades. The explicit resync re-grade path
+     ([api/views/core.py](../../backend/openshiksha/apps/api/views/core.py)) queues
+     `grade_submission.delay()` **directly**, bypassing this signal, so it is
+     unaffected — verified by the existing resync suite.
+
+## Legacy reference
+
+None — legacy (Django 1.11) was online-only and server-rendered; there is no
+offline write path to port. This is a correctness hardening of the modern grading
+signal.
+
+## Tests
+
+New `backend/openshiksha/apps/api/tests/test_submission_replay.py`:
+
+- First submit grades exactly once (`grade_submission.delay` called once).
+- Replayed submit after grading → 200, **no** second grade, same score.
+- Replayed submit before grading completes (score still `None`) → 200 no-op.
+- Stale answers auto-save after submit → 200, answers unchanged, no grade.
+- Normal pre-submit auto-save unchanged (answers update, no grade).
+- Signal-level: re-save of a graded submission does not re-grade; first submit does.
+
+Regression: `test_assignment_api.py` (submission workflow) and
+`test_assignment_resync.py` (resync re-grade path) remain green.
+
+## Migration notes
+
+None — no model changes.
+
+## Next steps
+
+MSO-7 — offline mutation queue foundation (frontend) replays onto this now-safe
+endpoint.


### PR DESCRIPTION
## Classification
**Improve** — hardens a latent re-grade hazard in the grading signal. Initiative: **Mobile Shell & PWA-Offline, Batch 2** (offline write-tolerance), build-first item.

## Why
An at-least-once offline mutation queue (MSO-7, next) replays submission writes onto the server. Today any PATCH to an already-submitted submission re-fires grading: the `post_save` signal triggers whenever `submitted_at` is non-null and `update_fields is None`, and DRF's `ModelSerializer.update()` always saves without `update_fields`. The frontend hid this by blocking post-submit edits — a guarantee the replay queue removes. Fix it server-side, once, before the queue exists.

## What changed
- **`SubmissionSerializer.update()`** — no-op when the instance is already submitted (returns existing instance, HTTP 200). Closes the async double-grade race (a replay arriving while the first grade is still pending).
- **`SubmissionSerializer.validate()`** — short-circuits the create/closed-assignment checks for an already-submitted instance so a replay returns 200, not 400.
- **`trigger_grading_on_submit` signal** — added a `score is None` gate: a save still carrying `submitted_at` on a graded submission never re-grades. The explicit resync re-grade path queues `grade_submission.delay()` directly (bypassing the signal) and is unaffected.

## Legacy reference
None — legacy (Django 1.11) was online-only/server-rendered; no offline write path to port. This is a correctness hardening of the modern grading signal.

## Tests
New `test_submission_replay.py`: single-grade on first submit; no re-grade on replayed submit (graded **and** pending-score); no re-grade on stale post-submit auto-save (answers immutable); unchanged in-progress auto-save; signal-level gating. Regression: `test_assignment_api.py` submission suite + `test_assignment_resync.py` green. Full backend suite: **973 passed**.

## Verify
`cd backend && ./venv/Scripts/python.exe -m pytest openshiksha/apps/api/tests/test_submission_replay.py openshiksha/apps/api/tests/test_assignment_resync.py -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
