### PR TITLE
feat(pwa-push): MPN-3 — service worker push + notificationclick handler

### DIFF
--- a/docs/changes/2026-06-17-mpn3-sw-push-handler.md
+++ b/docs/changes/2026-06-17-mpn3-sw-push-handler.md
@@ -1,0 +1,49 @@
+# MPN-3 — Service worker push + notificationclick handler
+
+**Date:** 2026-06-17
+**Initiative:** Mobile Shell & PWA-Offline → web-push later-phase
+**Classification:** New
+**Independent** — no dependency on MPN-1/MPN-2.
+
+## Summary
+
+Adds the client-side half of web push: the service worker now renders an OS
+notification when a push arrives and deep-links to the right page when the user
+taps it. Layered onto the existing generated SW (MSO-3) with zero change to the
+precache strategy.
+
+## What changed
+
+- **`public/push-handler.js`** — two listeners:
+  - `push`: parses the JSON payload (`{title, body, url, tag}`) and calls
+    `showNotification` with the 192 icon (used for both icon and badge until a
+    dedicated monochrome badge asset is added), tagging by assignment id so
+    duplicate reminders collapse. Falls back gracefully if the payload isn't
+    JSON.
+  - `notificationclick`: closes the toast, then focuses an open tab whose URL
+    matches the deep link, or opens a new window.
+- **`vite.config.ts`** — `workbox.importScripts: ['push-handler.js']`. This
+  pulls the handler into the **generateSW** output; we deliberately did **not**
+  switch to `injectManifest`, so all MSO-3 precache/runtime-cache behavior is
+  untouched.
+
+## Tests / verification
+
+- `scripts/check-push-handler.test.mjs` (4 checks): file present, both
+  listeners registered, `showNotification` + deep-link present, and
+  `importScripts` references it in `vite.config.ts`.
+- `npm run build` confirmed: built `dist/sw.js` contains
+  `importScripts("push-handler.js")` and the file is precached.
+- Entry chunk unchanged at **146 kB** (< 160 kB CI budget) — the handler is a
+  separate precached file, not in the entry bundle.
+- `type-check` + `lint` clean.
+
+## Notes
+
+- Dev has the SW disabled (`devOptions.enabled: false`), so push must be tested
+  against a prod build / preview (captured in the MPN-5 manual-test doc).
+
+## Next steps
+
+MPN-4 adds the frontend opt-in (`usePushSubscription`) that registers a
+subscription so this handler has something to receive.

--- a/frontend_modern/public/push-handler.js
+++ b/frontend_modern/public/push-handler.js
@@ -1,0 +1,40 @@
+/*
+ * MPN-3: Web Push handler, layered onto the generated service worker via
+ * `workbox.importScripts` (vite.config.ts). We keep the generateSW precache
+ * strategy (MSO-3) untouched and only add `push` + `notificationclick`
+ * listeners on top — lowest-risk way to add push without switching to
+ * injectManifest.
+ *
+ * Payload shape (from core.push.send_web_push): { title, body, url, tag }.
+ */
+
+self.addEventListener('push', (event) => {
+  let data = {};
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch (e) {
+    data = { body: event.data ? event.data.text() : '' };
+  }
+  const title = data.title || 'OpenShiksha';
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body: data.body || '',
+      icon: '/icons/icon-192.png',
+      badge: '/icons/icon-192.png',
+      data: { url: data.url || '/' },
+      tag: data.tag,
+    }),
+  );
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const url = (event.notification.data && event.notification.data.url) || '/';
+  event.waitUntil(
+    clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
+      const hit = clientList.find((c) => c.url.includes(url));
+      if (hit) return hit.focus();
+      return clients.openWindow(url);
+    }),
+  );
+});

--- a/frontend_modern/scripts/check-push-handler.test.mjs
+++ b/frontend_modern/scripts/check-push-handler.test.mjs
@@ -1,0 +1,36 @@
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// MPN-3: the Web Push handler is a hand-written file in `public/` that the
+// service worker pulls in via `workbox.importScripts`. This guards that the
+// file exists, registers the two listeners push actually needs, and that
+// vite.config.ts still imports it — so we never ship a SW that silently drops
+// notifications.
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const handlerPath = path.join(root, 'public', 'push-handler.js');
+const viteConfigPath = path.join(root, 'vite.config.ts');
+
+describe('Web Push service-worker handler', () => {
+  it('push-handler.js exists in public/', () => {
+    expect(existsSync(handlerPath)).toBe(true);
+  });
+
+  const handler = existsSync(handlerPath) ? readFileSync(handlerPath, 'utf-8') : '';
+
+  it('registers push and notificationclick listeners', () => {
+    expect(handler).toMatch(/addEventListener\(['"]push['"]/);
+    expect(handler).toMatch(/addEventListener\(['"]notificationclick['"]/);
+  });
+
+  it('shows a notification and deep-links on click', () => {
+    expect(handler).toContain('showNotification');
+    expect(handler).toMatch(/clients\.(openWindow|matchAll)/);
+  });
+
+  it('is imported by the service worker via workbox.importScripts', () => {
+    const cfg = readFileSync(viteConfigPath, 'utf-8');
+    expect(cfg).toMatch(/importScripts:\s*\[[^\]]*['"]push-handler\.js['"]/);
+  });
+});

--- a/frontend_modern/vite.config.ts
+++ b/frontend_modern/vite.config.ts
@@ -87,6 +87,10 @@ export default defineConfig(async ({ mode }) => ({
       devOptions: { enabled: false },
       workbox: {
         globPatterns: ['**/*.{js,css,html,svg,png,ico,woff,woff2}'],
+        // MPN-3: layer our push + notificationclick handlers onto the generated
+        // precache SW (root-relative path). Keeps the generateSW strategy
+        // intact — no switch to injectManifest.
+        importScripts: ['push-handler.js'],
         // Deep links boot offline from the precached shell. /api must never be
         // served the shell (principle 2) — the persisted React Query cache
         // (MSO-4), not Workbox, owns API read-tolerance.


### PR DESCRIPTION
## MPN-3 — Service worker push + notificationclick handler

Third PR of the web-push batch. **Independent** — targets `modernization` directly (no dependency on MPN-1/2).

**Classification:** New. Frontend-only.

### What changed
- `public/push-handler.js`: `push` → `showNotification` ({title,body,icon,badge,tag}); `notificationclick` → focus matching tab or open the deep link.
- `vite.config.ts`: `workbox.importScripts: ['push-handler.js']` layers it onto the **generateSW** output — no switch to injectManifest, MSO-3 behavior intact.

### Tests / verification
- `scripts/check-push-handler.test.mjs` (4 checks) — file present, both listeners, deep-link, imported by SW config.
- Build confirmed: `dist/sw.js` contains `importScripts("push-handler.js")` + precaches it.
- Entry chunk unchanged at 146 kB (< 160 kB budget). type-check + lint clean.

### How to verify
`cd frontend_modern && npm run build && grep importScripts dist/sw.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)