### PR TITLE
feat(pwa-offline): MSO-9 — offline final-submit

### DIFF
--- a/docs/changes/2026-06-15-mso9-offline-submit.md
+++ b/docs/changes/2026-06-15-mso9-offline-submit.md
@@ -1,0 +1,61 @@
+# MSO-9 — Offline final-submit
+
+**Date:** 2026-06-15
+**Initiative:** Mobile Shell & PWA-Offline — Batch 2 (offline write-tolerance)
+**Classification:** New
+
+## Summary
+
+Lets a student **submit an assignment while offline**. The submit optimistically
+flips to a submitted view immediately with honest "Submitted — will be graded
+when you're back online" copy (no fake score); the submit mutation is queued
+(MSO-7) and replays onto the idempotent server (MSO-6) when the network returns,
+at which point the real score reconciles into the card. If the replay ultimately
+fails (e.g. the assignment closed while offline), the form re-opens so the student
+isn't stuck.
+
+## What changed
+
+`src/features/student/AssignmentDetailPage.tsx`:
+- `useOnlineStatus()` + a new `submittedOffline` state.
+- `handleSubmit` now **optimistically** locks into the submitted view immediately
+  (`setIsSubmitted(true)`), sets `submittedOffline` when offline at submit time,
+  then fires the queued `patchSubmission.mutate`. Its `onSuccess` (fires
+  immediately online, or after the queued replay) reconciles the real score and
+  clears `submittedOffline`; its `onError` re-opens the form.
+- The post-submit card gains a **pending-grade** variant: when `submittedOffline`,
+  it shows `submittedOfflineTitle` + `gradePending` on the neutral `brand-50`
+  surface (not a red/amber/green score band), resolving to the real band once the
+  score arrives.
+- i18n: `assignmentDetail.submittedOfflineTitle` + `assignmentDetail.gradePending`
+  in `en.ts` + `hi.ts` (full parity).
+
+## Notes
+
+- Grading is async (Celery) even online, so the PATCH `score` is already
+  frequently `null` on submit until the task runs — the component already handled
+  that. Offline simply widens the existing "score not yet available" window with
+  honest copy.
+- Double-submit safety: if the student taps submit, goes online, and a manual
+  re-submit races the replay, MSO-6's idempotent guard makes the second a no-op
+  returning the same score.
+
+## Legacy reference
+
+None — legacy was online-only; submitting required a live connection. This is new
+capability built on the MSO-6 idempotent server + MSO-7 queue + MSO-8 sync UX.
+
+## Tests
+
+`src/features/student/AssignmentDetailPage.offline.test.tsx` (mocks the data +
+mutation hooks, drives connectivity): offline submit → optimistic
+"will be graded when you're back online" + no `%` score + locked inputs + queued
+mutation carrying `submitted_at`; replay `onSuccess` → real `80%` reconciles and
+the offline copy clears; replay `onError` → form re-opens (editable). Student
+suite (54) + parity guard + tsc + lint + build + bundle budget (146.00 kB ≤
+160 kB) green.
+
+## Next steps
+
+MSO-10 — batch close-out: manual offline-write test checklist, ledger rows, and
+the STATUS headline flip.

--- a/frontend_modern/src/features/student/AssignmentDetailPage.offline.test.tsx
+++ b/frontend_modern/src/features/student/AssignmentDetailPage.offline.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { I18nProvider } from '@/shared/i18n/I18nProvider';
+import { AssignmentDetailPage } from './AssignmentDetailPage';
+
+// MSO-9 — focused coverage of the offline final-submit flow. We mock the data +
+// mutation hooks so we can drive connectivity and the queued mutation's eventual
+// replay deterministically.
+
+const existingSubmission = {
+  id: 5,
+  assignment: 1,
+  answers: { '101': '42' },
+  completion: 1,
+  submitted_at: null,
+  score: null,
+};
+
+const assignment = {
+  id: 1,
+  problem_set: {
+    title: 'Polynomials Practice',
+    subject: { name: 'Mathematics' },
+    chapter: { id: 9, name: 'Polynomials' },
+    questions: [{ id: 1, subparts: [{ id: 101 }] }],
+  },
+};
+
+const patchMutate = vi.fn();
+
+vi.mock('./useAssignmentDetail', () => ({
+  useAssignmentDetail: () => ({ data: assignment, isLoading: false, error: null }),
+}));
+
+vi.mock('./useSubmission', () => ({
+  useSubmission: () => ({ data: existingSubmission, isLoading: false }),
+  useCreateSubmission: () => ({ mutate: vi.fn(), isPending: false }),
+  usePatchSubmission: () => ({ mutate: patchMutate, isPending: false }),
+}));
+
+// SyncStatus and VideosPanel read React Query / network; stub them out — covered
+// by their own tests.
+vi.mock('./SyncStatus', () => ({ SyncStatus: () => null }));
+vi.mock('./VideosPanel', () => ({ VideosPanel: () => null }));
+
+vi.mock('./QuestionCard', () => ({
+  QuestionCard: ({ isSubmitted }: { isSubmitted: boolean }) => (
+    <div data-testid="qcard">{isSubmitted ? 'locked' : 'editable'}</div>
+  ),
+}));
+
+const setOnLine = (value: boolean) =>
+  Object.defineProperty(navigator, 'onLine', { configurable: true, value });
+
+const renderPage = () =>
+  render(
+    <I18nProvider initialLocale="en">
+      <MemoryRouter initialEntries={['/student/assignments/1']}>
+        <Routes>
+          <Route path="/student/assignments/:id" element={<AssignmentDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </I18nProvider>,
+  );
+
+beforeEach(() => {
+  patchMutate.mockReset();
+  setOnLine(true);
+});
+afterEach(() => {
+  setOnLine(true);
+  vi.restoreAllMocks();
+});
+
+describe('AssignmentDetailPage — offline final-submit (MSO-9)', () => {
+  it('submits offline: optimistic "will be graded when back online" + locked inputs + queued mutation', async () => {
+    const user = userEvent.setup();
+    setOnLine(false);
+    renderPage();
+
+    expect(screen.getByTestId('qcard')).toHaveTextContent('editable');
+
+    await user.click(screen.getByRole('button', { name: 'Submit assignment' }));
+    // Confirm dialog → confirm.
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    // Optimistic submitted view with the honest offline copy (no fake score).
+    expect(screen.getByText(/will be graded when you're back online/i)).toBeInTheDocument();
+    expect(screen.queryByText('%')).not.toBeInTheDocument();
+    // Inputs are locked after submit.
+    expect(screen.getByTestId('qcard')).toHaveTextContent('locked');
+    // The submit mutation was queued with submitted_at set.
+    expect(patchMutate).toHaveBeenCalledTimes(1);
+    expect(patchMutate.mock.calls[0][0].data.submitted_at).toBeTruthy();
+  });
+
+  it('reconciles the real score when the queued submit replays on reconnect', async () => {
+    const user = userEvent.setup();
+    setOnLine(false);
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: 'Submit assignment' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(screen.getByText(/will be graded when you're back online/i)).toBeInTheDocument();
+
+    // Replay succeeds: invoke the onSuccess the component passed to mutate.
+    const onSuccess = patchMutate.mock.calls[0][1].onSuccess as (s: { score: number }) => void;
+    act(() => onSuccess({ score: 0.8 }));
+
+    expect(screen.getByText('80%')).toBeInTheDocument();
+    expect(
+      screen.queryByText(/will be graded when you're back online/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('re-opens the form if the queued submit ultimately fails', async () => {
+    const user = userEvent.setup();
+    setOnLine(false);
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: 'Submit assignment' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(screen.getByTestId('qcard')).toHaveTextContent('locked');
+
+    const onError = patchMutate.mock.calls[0][1].onError as () => void;
+    act(() => onError());
+
+    // Back to an editable, submittable form.
+    expect(screen.getByTestId('qcard')).toHaveTextContent('editable');
+    expect(screen.queryByText(/will be graded when you're back online/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend_modern/src/features/student/AssignmentDetailPage.tsx
+++ b/frontend_modern/src/features/student/AssignmentDetailPage.tsx
@@ -7,6 +7,7 @@ import { VideosPanel } from './VideosPanel';
 import { SyncStatus } from './SyncStatus';
 import { Button, EmptyState, LoadingSpinner } from '@/shared/ui';
 import { useT } from '@/shared/i18n';
+import { useOnlineStatus } from '@/shared/hooks/useOnlineStatus';
 import type { Question } from '@/types/index';
 
 function countSubparts(questions: Question[]): number {
@@ -33,12 +34,17 @@ export const AssignmentDetailPage = () => {
 
   const createSubmission = useCreateSubmission();
   const patchSubmission = usePatchSubmission(assignmentId);
+  const online = useOnlineStatus();
 
   const [submissionId, setSubmissionId] = useState<number | null>(null);
   const [answers, setAnswers] = useState<Record<string, string>>({});
   const [showConfirm, setShowConfirm] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [submitScore, setSubmitScore] = useState<number | null>(null);
+  // MSO-9: the student hit submit while offline — the submit mutation is queued
+  // (MSO-7) and will replay/grade on reconnect. Until the server confirms, show a
+  // "submitted — will be graded when back online" card instead of a fake score.
+  const [submittedOffline, setSubmittedOffline] = useState(false);
 
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -103,6 +109,13 @@ export const AssignmentDetailPage = () => {
 
   const handleSubmit = () => {
     if (!submissionId) return;
+    // Optimistically lock into a submitted view immediately. Online this resolves
+    // to the score (or the async "grading…" state) on success; offline the
+    // mutation pauses (MSO-7) and we show the "will be graded when back online"
+    // card until it replays onto the idempotent server (MSO-6).
+    setIsSubmitted(true);
+    setShowConfirm(false);
+    if (!online) setSubmittedOffline(true);
     patchSubmission.mutate(
       {
         id: submissionId,
@@ -114,9 +127,17 @@ export const AssignmentDetailPage = () => {
       },
       {
         onSuccess: (sub) => {
-          setIsSubmitted(true);
+          // Server confirmed (immediately online, or after the queued replay):
+          // reconcile the real score and drop the offline-pending state.
           setSubmitScore(sub.score);
-          setShowConfirm(false);
+          setSubmittedOffline(false);
+        },
+        onError: () => {
+          // The replay ultimately failed (e.g. the assignment closed while the
+          // student was offline). Re-open the form so they aren't stuck — the
+          // global sync indicator (MSO-8) already shows the failure.
+          setIsSubmitted(false);
+          setSubmittedOffline(false);
         },
       },
     );
@@ -195,7 +216,16 @@ export const AssignmentDetailPage = () => {
 
       {isSubmitted && (
         <div className={`mb-6 rounded-xl p-4 text-center border ${scoreBg}`}>
-          {submitScore !== null ? (
+          {submittedOffline ? (
+            <>
+              <p className="font-display font-semibold text-brand-800">
+                {t('assignmentDetail.submittedOfflineTitle')}
+              </p>
+              <p className="text-sm text-brand-700 mt-0.5">
+                {t('assignmentDetail.gradePending')}
+              </p>
+            </>
+          ) : submitScore !== null ? (
             <>
               <p className="text-2xl font-display font-semibold text-ink-900">
                 {Math.round(submitScore * 100)}%

--- a/frontend_modern/src/shared/i18n/locales/en.ts
+++ b/frontend_modern/src/shared/i18n/locales/en.ts
@@ -150,6 +150,8 @@ export const en = {
   'assignmentDetail.submittedNice': 'Assignment submitted — nice work!',
   'assignmentDetail.submittedTitle': 'Submitted',
   'assignmentDetail.grading': 'Grading in progress…',
+  'assignmentDetail.submittedOfflineTitle': 'Submitted',
+  'assignmentDetail.gradePending': "Will be graded when you're back online",
   'assignmentDetail.notFoundTitle': 'Assignment not found',
   'assignmentDetail.notFoundDescription': "It may have been removed or you don't have access.",
   'assignmentDetail.backToDashboard': 'Back to dashboard',

--- a/frontend_modern/src/shared/i18n/locales/hi.ts
+++ b/frontend_modern/src/shared/i18n/locales/hi.ts
@@ -151,6 +151,8 @@ export const hi: LocaleDict = {
   'assignmentDetail.submittedNice': 'असाइनमेंट जमा हो गया — शाबाश!',
   'assignmentDetail.submittedTitle': 'जमा हो गया',
   'assignmentDetail.grading': 'जाँच चल रही है…',
+  'assignmentDetail.submittedOfflineTitle': 'जमा हो गया',
+  'assignmentDetail.gradePending': 'ऑनलाइन होने पर जाँच की जाएगी',
   'assignmentDetail.notFoundTitle': 'असाइनमेंट नहीं मिला',
   'assignmentDetail.notFoundDescription':
     'यह हटाया जा चुका हो सकता है या आपके पास इसकी अनुमति नहीं है।',


### PR DESCRIPTION
## Classification
**New** — Initiative: **Mobile Shell & PWA-Offline, Batch 2** (offline write-tolerance). Stacked on #369 (MSO-8); depends on #367 (MSO-6) + #368 (MSO-7), both merged. **Merge #369 first** — until then this PR's diff includes MSO-8's commit.

## Why
MSO-7 queues offline writes; MSO-8 shows their status. This closes the loop: a student can **finish and submit** an assignment while offline and have it grade exactly once when they reconnect — the other half of the North Star ("the student core loop survives a flaky or absent connection").

## What changed
`src/features/student/AssignmentDetailPage.tsx`:
- `handleSubmit` **optimistically** locks into the submitted view immediately (`setIsSubmitted(true)`), sets a new `submittedOffline` flag when offline at submit time, then fires the queued `patchSubmission.mutate`. `onSuccess` (immediately online, or after the queued replay) reconciles the real score and clears `submittedOffline`; `onError` re-opens the form (e.g. assignment closed while offline).
- Post-submit card gains a **pending-grade** variant: when `submittedOffline`, shows `submittedOfflineTitle` + `gradePending` on the neutral `brand-50` surface (no red/amber/green band), resolving to the real band when the score arrives.
- i18n: `assignmentDetail.submittedOfflineTitle` + `gradePending` in `en` + `hi` (full parity).

## Honesty / safety
- No fake score — the copy is "will be graded when you're back online".
- Grading is async (Celery) even online, so `score` is already frequently `null` on submit; offline just widens that window. MSO-6's idempotent server makes a submit-then-online double-submit a no-op returning the same score.

## Legacy reference
None — legacy required a live connection to submit. New capability on the MSO-6 idempotent server + MSO-7 queue + MSO-8 sync UX.

## Tests
`src/features/student/AssignmentDetailPage.offline.test.tsx` (mocks data + mutation hooks, drives connectivity): offline submit → optimistic "will be graded when you're back online" + no `%` + locked inputs + queued mutation carrying `submitted_at`; replay `onSuccess` → real `80%` reconciles and offline copy clears; replay `onError` → form re-opens. Student suite (54) + parity guard + tsc + lint + build + bundle budget (146.00 kB ≤ 160 kB) green.

## Verify
`cd frontend_modern && npx vitest run src/features/student/AssignmentDetailPage.offline.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
