### PR TITLE
feat(pwa-offline): MSO-7 — offline submission mutation queue foundation

### DIFF
--- a/docs/changes/2026-06-15-mso7-offline-mutation-queue.md
+++ b/docs/changes/2026-06-15-mso7-offline-mutation-queue.md
@@ -1,0 +1,75 @@
+# MSO-7 — Offline mutation queue foundation
+
+**Date:** 2026-06-15
+**Initiative:** Mobile Shell & PWA-Offline — Batch 2 (offline write-tolerance)
+**Classification:** New
+
+## Summary
+
+Wires the *write* half of offline tolerance. The student's submission auto-saves
+and final submit become **keyed mutations** with `networkMode: 'offlineFirst'`:
+when the network is down they **pause** (durably persisted to IndexedDB) instead
+of failing, and replay automatically when connectivity returns — even across a
+full reload. No new runtime dependency — this turns on React Query's
+offline-mutation + persistence primitives that shipped with Batch 1.
+
+## What changed
+
+- **New `src/shared/query/offlineMutations.ts`:**
+  - `registerSubmissionMutationDefaults(queryClient)` — registers
+    `setMutationDefaults(['submission','patch'|'create'], { mutationFn,
+    networkMode: 'offlineFirst', retry: 3, onSuccess })`. The `mutationFn` and the
+    cache-reconciling `onSuccess` live in the defaults (keyed, not a closure) so a
+    **rehydrated** paused mutation — which has no component context — can still
+    resolve its function and update the cache on replay. `onSuccess` derives the
+    assignment from the server response, never a captured variable.
+  - `shouldDehydrateSubmissionMutation(mutation)` — persist allowlist: dehydrate a
+    mutation only when it is **paused** and `mutationKey[0] === 'submission'`.
+    Never auth or any token-bearing mutation.
+- **`src/main.tsx`:**
+  - Call `registerSubmissionMutationDefaults(queryClient)` **before** the
+    `PersistQueryClientProvider` restores the cache (order matters — a rehydrated
+    paused mutation looks up its `mutationFn` by key).
+  - Flip `shouldDehydrateMutation` from `() => false` to
+    `shouldDehydrateSubmissionMutation`.
+  - Add the provider's `onSuccess` (fires after the cache restores) →
+    `queryClient.resumePausedMutations()`. Mid-session reconnects auto-resume via
+    `onlineManager`'s browser online events.
+- **`src/features/student/useSubmission.ts`:** `useCreateSubmission` /
+  `usePatchSubmission` now reference the keyed defaults by `mutationKey` only (no
+  inline `mutationFn`/`onSuccess`). Online behavior is identical; the component
+  (`AssignmentDetailPage`) is unchanged — same `mutate` signatures.
+
+## Scope note
+
+Only **patch/submit of an already-created submission** is made offline-durable.
+A submission row is created online on first open (Batch 1 already requires an
+online first open for offline read), so creating a brand-new submission from a
+cold offline start is out of scope for this batch.
+
+## Legacy reference
+
+None — legacy (Django 1.11) was online-only/server-rendered; a dropped connection
+lost everything. Offline write-tolerance is new capability the SPA +
+service-worker architecture enables. We use React Query's *paused mutation* model
+(durable in IndexedDB, replayed even across reload) rather than a naive in-memory
+retry, and rely on MSO-6's server idempotency for safe at-least-once replay.
+
+## Tests
+
+`src/shared/query/offlineMutations.test.ts`:
+- `shouldDehydrateSubmissionMutation` allowlist: paused submission → true;
+  running submission → false; paused non-submission / no key → false.
+- Offline round-trip: fire a patch while offline → it **pauses** (not fails) and
+  is captured by the allowlist; reconnect + `resumePausedMutations()` drives the
+  keyed `mutationFn` and the default `onSuccess` reconciles the cache.
+- Rehydration-safety: a mutation created with only a `mutationKey` still resolves
+  its function from the registered defaults.
+
+Regression: student feature suite (38 tests) green; `npx tsc --noEmit`, eslint,
+`npm run build`, and the bundle budget (144.33 kB ≤ 160 kB, no new dep) all green.
+
+## Next steps
+
+- MSO-8 — "Saved offline · will sync" status UX (reads this queue's state).
+- MSO-9 — offline final-submit (optimistic submitted state, replays onto MSO-6).

--- a/frontend_modern/src/features/student/useSubmission.ts
+++ b/frontend_modern/src/features/student/useSubmission.ts
@@ -1,27 +1,17 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import { apiClient } from '@/api/client';
 import type { Submission, PaginatedResponse } from '@/types/index';
+import {
+  SUBMISSION_CREATE_KEY,
+  SUBMISSION_PATCH_KEY,
+  type PatchSubmissionVars,
+} from '@/shared/query/offlineMutations';
 
 const fetchSubmission = async (assignmentId: number): Promise<Submission | null> => {
   const response = await apiClient.get<PaginatedResponse<Submission>>(
     `/submissions/?assignment=${assignmentId}`
   );
   return response.data.results[0] ?? null;
-};
-
-const createSubmission = async (assignmentId: number): Promise<Submission> => {
-  const response = await apiClient.post<Submission>('/submissions/', {
-    assignment: assignmentId,
-  });
-  return response.data;
-};
-
-const patchSubmission = async (
-  id: number,
-  data: Partial<Pick<Submission, 'answers' | 'completion' | 'submitted_at'>>
-): Promise<Submission> => {
-  const response = await apiClient.patch<Submission>(`/submissions/${id}/`, data);
-  return response.data;
 };
 
 export const useSubmission = (assignmentId: number) => {
@@ -33,25 +23,25 @@ export const useSubmission = (assignmentId: number) => {
   });
 };
 
+/**
+ * MSO-7: submission writes are keyed mutations whose `mutationFn`, `networkMode:
+ * 'offlineFirst'`, and cache-reconciling `onSuccess` are registered once in
+ * `offlineMutations.ts`. The components reference them only by `mutationKey`, so
+ * offline they pause + persist + replay instead of failing — and a rehydrated
+ * paused mutation (no live observer) still resolves its function and updates the
+ * cache on replay.
+ */
 export const useCreateSubmission = () => {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: createSubmission,
-    onSuccess: (data) => {
-      queryClient.setQueryData(['submission', data.assignment], data);
-    },
+  return useMutation<Submission, Error, number>({
+    mutationKey: SUBMISSION_CREATE_KEY,
   });
 };
 
-export const usePatchSubmission = (assignmentId: number) => {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({ id, data }: { id: number; data: Parameters<typeof patchSubmission>[1] }) =>
-      patchSubmission(id, data),
-    onSuccess: (updated) => {
-      queryClient.setQueryData(['submission', assignmentId], updated);
-      // Invalidate assignment list so completion/score reflects in dashboard
-      queryClient.invalidateQueries({ queryKey: ['assignments'] });
-    },
+// `assignmentId` is no longer needed for cache reconciliation (the default
+// `onSuccess` derives it from the server response) but the signature is kept so
+// callers don't change.
+export const usePatchSubmission = (_assignmentId: number) => {
+  return useMutation<Submission, Error, PatchSubmissionVars>({
+    mutationKey: SUBMISSION_PATCH_KEY,
   });
 };

--- a/frontend_modern/src/main.tsx
+++ b/frontend_modern/src/main.tsx
@@ -10,6 +10,10 @@ import {
   CACHE_BUSTER,
   PERSIST_MAX_AGE,
 } from './shared/query/persist';
+import {
+  registerSubmissionMutationDefaults,
+  shouldDehydrateSubmissionMutation,
+} from './shared/query/offlineMutations';
 
 // Create a client. `gcTime` is bumped to 24h so entries survive long enough to
 // be persisted to / restored from IndexedDB (MSO-4); `staleTime` stays at 5 min
@@ -25,9 +29,15 @@ const queryClient = new QueryClient({
   },
 });
 
+// MSO-7: register the keyed submission mutation defaults BEFORE the persister
+// restores the cache, so a rehydrated paused mutation can resolve its
+// `mutationFn` by `mutationKey` and replay after a reload.
+registerSubmissionMutationDefaults(queryClient);
+
 // IndexedDB-backed persister so the last-fetched student core-loop reads
-// (assignments, dashboard, due-for-review) are readable offline. Reads only;
-// the dehydrate allowlist excludes auth + mutations (see shared/query/persist).
+// (assignments, dashboard, due-for-review) are readable offline, and queued
+// offline submission writes (MSO-7) survive a reload. Reads use the MSO-4
+// allowlist; mutations dehydrate only when paused + in the `submission` family.
 const persister = createIDBPersister();
 
 // ReactQueryDevtools is dev-only. Production builds must never ship it — the
@@ -49,9 +59,16 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
         buster: CACHE_BUSTER,
         dehydrateOptions: {
           shouldDehydrateQuery,
-          // Never persist mutations — restoring one could double-submit.
-          shouldDehydrateMutation: () => false,
+          // MSO-7: persist only PAUSED submission mutations (queued offline). The
+          // server is idempotent (MSO-6), so replaying these at-least-once is safe.
+          shouldDehydrateMutation: shouldDehydrateSubmissionMutation,
         },
+      }}
+      onSuccess={() => {
+        // The cache (and any persisted paused mutations) has been restored — flush
+        // queued offline writes. Mid-session reconnects auto-resume via
+        // onlineManager's browser online events.
+        void queryClient.resumePausedMutations();
       }}
     >
       <App />

--- a/frontend_modern/src/shared/query/offlineMutations.test.ts
+++ b/frontend_modern/src/shared/query/offlineMutations.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { QueryClient, MutationObserver, onlineManager, type Mutation } from '@tanstack/react-query';
+
+// Mock the axios client so the mutationFns hit no real network.
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    patch: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/api/client';
+import {
+  registerSubmissionMutationDefaults,
+  shouldDehydrateSubmissionMutation,
+  SUBMISSION_PATCH_KEY,
+  type PatchSubmissionVars,
+} from './offlineMutations';
+
+const patch = apiClient.patch as unknown as ReturnType<typeof vi.fn>;
+
+const submission = { id: 1, assignment: 7, answers: { '1': '2' }, completion: 0.5, score: null };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  onlineManager.setOnline(true);
+});
+
+afterEach(() => {
+  onlineManager.setOnline(true);
+});
+
+describe('shouldDehydrateSubmissionMutation (offline-write allowlist)', () => {
+  const fake = (isPaused: boolean, key: readonly unknown[] | undefined) =>
+    ({ state: { isPaused }, options: { mutationKey: key } }) as unknown as Mutation;
+
+  it('persists only PAUSED submission mutations', () => {
+    expect(shouldDehydrateSubmissionMutation(fake(true, ['submission', 'patch']))).toBe(true);
+    expect(shouldDehydrateSubmissionMutation(fake(true, ['submission', 'create']))).toBe(true);
+  });
+
+  it('never persists a running (non-paused) submission mutation', () => {
+    expect(shouldDehydrateSubmissionMutation(fake(false, ['submission', 'patch']))).toBe(false);
+  });
+
+  it('never persists a non-submission mutation, even when paused', () => {
+    expect(shouldDehydrateSubmissionMutation(fake(true, ['auth', 'login']))).toBe(false);
+    expect(shouldDehydrateSubmissionMutation(fake(true, undefined))).toBe(false);
+  });
+});
+
+describe('offline submission mutation queue', () => {
+  it('pauses (not fails) when offline and replays the keyed mutationFn on reconnect', async () => {
+    const queryClient = new QueryClient();
+    registerSubmissionMutationDefaults(queryClient);
+
+    // Go offline; the first offlineFirst attempt rejects with a network error and
+    // the retry is then paused (durable) rather than the mutation failing.
+    onlineManager.setOnline(false);
+    patch.mockRejectedValue(new Error('Network Error'));
+
+    const observer = new MutationObserver<typeof submission, Error, PatchSubmissionVars>(queryClient, { mutationKey: SUBMISSION_PATCH_KEY });
+    const result = observer.mutate({ id: 1, data: { answers: { '1': '2' }, completion: 0.5 } });
+
+    // The mutation is captured as paused (queued), not errored — and the allowlist
+    // picks it up. offlineFirst runs the first attempt, then pauses the retry while
+    // offline (after the retry backoff), so allow time for that transition.
+    await vi.waitFor(
+      () => {
+        const m = queryClient.getMutationCache().getAll()[0];
+        expect(m?.state.isPaused).toBe(true);
+      },
+      { timeout: 4000, interval: 50 },
+    );
+    const paused = queryClient.getMutationCache().getAll()[0];
+    expect(shouldDehydrateSubmissionMutation(paused)).toBe(true);
+
+    // Reconnect: the server is reachable now; resume drives the keyed mutationFn.
+    patch.mockResolvedValue({ data: submission });
+    onlineManager.setOnline(true);
+    await queryClient.resumePausedMutations();
+
+    await expect(result).resolves.toEqual(submission);
+    expect(patch).toHaveBeenLastCalledWith('/submissions/1/', {
+      answers: { '1': '2' },
+      completion: 0.5,
+    });
+
+    // Default onSuccess reconciled the cache from the server response (no closure).
+    expect(queryClient.getQueryData(['submission', 7])).toEqual(submission);
+  });
+
+  it('registers a rehydration-safe keyed mutationFn (no inline closure needed)', async () => {
+    const queryClient = new QueryClient();
+    registerSubmissionMutationDefaults(queryClient);
+    patch.mockResolvedValue({ data: submission });
+
+    // A mutation created with only a mutationKey (as a rehydrated paused mutation
+    // would be) still resolves its function from the registered defaults.
+    const observer = new MutationObserver<typeof submission, Error, PatchSubmissionVars>(queryClient, { mutationKey: SUBMISSION_PATCH_KEY });
+    await observer.mutate({ id: 1, data: { answers: {} } });
+
+    expect(patch).toHaveBeenCalledWith('/submissions/1/', { answers: {} });
+  });
+});

--- a/frontend_modern/src/shared/query/offlineMutations.ts
+++ b/frontend_modern/src/shared/query/offlineMutations.ts
@@ -1,0 +1,87 @@
+import type { Mutation, QueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+import type { Submission } from '@/types/index';
+
+/**
+ * MSO-7 — offline mutation queue foundation.
+ *
+ * Batch 1 made the student core loop survive a dropped connection for *reads*
+ * (precached shell + persisted React Query cache). This wires the *write* half:
+ * the student's submission auto-saves and final submit become keyed mutations
+ * with `networkMode: 'offlineFirst'`, so when the network is down they **pause**
+ * (durably persisted to IndexedDB) instead of failing, and replay automatically
+ * when connectivity returns — even across a full reload.
+ *
+ * Two design constraints make a *rehydrated* paused mutation replayable:
+ *
+ *  1. **The `mutationFn` must not be a closure.** A mutation restored from
+ *     IndexedDB has no component context, so its function is looked up by
+ *     `mutationKey` from `setMutationDefaults` — registered here, before the
+ *     persister restores the client (see `main.tsx`).
+ *  2. **Cache reconciliation lives in the default `onSuccess`.** A replayed
+ *     mutation has no live observer, so the `setQueryData`/invalidation that
+ *     keeps the UI honest must run from the default, deriving everything it needs
+ *     from the server response (never a captured variable).
+ *
+ * MSO-6 made the server idempotent, so an at-least-once replay of these is safe.
+ */
+
+/** Keyed mutation for an in-progress auto-save / final submit PATCH. */
+export const SUBMISSION_PATCH_KEY = ['submission', 'patch'] as const;
+/** Keyed mutation for creating the (online-first) submission row. */
+export const SUBMISSION_CREATE_KEY = ['submission', 'create'] as const;
+
+export interface PatchSubmissionVars {
+  id: number;
+  data: Partial<Pick<Submission, 'answers' | 'completion' | 'submitted_at'>>;
+}
+
+const patchSubmissionFn = async ({ id, data }: PatchSubmissionVars): Promise<Submission> => {
+  const response = await apiClient.patch<Submission>(`/submissions/${id}/`, data);
+  return response.data;
+};
+
+const createSubmissionFn = async (assignmentId: number): Promise<Submission> => {
+  const response = await apiClient.post<Submission>('/submissions/', { assignment: assignmentId });
+  return response.data;
+};
+
+/**
+ * Register the keyed submission mutation defaults on a client. MUST be called
+ * before `PersistQueryClientProvider` restores the cache, so a rehydrated paused
+ * mutation can resolve its `mutationFn` by key.
+ */
+export function registerSubmissionMutationDefaults(queryClient: QueryClient): void {
+  queryClient.setMutationDefaults(SUBMISSION_PATCH_KEY, {
+    mutationFn: patchSubmissionFn as (vars: unknown) => Promise<Submission>,
+    networkMode: 'offlineFirst',
+    retry: 3,
+    onSuccess: (updated: Submission) => {
+      // Derive the assignment from the response — never a closure — so this also
+      // runs correctly when a rehydrated mutation replays with no live observer.
+      queryClient.setQueryData(['submission', updated.assignment], updated);
+      queryClient.invalidateQueries({ queryKey: ['assignments'] });
+    },
+  });
+
+  queryClient.setMutationDefaults(SUBMISSION_CREATE_KEY, {
+    mutationFn: createSubmissionFn as (vars: unknown) => Promise<Submission>,
+    networkMode: 'offlineFirst',
+    retry: 3,
+    onSuccess: (created: Submission) => {
+      queryClient.setQueryData(['submission', created.assignment], created);
+    },
+  });
+}
+
+/**
+ * Persist allowlist for mutations: dehydrate a mutation only when it is **paused**
+ * (queued offline) and belongs to the `submission` family. Never persist auth or
+ * any other token-bearing mutation. Paired with the MSO-4 reads allowlist in
+ * `persist.ts` (`shouldDehydrateQuery`).
+ */
+export const shouldDehydrateSubmissionMutation = (mutation: Mutation): boolean => {
+  if (mutation.state.isPaused !== true) return false;
+  const key = mutation.options.mutationKey;
+  return Array.isArray(key) && key[0] === 'submission';
+};


### PR DESCRIPTION
## Classification
**New** — Initiative: **Mobile Shell & PWA-Offline, Batch 2** (offline write-tolerance), queue foundation. Pairs with #367 (MSO-6).

## Why
Batch 1 made the student core loop survive a dropped connection for *reads*. Today the assignment page's auto-save and submit are plain `useMutation` calls that **fail silently or error** offline — a student who finishes an assignment on a train or patchy rural 3G loses their answers. This wires the *write* half.

## What changed
- **New `src/shared/query/offlineMutations.ts`**
  - `registerSubmissionMutationDefaults(queryClient)` — `setMutationDefaults(['submission','patch'|'create'], { mutationFn, networkMode: 'offlineFirst', retry: 3, onSuccess })`. The `mutationFn` and cache-reconciling `onSuccess` live in the defaults (keyed, not a closure) so a **rehydrated** paused mutation — which has no component context — still resolves its function and reconciles the cache on replay. `onSuccess` derives the assignment from the server response.
  - `shouldDehydrateSubmissionMutation(mutation)` — persist allowlist: dehydrate only when the mutation is **paused** and `mutationKey[0] === 'submission'`. Never auth/token-bearing mutations.
- **`src/main.tsx`** — register defaults **before** the persister restores the cache; flip `shouldDehydrateMutation` from `() => false` to the submission allowlist; add the provider `onSuccess` → `resumePausedMutations()` (mid-session reconnects auto-resume via `onlineManager`).
- **`src/features/student/useSubmission.ts`** — the submission hooks now reference the keyed defaults by `mutationKey` only. Online behavior and the `AssignmentDetailPage` mutate signatures are unchanged.

## Scope
Only **patch/submit of an already-created (online) submission** is made offline-durable — a submission row is created online on first open (Batch 1 already requires an online first open for offline read). Cold-offline create is out of scope for this batch. Rides MSO-6 (#367) server idempotency for safe at-least-once replay. **No new runtime dependency** — turns on React Query primitives shipped in Batch 1.

## Legacy reference
None — legacy (Django 1.11) was online-only; a dropped connection lost everything. We use React Query's *paused mutation* model (durable in IndexedDB, replayed across reload) rather than a naive in-memory retry.

## Tests
`src/shared/query/offlineMutations.test.ts`: allowlist (paused submission → persist; running / non-submission → not); offline round-trip (fire patch offline → **pauses** not fails → reconnect + resume drives the keyed `mutationFn` and reconciles cache); rehydration-safety (key-only mutation resolves its fn from defaults). Student feature suite (38) green; `tsc --noEmit`, eslint, `npm run build`, bundle budget (144.33 kB ≤ 160 kB, no new dep) green.

## Verify
`cd frontend_modern && npx vitest run src/shared/query/offlineMutations.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
