### PR TITLE
docs(pwa-offline): MSO-10 — Batch 2 close-out (offline write-tolerance)

### DIFF
--- a/docs/changes/2026-06-15-mso10-batch2-closeout.md
+++ b/docs/changes/2026-06-15-mso10-batch2-closeout.md
@@ -1,0 +1,47 @@
+# MSO-10 — Mobile Shell & PWA-Offline Batch 2 close-out
+
+**Date:** 2026-06-15
+**Initiative:** Mobile Shell & PWA-Offline — Batch 2 (offline write-tolerance)
+**Classification:** Docs
+
+## Summary
+
+Closes out Batch 2 (offline *write*-tolerance, MSO-6..9): adds the manual
+offline-write test checklist, appends the ledger rows, marks the "Offline
+write-tolerance" later-phase item shipped, and flips the STATUS headline.
+
+## What changed
+
+- **New `docs/perf/2026-06-15-pwa-offline-write-manual-test.md`** — manual
+  end-to-end checklist (sibling to Batch 1's read-tolerance checklist): open
+  online → go offline → answers queue ("saved on this device") → reload survives →
+  submit offline ("will be graded when back online") → reconnect → queued writes
+  replay, score reconciles, **no double-grade**; double-submit race is a no-op;
+  repeat in en/हिं.
+- **`docs/initiatives/2026-mobile-shell-pwa-offline.md`** — appended ledger rows
+  for MSO-6 (#367), MSO-7 (#368), MSO-8 (#369), MSO-9 (#370); added the
+  "Batch 2 shipped 2026-06-15" summary; marked the Batch 2 section ✅ and the
+  "Offline write-tolerance" later-phase item shipped.
+- **`docs/initiatives/STATUS.md`** — headline flipped from "Batch 2 planned" to
+  "Batch 2 SHIPPED", with per-PR links and the remaining next phases (route-level
+  mobile layouts; web push for due-date reminders).
+
+## Batch 2 recap
+
+| PR | Increment | Classification |
+|---|---|---|
+| #367 | MSO-6 — replay-safe / idempotent submission writes | Improve |
+| #368 | MSO-7 — offline mutation queue foundation | New |
+| #369 | MSO-8 — "Saved offline · will sync" status UX | New |
+| #370 | MSO-9 — offline final-submit | New |
+| (this) | MSO-10 — batch close-out | Docs |
+
+The student core loop is now write-tolerant offline: auto-saves and final submit
+queue durably to IndexedDB, replay on reconnect, and grade exactly once on a
+server hardened idempotent in MSO-6 — no new runtime dependency, riding Batch 1's
+persister + `useOnlineStatus` + the LA i18n framework.
+
+## Next steps
+
+- Route-level mobile layouts for dense teacher tables.
+- Web push for due-date reminders (the email reminder already exists).

--- a/docs/initiatives/2026-mobile-shell-pwa-offline.md
+++ b/docs/initiatives/2026-mobile-shell-pwa-offline.md
@@ -79,7 +79,7 @@ not the exception, and an installable PWA removes the app-store barrier entirely
 - **MSO-5 — A2HS install prompt + batch close-out.** `beforeinstallprompt` capture
   + dismissible install affordance; ledger + manual offline-test doc. **New/docs.**
 
-### Batch 2 (planned 2026-06-15 — `docs/daily-plans/2026-06-15-plan.md`) — offline write-tolerance
+### Batch 2 (shipped 2026-06-15 — `docs/daily-plans/2026-06-15-plan.md`) — offline write-tolerance ✅
 
 - **MSO-6 — Replay-safe / idempotent submission writes (backend).** Make the
   submission write path safe to replay: a re-submit of an already-submitted
@@ -117,6 +117,19 @@ _(append one row per merged PR)_
 | #360 | MSO-3 | `vite-plugin-pwa` SW: precache shell, `CacheFirst` fonts/KaTeX, `/api` `NetworkOnly`, navigateFallback; prod-only manual registration; localized "new version" `UpdateBanner`; SW emitted as separate files (entry chunk unchanged) |
 | #361 | MSO-4 | `PersistQueryClientProvider` + `idb-keyval` persister; reads-only dehydrate allowlist (student core-loop keys; never auth/PII/mutations); `buster` keyed to a cache version; `gcTime` 24h |
 | #362 | MSO-5 | `useInstallPrompt` (module-level `beforeinstallprompt` capture) + dismissible `InstallBanner` (localized `pwa.install*`); manual offline-test checklist; batch close-out |
+| #367 | MSO-6 | Replay-safe / idempotent submission writes: `SubmissionSerializer.update()` no-op on already-submitted (closes the async double-grade race) + `validate()` 200-not-400 on replay; signal `score is None` grade gate. **Improve** |
+| #368 | MSO-7 | Offline mutation queue: keyed `setMutationDefaults` (`networkMode: 'offlineFirst'`, rehydration-safe `mutationFn`/`onSuccess`) + paused-submission persist allowlist + `resumePausedMutations()` on restore. No new dep. **New** |
+| #369 | MSO-8 | "Saved offline · will sync" UX: `useSyncState`/`usePendingSyncCount` over `useMutationState`; `SyncStatus` inline indicator + `PendingSyncBadge`; honest copy; `sync.*` i18n (en/hi). **New** |
+| #370 | MSO-9 | Offline final-submit: optimistic "will be graded when back online" card (no fake score), queued submit replays onto MSO-6 and the real score reconciles; `onError` re-opens the form. **New** |
+
+**Batch 2 shipped 2026-06-15** — the student core loop is now write-tolerant
+offline. A student on a dropped connection keeps answering (auto-saves queue
+durably to IndexedDB), can submit (optimistic "will be graded when back online"),
+and every queued write replays **exactly once** — without double-grading — when
+the network returns (server hardened idempotent in MSO-6). The **"Offline
+write-tolerance" later-phase item is shipped.** See the manual offline-*write*
+test checklist in `docs/perf/2026-06-15-pwa-offline-write-manual-test.md`
+(sibling to Batch 1's `docs/perf/2026-06-14-pwa-offline-manual-test.md`).
 
 **Batch 1 shipped 2026-06-14** — OpenShiksha is now an installable PWA whose
 student core loop survives a flaky/absent connection: precached shell boots

--- a/docs/initiatives/STATUS.md
+++ b/docs/initiatives/STATUS.md
@@ -12,18 +12,22 @@
 > priority table below** so it is never picked as the "top active initiative."
 
 **Last updated:** 2026-06-15 (latest) — **Mobile Shell & PWA-Offline — Batch 2
-(MSO-6..10) planned: offline *write*-tolerance**
+(MSO-6..10) SHIPPED: offline *write*-tolerance**
 ([plan](../daily-plans/2026-06-15-plan.md)). Batch 1 made the student core loop
-survive offline for *reads*; Batch 2 queues and replays assignment auto-saves and
-submissions made offline — exactly once, no double-grade. Five PRs, lowest-risk
-first: **MSO-6** replay-safe/idempotent submission writes server-side (closes a
-latent re-grade hazard in the grading `post_save` signal — fires whenever
-`submitted_at` is non-null on a no-`update_fields` save) → **MSO-7** durable offline
-mutation queue (flip Batch 1's `shouldDehydrateMutation` on for an allowlist + keyed
-`setMutationDefaults` + `networkMode: 'offlineFirst'` + `resumePausedMutations` on
-reconnect — no new dep) → **MSO-8** "Saved offline · will sync" status UX → **MSO-9**
-offline final-submit (optimistic + score reconcile on replay) → **MSO-10** close-out.
-No new runtime dependency; rides Batch 1's persister + `useOnlineStatus` + LA i18n.
+survive offline for *reads*; Batch 2 now queues and replays assignment auto-saves
+and submissions made offline — **exactly once, no double-grade**. Five PRs,
+lowest-risk first: **MSO-6** ([#367](https://github.com/openshiksha/openshiksha/pull/367))
+replay-safe/idempotent submission writes server-side (closed a latent re-grade
+hazard in the grading `post_save` signal) → **MSO-7**
+([#368](https://github.com/openshiksha/openshiksha/pull/368)) durable offline
+mutation queue (paused-mutation persist allowlist + keyed `setMutationDefaults` +
+`networkMode: 'offlineFirst'` + `resumePausedMutations` on reconnect — no new dep)
+→ **MSO-8** ([#369](https://github.com/openshiksha/openshiksha/pull/369)) "Saved
+offline · will sync" status UX → **MSO-9**
+([#370](https://github.com/openshiksha/openshiksha/pull/370)) offline final-submit
+(optimistic + score reconcile on replay) → **MSO-10** close-out. No new runtime
+dependency; rode Batch 1's persister + `useOnlineStatus` + LA i18n. **Next phases:**
+route-level mobile layouts (dense teacher tables); web push for due-date reminders.
 
 **Earlier (2026-06-14)** — **Mobile Shell & PWA-Offline — Batch 1
 (MSO-1..5) shipped** ([doc](2026-mobile-shell-pwa-offline.md),

--- a/docs/perf/2026-06-15-pwa-offline-write-manual-test.md
+++ b/docs/perf/2026-06-15-pwa-offline-write-manual-test.md
@@ -1,0 +1,82 @@
+# PWA / Offline-write — manual test checklist
+
+**Initiative:** Mobile Shell & PWA-Offline (Batch 2, 2026-06-15) — offline
+*write*-tolerance
+
+Batch 2 makes the student core loop survive a dropped connection for **writes**:
+auto-saves and final submit are queued durably (MSO-7), shown honestly (MSO-8),
+submittable offline (MSO-9), and replay **exactly once** onto an idempotent server
+(MSO-6). The queue + IndexedDB persistence + real service worker can't be fully
+exercised by Vitest, so run this checklist against a production build.
+
+This is the sibling of Batch 1's read-tolerance checklist
+(`docs/perf/2026-06-14-pwa-offline-manual-test.md`); run that first to confirm
+the shell + reads still boot offline.
+
+## Setup
+
+```bash
+cd frontend_modern
+npm run build
+npm run preview   # serves dist/ on http://localhost:4173 (localhost = SW-eligible)
+```
+
+Open the preview URL in Chrome or Edge and sign in as a **student** with at least
+one open (not-yet-submitted) assignment. Keep DevTools → Network open to toggle
+**Offline**.
+
+## 1. Queue an auto-save offline (MSO-7 + MSO-8)
+
+- [ ] Open an assignment **online** so its questions and the submission row load.
+- [ ] DevTools → Network → **Offline**.
+- [ ] Type/select answers. Within ~2 s the assignment header shows the honest
+      sync line: **"Saved on this device · will sync when you're back online"**
+      (`role="status"`). It does **not** say "saved to server".
+- [ ] A small **pending-sync badge** appears near the offline banner in the app
+      shell ("N change(s) waiting to sync"), visible even if you navigate away.
+
+## 2. Survive a reload while offline (MSO-7 persistence)
+
+- [ ] Still offline, **reload** the page. The shell boots (Batch 1), the
+      assignment re-opens with your typed answers, and the queued write is still
+      pending (the badge persists) — the paused mutation was rehydrated from
+      IndexedDB.
+
+## 3. Submit while offline (MSO-9)
+
+- [ ] Still offline, tap **Submit assignment** → confirm. The page flips
+      immediately to a **neutral** submitted card reading **"Submitted — will be
+      graded when you're back online"** (no score band, no fake %). The answer
+      inputs lock.
+
+## 4. Reconnect → replay exactly once (MSO-6 + MSO-7)
+
+- [ ] DevTools → Network → **Online** (or **Back online**). The queued writes
+      replay automatically (the badge drains to zero; the sync line shows
+      "Syncing…" then clears).
+- [ ] The submitted card reconciles to the **real score band** (red/amber/green)
+      once grading completes — refresh if grading is still async.
+- [ ] Confirm in the backend/admin that the submission was graded **once** (a
+      single set of ticks, one score) — the replayed submit did **not** re-grade
+      (MSO-6).
+
+## 5. Double-submit race (MSO-6 idempotency)
+
+- [ ] Repeat 1–3, then go online and quickly **re-submit** the same assignment
+      from another tab/device before the queue drains. The second submit is a
+      **no-op returning the same score** — no error, no second grade.
+
+## 6. Localized copy (en / हिं)
+
+- [ ] Switch language to **हिंदी** and repeat 1 + 3. The sync line
+      ("इस डिवाइस पर सहेजा गया · ऑनलाइन होने पर सिंक होगा") and the offline-submit
+      card ("ऑनलाइन होने पर जाँच की जाएगी") are localized.
+
+> Note: Marathi (मराठी) was removed as a product language on 2026-06-14, so only
+> en/हिं are exercised here.
+
+## Pass criteria
+
+Offline answers and submits are **never lost**, the UI is **honest** about what is
+queued vs. saved-to-server, and every queued write grades **exactly once** on
+reconnect with no double-grading.


### PR DESCRIPTION
## Classification
**Docs** — Initiative: **Mobile Shell & PWA-Offline, Batch 2** close-out.

## What changed
- **New `docs/perf/2026-06-15-pwa-offline-write-manual-test.md`** — manual end-to-end offline-*write* checklist (sibling to Batch 1's read checklist): open online → offline → answers queue ("saved on this device") → reload survives → submit offline ("will be graded when back online") → reconnect replays **exactly once**, score reconciles, no double-grade; double-submit race is a no-op; repeat in en/हिं.
- **`docs/initiatives/2026-mobile-shell-pwa-offline.md`** — appended ledger rows for MSO-6 (#367), MSO-7 (#368), MSO-8 (#369), MSO-9 (#370); "Batch 2 shipped" summary; marked the Batch 2 section ✅ and the "Offline write-tolerance" later-phase shipped.
- **`docs/initiatives/STATUS.md`** — headline flipped "Batch 2 planned" → "SHIPPED" with per-PR links; next phases noted (route-level mobile layouts; web push).

## Batch 2 recap
MSO-6 (idempotent server) → MSO-7 (durable offline queue) → MSO-8 (sync UX) → MSO-9 (offline submit) → MSO-10 (this). The student core loop is now write-tolerant offline: auto-saves + submit queue durably to IndexedDB, replay on reconnect, grade exactly once. No new runtime dependency.

> Docs-only; depends on #367–#370. Merge after the code PRs land so the ledger/STATUS reflect reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
