### PR TITLE
feat(pwa-push): MPN-2 — subscribe/unsubscribe API + send_web_push helper

### DIFF
--- a/backend/openshiksha/apps/api/tests/test_push_api.py
+++ b/backend/openshiksha/apps/api/tests/test_push_api.py
@@ -1,0 +1,133 @@
+"""
+API + helper tests for Web Push (MPN-2):
+- subscribe creates a row and is idempotent on repeat (upsert by endpoint)
+- unsubscribe deletes the caller's row
+- vapid-public-key reflects settings
+- send_web_push prunes stale (410) subscriptions and no-ops without a key
+"""
+
+from unittest import mock
+
+import pytest
+
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from openshiksha.apps.core.models import PushSubscription, User, UserRole
+
+
+@pytest.fixture
+def student(db):
+    return User.objects.create_user(username="push_api_student", password="pass", role=UserRole.STUDENT)
+
+
+@pytest.fixture
+def client(student):
+    c = APIClient()
+    c.force_authenticate(user=student)
+    return c
+
+
+SUB_BODY = {
+    "endpoint": "https://push.example.com/endpoint-1",
+    "keys": {"p256dh": "pub-key", "auth": "auth-secret"},
+}
+
+
+class TestPushSubscribeAPI:
+    def test_subscribe_creates_row(self, db, client, student):
+        resp = client.post("/api/v1/push/subscribe/", SUB_BODY, format="json")
+        assert resp.status_code == status.HTTP_201_CREATED
+        assert resp.data["created"] is True
+        sub = PushSubscription.objects.get(endpoint=SUB_BODY["endpoint"])
+        assert sub.user == student
+        assert sub.p256dh == "pub-key"
+
+    def test_subscribe_is_idempotent(self, db, client):
+        client.post("/api/v1/push/subscribe/", SUB_BODY, format="json")
+        resp = client.post("/api/v1/push/subscribe/", SUB_BODY, format="json")
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data["created"] is False
+        assert PushSubscription.objects.filter(endpoint=SUB_BODY["endpoint"]).count() == 1
+
+    def test_subscribe_requires_keys(self, db, client):
+        resp = client.post(
+            "/api/v1/push/subscribe/",
+            {"endpoint": "https://push.example.com/x", "keys": {"p256dh": "only-one"}},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_subscribe_requires_auth(self, db):
+        resp = APIClient().post("/api/v1/push/subscribe/", SUB_BODY, format="json")
+        assert resp.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+
+    def test_unsubscribe_deletes_row(self, db, client, student):
+        client.post("/api/v1/push/subscribe/", SUB_BODY, format="json")
+        resp = client.post("/api/v1/push/unsubscribe/", {"endpoint": SUB_BODY["endpoint"]}, format="json")
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data["deleted"] == 1
+        assert PushSubscription.objects.count() == 0
+
+
+class TestVapidPublicKey:
+    def test_returns_configured_key(self, db, settings):
+        settings.VAPID_PUBLIC_KEY = "test-public-key"
+        resp = APIClient().get("/api/v1/push/vapid-public-key/")
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data["publicKey"] == "test-public-key"
+
+    def test_blank_when_unconfigured(self, db, settings):
+        settings.VAPID_PUBLIC_KEY = ""
+        resp = APIClient().get("/api/v1/push/vapid-public-key/")
+        assert resp.data["publicKey"] == ""
+
+
+class TestSendWebPush:
+    def test_noop_when_key_blank(self, db, student, settings):
+        settings.VAPID_PRIVATE_KEY = ""
+        PushSubscription.objects.create(user=student, endpoint="https://push.example.com/a", p256dh="k", auth="a")
+        from openshiksha.apps.core.push import send_web_push
+
+        assert send_web_push(student, {"title": "Hi"}) == 0
+
+    def test_sends_to_all_subscriptions(self, db, student, settings):
+        settings.VAPID_PRIVATE_KEY = "private"
+        for i in range(2):
+            PushSubscription.objects.create(
+                user=student, endpoint=f"https://push.example.com/{i}", p256dh="k", auth="a"
+            )
+        with mock.patch("pywebpush.webpush") as m:
+            from openshiksha.apps.core.push import send_web_push
+
+            sent = send_web_push(student, {"title": "Hi"})
+        assert sent == 2
+        assert m.call_count == 2
+
+    def test_prunes_stale_410(self, db, student, settings):
+        settings.VAPID_PRIVATE_KEY = "private"
+        PushSubscription.objects.create(user=student, endpoint="https://push.example.com/stale", p256dh="k", auth="a")
+        from pywebpush import WebPushException
+
+        fake_response = mock.Mock(status_code=410)
+        with mock.patch("pywebpush.webpush", side_effect=WebPushException("gone", response=fake_response)):
+            from openshiksha.apps.core.push import send_web_push
+
+            sent = send_web_push(student, {"title": "Hi"})
+        assert sent == 0
+        assert PushSubscription.objects.count() == 0
+
+    def test_keeps_subscription_on_transient_error(self, db, student, settings):
+        settings.VAPID_PRIVATE_KEY = "private"
+        PushSubscription.objects.create(
+            user=student, endpoint="https://push.example.com/transient", p256dh="k", auth="a"
+        )
+        from pywebpush import WebPushException
+
+        fake_response = mock.Mock(status_code=500)
+        with mock.patch("pywebpush.webpush", side_effect=WebPushException("boom", response=fake_response)):
+            from openshiksha.apps.core.push import send_web_push
+
+            sent = send_web_push(student, {"title": "Hi"})
+        assert sent == 0
+        assert PushSubscription.objects.count() == 1  # transient → not pruned

--- a/backend/openshiksha/apps/api/urls.py
+++ b/backend/openshiksha/apps/api/urls.py
@@ -22,6 +22,11 @@ from openshiksha.apps.api.views.core import (
     SubmissionViewSet,
     UserViewSet,
 )
+from openshiksha.apps.api.views.push import (
+    PushSubscribeView,
+    PushUnsubscribeView,
+    VapidPublicKeyView,
+)
 
 # Create router for ViewSets
 router = DefaultRouter()
@@ -45,6 +50,10 @@ urlpatterns = [
     path("auth/verify/", TokenVerifyView.as_view(), name="token_verify"),
     path("auth/register/open/", RegisterOpenView.as_view(), name="register_open"),
     path("auth/register/school/", RegisterSchoolView.as_view(), name="register_school"),
+    # Web Push subscription endpoints (MPN-2)
+    path("push/vapid-public-key/", VapidPublicKeyView.as_view(), name="push_vapid_public_key"),
+    path("push/subscribe/", PushSubscribeView.as_view(), name="push_subscribe"),
+    path("push/unsubscribe/", PushUnsubscribeView.as_view(), name="push_unsubscribe"),
     # Health check endpoint
     path("health/", include("openshiksha.apps.api.views.health")),
     # Router URLs (all ViewSets)

--- a/backend/openshiksha/apps/api/views/push.py
+++ b/backend/openshiksha/apps/api/views/push.py
@@ -1,0 +1,81 @@
+"""
+Web Push subscription endpoints (MPN-2).
+
+  GET  /api/v1/push/vapid-public-key/ — public key the frontend needs to
+                                        subscribe (empty ⇒ push disabled)
+  POST /api/v1/push/subscribe/        — upsert a browser subscription
+  POST /api/v1/push/unsubscribe/      — remove a browser subscription
+
+All require authentication; subscriptions are always scoped to request.user.
+"""
+
+from django.conf import settings
+from rest_framework import serializers, status
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from openshiksha.apps.core.models import PushSubscription
+
+
+class VapidPublicKeyView(APIView):
+    """Expose the VAPID public key. Empty string ⇒ frontend hides push UI."""
+
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        return Response({"publicKey": getattr(settings, "VAPID_PUBLIC_KEY", "")})
+
+
+class _SubscribeSerializer(serializers.Serializer):
+    endpoint = serializers.URLField(max_length=512)
+    keys = serializers.DictField(child=serializers.CharField())
+
+    def validate_keys(self, value):
+        if "p256dh" not in value or "auth" not in value:
+            raise serializers.ValidationError("keys must contain 'p256dh' and 'auth'.")
+        return value
+
+
+class PushSubscribeView(APIView):
+    """Register (or upsert) the caller's browser push subscription."""
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        serializer = _SubscribeSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        user_agent = request.META.get("HTTP_USER_AGENT", "")[:255]
+        sub, created = PushSubscription.objects.update_or_create(
+            endpoint=data["endpoint"],
+            defaults={
+                "user": request.user,
+                "p256dh": data["keys"]["p256dh"],
+                "auth": data["keys"]["auth"],
+                "user_agent": user_agent,
+            },
+        )
+        return Response(
+            {"id": sub.id, "created": created},
+            status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
+        )
+
+
+class _UnsubscribeSerializer(serializers.Serializer):
+    endpoint = serializers.URLField(max_length=512)
+
+
+class PushUnsubscribeView(APIView):
+    """Remove the caller's subscription for a given endpoint (own rows only)."""
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        serializer = _UnsubscribeSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        deleted, _ = PushSubscription.objects.filter(
+            user=request.user, endpoint=serializer.validated_data["endpoint"]
+        ).delete()
+        return Response({"deleted": deleted}, status=status.HTTP_200_OK)

--- a/backend/openshiksha/apps/core/push.py
+++ b/backend/openshiksha/apps/core/push.py
@@ -1,0 +1,72 @@
+"""
+Web Push delivery helper (MPN-2).
+
+Sends an encrypted Web Push payload to every browser a user has subscribed
+(see ``PushSubscription``). This is the mobile-native counterpart to
+``core.emails`` — it reaches a student's home-screen PWA install even when the
+app is closed (docs/initiatives/2026-mobile-shell-pwa-offline.md, web-push phase).
+
+Design rules:
+- **Never raise into a caller.** A reminder/grading task must never fail because
+  one push endpoint is dead, so every send is wrapped per-subscription.
+- **Self-pruning.** A push service returning 404/410 means the subscription is
+  permanently gone; we delete that row so it never retries.
+- **No-op without keys.** If ``VAPID_PRIVATE_KEY`` is blank (dev/CI), send
+  nothing and return 0 — push is an additive channel, never required.
+"""
+
+import json
+import logging
+
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+def send_web_push(user, payload: dict) -> int:
+    """
+    Deliver ``payload`` (a JSON-serializable dict, e.g.
+    ``{"title", "body", "url", "tag"}``) to all of ``user``'s push subscriptions.
+
+    Returns the number of subscriptions successfully sent to. Stale (404/410)
+    subscriptions are deleted. No-op (returns 0) when VAPID is not configured.
+    """
+    private_key = getattr(settings, "VAPID_PRIVATE_KEY", "")
+    if not private_key:
+        return 0
+
+    # Imported lazily so the dependency is only needed when push is configured.
+    from pywebpush import WebPushException, webpush
+
+    from openshiksha.apps.core.models import PushSubscription
+
+    admin_email = getattr(settings, "VAPID_ADMIN_EMAIL", "admin@openshiksha.org")
+    vapid_claims = {"sub": f"mailto:{admin_email}"}
+    data = json.dumps(payload)
+
+    sent = 0
+    for sub in PushSubscription.objects.filter(user=user):
+        subscription_info = {
+            "endpoint": sub.endpoint,
+            "keys": {"p256dh": sub.p256dh, "auth": sub.auth},
+        }
+        try:
+            webpush(
+                subscription_info=subscription_info,
+                data=data,
+                vapid_private_key=private_key,
+                vapid_claims=dict(vapid_claims),
+            )
+            sent += 1
+        except WebPushException as exc:
+            status_code = getattr(getattr(exc, "response", None), "status_code", None)
+            if status_code in (404, 410):
+                # Subscription is permanently gone — prune it.
+                logger.info("send_web_push: pruning stale subscription %s (%s)", sub.endpoint[:40], status_code)
+                sub.delete()
+            else:
+                logger.warning("send_web_push: failed for %s: %s", sub.endpoint[:40], exc)
+        except Exception:
+            logger.exception("send_web_push: unexpected error for %s", sub.endpoint[:40])
+
+    return sent

--- a/docs/changes/2026-06-17-mpn2-push-api.md
+++ b/docs/changes/2026-06-17-mpn2-push-api.md
@@ -1,0 +1,47 @@
+# MPN-2 — Subscribe/unsubscribe API + send_web_push helper
+
+**Date:** 2026-06-17
+**Initiative:** Mobile Shell & PWA-Offline → web-push later-phase
+**Classification:** New
+**Depends on:** MPN-1 (PushSubscription model)
+
+## Summary
+
+Wires the `PushSubscription` model (MPN-1) to the frontend with three DRF
+endpoints and adds the server-side delivery helper that the due-date reminder
+task will call in MPN-5. Backend-only; still ships dark until MPN-4/MPN-5.
+
+## What changed
+
+- **`core/push.py` — `send_web_push(user, payload) -> int`**: fans out an
+  encrypted Web Push to every one of a user's subscriptions. Returns the count
+  sent. Key behaviours:
+  - **No-op without VAPID** — returns 0 when `VAPID_PRIVATE_KEY` is blank, so
+    push is purely additive.
+  - **Self-pruning** — a `404`/`410` from the push service deletes that stale
+    subscription row; transient errors (e.g. 500) are logged and kept.
+  - **Never raises into the caller** — each send is wrapped per-subscription so
+    one dead endpoint can't abort a reminder fan-out.
+  - `pywebpush` is imported lazily so the dep is only touched when push is on.
+- **Endpoints** (`api/views/push.py`, wired in `api/urls.py`):
+  - `GET /api/v1/push/vapid-public-key/` (AllowAny) → `{"publicKey": ...}`;
+    empty string ⇒ frontend hides the affordance.
+  - `POST /api/v1/push/subscribe/` (auth) → upsert by `endpoint`, scoped to
+    `request.user`; 201 on create, 200 on update. Captures `user_agent`.
+  - `POST /api/v1/push/unsubscribe/` (auth) → deletes the caller's row for the
+    given endpoint only.
+
+## Tests
+
+`api/tests/test_push_api.py` (11 tests): subscribe create/idempotency, key
+validation, auth gate, unsubscribe, vapid-key passthrough, and `send_web_push`
+stale-prune (410) / transient-keep (500) / blank-key no-op (pywebpush mocked).
+
+## Migration notes
+
+None — no model changes.
+
+## Next steps
+
+MPN-4 consumes these endpoints from the frontend; MPN-5 calls `send_web_push`
+from the due-date reminder task.


### PR DESCRIPTION
## MPN-2 — Subscribe/unsubscribe API + send_web_push helper

Second PR of the web-push batch. **Stacked on #375 (MPN-1).** Backend-only, ships dark.

**Classification:** New.

### What changed
- `core/push.py` `send_web_push(user, payload)`: encrypted fan-out to all of a user's subscriptions; prunes stale 404/410 endpoints, keeps transient failures; **no-op when `VAPID_PRIVATE_KEY` blank**; never raises into the caller.
- `GET /push/vapid-public-key/` (AllowAny), `POST /push/subscribe/` (upsert by endpoint, auth), `POST /push/unsubscribe/` (own rows, auth).

### Tests
`api/tests/test_push_api.py` — 11 tests: subscribe create/idempotency, key validation, auth gate, unsubscribe, vapid passthrough, `send_web_push` prune/keep/no-op (pywebpush mocked). All pass.

### How to verify
`cd backend && ./venv/Scripts/python.exe -m pytest openshiksha/apps/api/tests/test_push_api.py -q`

> Review/merge **after #375**. Re-targets to `modernization` once MPN-1 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)