### PR TITLE
ci(security): add CodeQL SAST workflow for backend + frontend

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,78 @@
+name: CodeQL
+# Static application-security testing (SAST) on our OWN source code.
+#
+# This complements — does not duplicate — the existing dependency-level
+# scanning:
+#   - `security` (ci-cd.yaml) ........ pip-audit on backend requirements
+#   - `frontend` (ci-cd.yaml) ........ npm audit on the frontend lockfile
+#   - dependency-review.yaml ......... CVEs/licenses a PR newly *adds*
+# Those three find vulnerabilities in third-party packages. CodeQL is the
+# missing layer: it analyses the code *we* write for injection flaws
+# (SQLi, command/path injection), unsafe deserialization, XSS, cleartext
+# logging of secrets, and similar. Findings surface in the repo's
+# Security ▸ Code scanning tab as SARIF, and annotate the offending PR.
+#
+# Lives in its own workflow (not ci-cd.yaml) because it needs
+# `security-events: write` and runs on a weekly schedule in addition to
+# push/PR — keeping it separate avoids widening ci-cd.yaml's permissions.
+
+on:
+    push:
+        branches:
+            - modernization
+            - qa
+            - prod
+    pull_request:
+        branches:
+            - modernization
+            - qa
+            - prod
+    schedule:
+        # Weekly full scan (Mondays 06:17 UTC). Catches advisories that land
+        # in CodeQL's query packs between code changes on quiet branches.
+        - cron: '17 6 * * 1'
+
+# Cancel superseded runs on feature branches; let the gated long-lived
+# branches (modernization/qa/prod) each run to completion, mirroring
+# ci-cd.yaml's concurrency policy.
+concurrency:
+    group: codeql-${{ github.ref }}
+    cancel-in-progress: ${{ github.ref != 'refs/heads/modernization' && github.ref != 'refs/heads/qa' && github.ref != 'refs/heads/prod' }}
+
+jobs:
+    analyze:
+        name: Analyze (${{ matrix.language }})
+        timeout-minutes: 30
+        runs-on: ubuntu-latest
+        permissions:
+            # Required to upload SARIF results to the Security tab.
+            security-events: write
+            # `actions: read` is needed for private repos so CodeQL can read
+            # workflow run metadata; `contents: read` to check out the code.
+            actions: read
+            contents: read
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    # Backend: Django 4.2 + Python 3.12 under backend/.
+                    - language: python
+                    # Frontend: React 18 + TypeScript under frontend_modern/.
+                    - language: javascript-typescript
+        steps:
+            - name: Check out the repo
+              uses: actions/checkout@v4
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v3
+              with:
+                languages: ${{ matrix.language }}
+                # Python and JS/TS are interpreted — no compilation step, so
+                # CodeQL builds its database directly from source.
+                build-mode: none
+                # `security-and-quality` adds maintainability/quality queries
+                # on top of the default security suite for broader coverage.
+                queries: security-and-quality
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@v3
+              with:
+                category: '/language:${{ matrix.language }}'

--- a/docs/infra/code-scanning.md
+++ b/docs/infra/code-scanning.md
@@ -1,0 +1,48 @@
+# Code scanning (CodeQL SAST)
+
+`.github/workflows/codeql.yaml` runs GitHub's CodeQL static analysis on the
+code **we** write — backend (`python`) and frontend (`javascript-typescript`)
+in parallel via a matrix.
+
+## Why it exists / how it layers
+
+The repo already scans **dependencies** at three points:
+
+| Check | Where | Scope |
+|-------|-------|-------|
+| `pip-audit` | `security` job, `ci-cd.yaml` | backend requirements vs known CVEs |
+| `npm audit` | `frontend` job, `ci-cd.yaml` | frontend lockfile vs known CVEs |
+| `dependency-review-action` | `dependency-review.yaml` | CVEs/licenses a PR newly adds |
+
+All three find flaws in **third-party packages**. None of them look at our own
+source. CodeQL fills that gap: it flags injection (SQLi, command/path),
+unsafe deserialization, XSS, cleartext logging of secrets, SSRF, and similar
+patterns in first-party code.
+
+## When it runs
+
+- Every push and PR to `modernization` / `qa` / `prod`.
+- A weekly scheduled full scan (Mondays 06:17 UTC) so advisories that land in
+  CodeQL's query packs are caught even on quiet branches.
+
+`build-mode: none` — Python and TS are interpreted, so CodeQL builds its
+database straight from source with no compile step. The
+`security-and-quality` query suite is used for broader coverage than the
+default security-only suite.
+
+## Where results show up
+
+Findings appear under **Security ▸ Code scanning** as SARIF and annotate the
+offending PR. CodeQL alerts do **not** hard-fail the merge by default; to gate
+merges on them, enable *required* code-scanning results in branch protection
+(see [`branch-protection.md`](branch-protection.md)).
+
+## Triaging a finding
+
+1. Open the alert in the Code scanning tab; CodeQL shows the data-flow path.
+2. Fix the root cause if it's a true positive.
+3. If it's a false positive or accepted risk, dismiss with a reason in the UI,
+   or scope it out with an inline `# codeql[rule-id]` style suppression /
+   a `.github/codeql/codeql-config.yml` `query-filters` entry. Record any
+   standing ignore here, alongside the rationale, mirroring how the
+   `security` job documents its `--ignore-vuln` entries.


### PR DESCRIPTION
## What

Adds `.github/workflows/codeql.yaml` — GitHub **CodeQL** static analysis (SAST) on our own source, running `python` (backend) and `javascript-typescript` (frontend_modern) in parallel via a matrix. Plus `docs/infra/code-scanning.md` explaining the layering and triage flow.

## Why

The security pipeline already scans **dependencies** thoroughly:

| Check | Scope |
|-------|-------|
| `pip-audit` (`security` job) | backend requirements vs known CVEs |
| `npm audit` (`frontend` job) | frontend lockfile vs known CVEs |
| `dependency-review-action` | CVEs/licenses a PR newly adds |

All three look at **third-party packages**. Nothing analysed the code **we** write. CodeQL is the missing layer — it flags injection (SQLi, command/path), unsafe deserialization, XSS, cleartext logging of secrets, SSRF, and similar in first-party code. Findings surface under **Security ▸ Code scanning** as SARIF and annotate the offending PR.

## Details

- **Triggers:** push/PR to `modernization`/`qa`/`prod`, plus a weekly scheduled full scan (Mondays 06:17 UTC).
- **`build-mode: none`** — Python and TS are interpreted, no compile step needed.
- **`security-and-quality`** query suite for broader coverage than security-only.
- Lives in its **own workflow** (not `ci-cd.yaml`) so that file doesn't need the `security-events: write` permission. Concurrency policy mirrors `ci-cd.yaml` (cancel superseded feature-branch runs; let gated branches finish).
- `timeout-minutes: 30`, matching the repo's per-job timeout discipline.

## Validation

- `actionlint -shellcheck=` passes (same linter the `workflow-lint` job runs).
- YAML parses clean.

Atomic, single-concern infra change; no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)