### PR TITLE
feat(pwa-push): MPN-5 — fan due-date reminders out to Web Push

### DIFF
--- a/backend/openshiksha/apps/core/emails.py
+++ b/backend/openshiksha/apps/core/emails.py
@@ -153,6 +153,38 @@ def _h(user, key: str, **kwargs) -> str:
     return format_email_string(_HTML, user, key, **kwargs)
 
 
+# Short, plain-text copy for Web Push notifications (MPN-5). A push toast has no
+# room for the branded email shell, so this is a deliberately terse en/hi
+# catalog mirroring the reminder tone. Shares the recipient's preferred_language
+# so the push and email channels never drift.
+_PUSH = {
+    "en": {
+        "reminder.title": "Assignment due soon",
+        "reminder.body": "‘{assignment_title}’ is due {due_date}. Tap to finish it.",
+    },
+    "hi": {
+        "reminder.title": "असाइनमेंट जल्द देय है",
+        "reminder.body": "‘{assignment_title}’ की अंतिम तिथि {due_date} है। पूरा करने के लिए टैप करें।",
+    },
+}
+
+
+def build_due_reminder_push(student, assignment_title: str, due_date_str: str) -> dict:
+    """
+    Build the localized Web Push payload (title + body) for a due-date reminder.
+
+    Returns ``{"title", "body"}`` in the student's ``preferred_language``
+    (falling back to English). The caller adds ``url``/``tag`` and hands it to
+    ``core.push.send_web_push``.
+    """
+    return {
+        "title": format_email_string(_PUSH, student, "reminder.title"),
+        "body": format_email_string(
+            _PUSH, student, "reminder.body", assignment_title=assignment_title, due_date=due_date_str
+        ),
+    }
+
+
 def notify_remedial_assigned(student, chapter_name: str, due_date_str: str) -> None:
     """Email a student when a remedial practice assignment is created for them."""
     if not student.email:

--- a/backend/openshiksha/apps/core/tasks.py
+++ b/backend/openshiksha/apps/core/tasks.py
@@ -452,8 +452,15 @@ def send_due_date_reminders(window_hours: int = 24) -> dict:
 
     from django.utils import timezone
 
-    from openshiksha.apps.core.emails import notify_due_date_reminder
-    from openshiksha.apps.core.models import Assignment, AssignmentReminder, Submission, UserRole
+    from openshiksha.apps.core.emails import build_due_reminder_push, notify_due_date_reminder
+    from openshiksha.apps.core.models import (
+        Assignment,
+        AssignmentReminder,
+        PushSubscription,
+        Submission,
+        UserRole,
+    )
+    from openshiksha.apps.core.push import send_web_push
 
     now = timezone.now()
     window_end = now + timedelta(hours=window_hours)
@@ -493,6 +500,9 @@ def send_due_date_reminders(window_hours: int = 24) -> dict:
         reminded_ids = set(
             AssignmentReminder.objects.filter(assignment=assignment).values_list("student_id", flat=True)
         )
+        # Students with at least one Web Push subscription (MPN-5). Push reaches
+        # a home-screen PWA install even when the student has no email on file.
+        push_user_ids = set(PushSubscription.objects.filter(user__in=students).values_list("user_id", flat=True))
 
         due_str = timezone.localtime(assignment.due_at).strftime("on %B %d at %I:%M %p")
 
@@ -502,7 +512,15 @@ def send_due_date_reminders(window_hours: int = 24) -> dict:
             if student.id in submitted_ids or student.id in reminded_ids:
                 stats["skipped"] += 1
                 continue
-            if student.email_reminders_opt_out or not student.email:
+            # A single opt-out governs both channels (email + push) for v1.
+            if student.email_reminders_opt_out:
+                stats["skipped"] += 1
+                continue
+
+            has_email = bool(student.email)
+            has_push = student.id in push_user_ids
+            if not has_email and not has_push:
+                # No deliverable channel — don't burn the idempotency row.
                 stats["skipped"] += 1
                 continue
 
@@ -512,7 +530,15 @@ def send_due_date_reminders(window_hours: int = 24) -> dict:
                 stats["skipped"] += 1
                 continue
 
-            notify_due_date_reminder(student, assignment.problem_set.title, due_str)
+            if has_email:
+                notify_due_date_reminder(student, assignment.problem_set.title, due_str)
+            if has_push:
+                # send_web_push never raises into the task; email is the source
+                # of truth and must not fail because a push endpoint is dead.
+                payload = build_due_reminder_push(student, assignment.problem_set.title, due_str)
+                payload["url"] = f"/student/assignments/{assignment.id}"
+                payload["tag"] = f"assignment-{assignment.id}"
+                send_web_push(student, payload)
             stats["reminded"] += 1
 
     logger.info(

--- a/backend/openshiksha/apps/core/tests/test_due_date_reminders.py
+++ b/backend/openshiksha/apps/core/tests/test_due_date_reminders.py
@@ -215,3 +215,64 @@ class TestDueDateReminders:
         # Default 24h window misses it; a 48h window catches it.
         assert send_due_date_reminders()["reminded"] == 0
         assert send_due_date_reminders(window_hours=48)["reminded"] == 1
+
+
+class TestDueDateReminderPush:
+    """MPN-5: due-date reminders also fan out Web Push to subscribed students."""
+
+    def test_push_sent_for_subscribed_student(self, db, school, standard, subject, chapter, teacher, student):
+        from unittest import mock
+
+        from openshiksha.apps.core.models import PushSubscription
+        from openshiksha.apps.core.tasks import send_due_date_reminders
+
+        PushSubscription.objects.create(user=student, endpoint="https://push.example.com/s1", p256dh="k", auth="a")
+        _make_assignment(school, standard, subject, chapter, teacher, [student], due_in_hours=12)
+
+        with mock.patch("openshiksha.apps.core.push.send_web_push", return_value=1) as m:
+            stats = send_due_date_reminders()
+
+        assert stats["reminded"] == 1
+        m.assert_called_once()
+        called_student, payload = m.call_args[0]
+        assert called_student == student
+        assert "title" in payload and "body" in payload
+        assert payload["url"].startswith("/student/assignments/")
+        assert payload["tag"].startswith("assignment-")
+
+    def test_push_not_sent_for_opted_out_student(self, db, school, standard, subject, chapter, teacher, student):
+        from unittest import mock
+
+        from openshiksha.apps.core.models import PushSubscription
+        from openshiksha.apps.core.tasks import send_due_date_reminders
+
+        student.email_reminders_opt_out = True
+        student.save(update_fields=["email_reminders_opt_out"])
+        PushSubscription.objects.create(user=student, endpoint="https://push.example.com/s2", p256dh="k", auth="a")
+        _make_assignment(school, standard, subject, chapter, teacher, [student], due_in_hours=12)
+
+        with mock.patch("openshiksha.apps.core.push.send_web_push") as m:
+            stats = send_due_date_reminders()
+
+        assert stats["reminded"] == 0
+        m.assert_not_called()
+
+    def test_no_email_but_subscribed_student_is_push_reminded(self, db, school, standard, subject, chapter, teacher):
+        from unittest import mock
+
+        from openshiksha.apps.core.models import PushSubscription, User, UserRole
+        from openshiksha.apps.core.tasks import send_due_date_reminders
+
+        no_email = User.objects.create_user(
+            username="push_only", password="pass", role=UserRole.STUDENT, school=school, email=""
+        )
+        PushSubscription.objects.create(user=no_email, endpoint="https://push.example.com/s3", p256dh="k", auth="a")
+        _make_assignment(school, standard, subject, chapter, teacher, [no_email], due_in_hours=12)
+
+        with mock.patch("openshiksha.apps.core.push.send_web_push", return_value=1) as m:
+            stats = send_due_date_reminders()
+
+        # No email is sent, but push reaches the home-screen install.
+        assert stats["reminded"] == 1
+        assert len(mail.outbox) == 0
+        m.assert_called_once()

--- a/docs/changes/2026-06-17-mpn5-reminder-push.md
+++ b/docs/changes/2026-06-17-mpn5-reminder-push.md
@@ -1,0 +1,52 @@
+# MPN-5 — Wire due-date reminders to Web Push
+
+**Date:** 2026-06-17
+**Initiative:** Mobile Shell & PWA-Offline → web-push later-phase
+**Classification:** Improve
+**Depends on:** MPN-2 (`send_web_push` helper)
+
+## Summary
+
+Extends the existing `send_due_date_reminders` Celery task to **also** fan out a
+Web Push notification to subscribed students, reusing the same cadence,
+eligibility, and idempotency logic as the email channel — so the two channels can
+never drift. Push is additive: email remains the source of truth.
+
+## What changed
+
+- **`core/emails.py`** — `build_due_reminder_push(student, title, due_str)`
+  returns a localized `{title, body}` push payload from a terse en/hi `_PUSH`
+  catalog, sharing the student's `preferred_language` with the email path.
+- **`core/tasks.py` — `send_due_date_reminders`**:
+  - A single `email_reminders_opt_out` now governs **both** channels (v1
+    decision — one toggle for email + push; a separate `push_reminders_opt_out`
+    can be added later if needed).
+  - Eligibility broadened: a student is reminded if they have **email OR a push
+    subscription** (previously email-only). A student with neither is skipped so
+    the idempotency row isn't burned.
+  - For eligible students: email is sent if they have an address; push is sent if
+    they have a subscription. The payload adds `url` (`/student/assignments/<id>`
+    deep link) and `tag` (`assignment-<id>`, collapses duplicate reminders).
+  - The push fan-out goes through `send_web_push`, which never raises into the
+    task — a dead endpoint can't abort a reminder run.
+
+## Tests
+
+`core/tests/test_due_date_reminders.py` — added `TestDueDateReminderPush`:
+- push sent (with correct payload `title/body/url/tag`) for a subscribed student;
+- push **not** sent for an opted-out student;
+- a **no-email but subscribed** student is still push-reminded (no email sent).
+Existing email tests unchanged and green (12 total in the file).
+
+## Migration notes
+
+None — no model changes.
+
+## Manual verification
+
+See `docs/perf/2026-06-17-pwa-push-manual-test.md`.
+
+## Next steps
+
+MPN-4 (frontend opt-in hook + ProfilePage toggle) is the remaining batch item —
+it lets a student actually create the subscription this task delivers to.

--- a/docs/initiatives/2026-mobile-shell-pwa-offline.md
+++ b/docs/initiatives/2026-mobile-shell-pwa-offline.md
@@ -102,9 +102,9 @@ not the exception, and an installable PWA removes the app-store barrier entirely
 ### Later phases (not yet scoped)
 
 - **Route-level mobile layouts:** per-route mobile-first layouts beyond the shared
-  shell, where dense teacher tables still overflow on phones.
-- **Push notifications:** due-date reminders as web push (the email reminder
-  already exists; web push is the mobile-native channel).
+  shell, where dense teacher tables still overflow on phones. **← next batch.**
+- ~~**Push notifications:** due-date reminders as web push.~~ **SHIPPED 2026-06-17
+  (Batch 3, MPN-1..5, #375–#379)** — see ledger below.
 
 ## Ledger
 
@@ -121,6 +121,19 @@ _(append one row per merged PR)_
 | #368 | MSO-7 | Offline mutation queue: keyed `setMutationDefaults` (`networkMode: 'offlineFirst'`, rehydration-safe `mutationFn`/`onSuccess`) + paused-submission persist allowlist + `resumePausedMutations()` on restore. No new dep. **New** |
 | #369 | MSO-8 | "Saved offline · will sync" UX: `useSyncState`/`usePendingSyncCount` over `useMutationState`; `SyncStatus` inline indicator + `PendingSyncBadge`; honest copy; `sync.*` i18n (en/hi). **New** |
 | #370 | MSO-9 | Offline final-submit: optimistic "will be graded when back online" card (no fake score), queued submit replays onto MSO-6 and the real score reconciles; `onError` re-opens the form. **New** |
+| #375 | MPN-1 | `PushSubscription` model (unique endpoint, p256dh/auth keys) + migration 0029 + `pywebpush` dep + blank-safe VAPID settings + admin. Ships dark. **New** |
+| #376 | MPN-2 | `core.push.send_web_push` (stale 404/410 prune, blank-key no-op, never raises) + `GET /push/vapid-public-key/`, `POST /push/subscribe/` (upsert by endpoint), `POST /push/unsubscribe/`. **New** |
+| #377 | MPN-3 | `public/push-handler.js` (`push` → showNotification, `notificationclick` → deep-link) layered via `workbox.importScripts` on the generateSW output; SW-presence guard. Entry chunk unchanged. **New** |
+| #379 | MPN-4 | `usePushSubscription` hook (key-gated supported, requestPermission → subscribe → POST) + dismissible `PushBanner` + ProfilePage toggle + `push.*` i18n (en/hi). **New** |
+| #378 | MPN-5 | `send_due_date_reminders` fans web push alongside email (one opt-out governs both; eligibility broadened to email OR push; deep-link url + collapse tag); `emails.build_due_reminder_push` localized copy. Manual-test doc. **Improve** |
+
+**Batch 3 shipped 2026-06-17** — web push due-date reminders. A student who
+installs OpenShiksha to their home screen can opt in (banner / ProfilePage
+toggle) and receive a due-date reminder as a native phone notification — even
+with the app closed — reusing MSO-3's service worker and the existing
+`send_due_date_reminders` task. Email stays the source of truth; push is an
+additive channel that never fails the reminder run. The **"web push" later-phase
+item is shipped**; manual test in `docs/perf/2026-06-17-pwa-push-manual-test.md`.
 
 **Batch 2 shipped 2026-06-15** — the student core loop is now write-tolerant
 offline. A student on a dropped connection keeps answering (auto-saves queue

--- a/docs/initiatives/STATUS.md
+++ b/docs/initiatives/STATUS.md
@@ -12,18 +12,19 @@
 > priority table below** so it is never picked as the "top active initiative."
 
 **Last updated:** 2026-06-17 (latest) — **Mobile Shell & PWA-Offline — Batch 3
-(MPN-1..5) PLANNED: web push due-date reminders**
-([plan](../daily-plans/2026-06-17-plan.md)). With offline read+write tolerance
-shipped, the next later-phase is the **mobile-native notification channel**:
-`PushSubscription` model + VAPID config + `pywebpush` (MPN-1) → subscribe/
-unsubscribe API + `send_web_push` stale-pruning helper (MPN-2) →
-`public/push-handler.js` (`push`+`notificationclick`) layered on the MSO-3 SW via
-`workbox.importScripts`, no strategy change (MPN-3) → `usePushSubscription` hook +
-localized opt-in affordance + ProfilePage toggle (MPN-4) → fan out web push from
-the existing `send_due_date_reminders` task + close-out (MPN-5). Reuses MSO-3's
-service worker, MSO-1's icons, the LA i18n registry, and the existing reminder
-task — every piece rides shipped infra. After this, only **route-level mobile
-layouts** (dense teacher tables → cards) remains before the initiative is complete.
+(MPN-1..5) SHIPPED: web push due-date reminders**
+([plan](../daily-plans/2026-06-17-plan.md), [#375](https://github.com/openshiksha/openshiksha/pull/375)–[#379](https://github.com/openshiksha/openshiksha/pull/379)).
+The **mobile-native notification channel** is now live: `PushSubscription` model +
+VAPID config + `pywebpush` (MPN-1, #375) → subscribe/unsubscribe API +
+`send_web_push` stale-pruning helper (MPN-2, #376) → `public/push-handler.js`
+(`push`+`notificationclick`) layered on the MSO-3 SW via `workbox.importScripts`,
+no strategy change (MPN-3, #377) → `usePushSubscription` hook + localized opt-in
+banner + ProfilePage toggle (MPN-4, #379) → web push fanned out from the existing
+`send_due_date_reminders` task (MPN-5, #378). Reused MSO-3's service worker,
+MSO-1's icons, the LA i18n registry, and the existing reminder task — every piece
+rode shipped infra. Email stays source of truth; push is additive and never fails
+the reminder run. **Only the final later-phase remains: route-level mobile
+layouts** (dense teacher tables → cards) before the initiative is complete.
 
 **Earlier (2026-06-15)** — **Mobile Shell & PWA-Offline — Batch 2
 (MSO-6..10) SHIPPED: offline *write*-tolerance**
@@ -194,7 +195,7 @@ at 160 kB defends the cut.
 
 | Priority | Initiative | Status | Headline progress | Next increment |
 |:--:|---|---|---|---|
-| 1 | [Mobile Shell & PWA-Offline](2026-mobile-shell-pwa-offline.md) | **Active** | **Batch 1 (MSO-1..5) shipped 2026-06-14** ([#358](https://github.com/openshiksha/openshiksha/pull/358)–[#362](https://github.com/openshiksha/openshiksha/pull/362)): installable PWA + offline *read*-tolerance (manifest/maskable icons, service worker precache, persisted React Query cache, localized offline banner, A2HS prompt). **Batch 2 (MSO-6..10) planned 2026-06-15** ([plan](../daily-plans/2026-06-15-plan.md)): offline *write*-tolerance — queue + replay auto-saves/submissions. | **MSO-6** — replay-safe/idempotent submission writes server-side (build first); then MSO-7 durable offline mutation queue, MSO-8 sync-status UX, MSO-9 offline submit, MSO-10 close-out. Later: route-level mobile layouts; web push reminders |
+| 1 | [Mobile Shell & PWA-Offline](2026-mobile-shell-pwa-offline.md) | **Active** | **Batch 1 (MSO-1..5) shipped 2026-06-14** ([#358](https://github.com/openshiksha/openshiksha/pull/358)–[#362](https://github.com/openshiksha/openshiksha/pull/362)): installable PWA + offline *read*-tolerance (manifest/maskable icons, service worker precache, persisted React Query cache, localized offline banner, A2HS prompt). **Batch 2 (MSO-6..10) shipped 2026-06-15** ([#367](https://github.com/openshiksha/openshiksha/pull/367)–[#370](https://github.com/openshiksha/openshiksha/pull/370)): offline *write*-tolerance — queue + replay auto-saves/submissions. **Batch 3 (MPN-1..5) shipped 2026-06-17** ([#375](https://github.com/openshiksha/openshiksha/pull/375)–[#379](https://github.com/openshiksha/openshiksha/pull/379)): web push due-date reminders (PushSubscription + VAPID, subscribe/unsubscribe API + send_web_push, SW push handler, opt-in hook/banner/toggle, reminder fan-out). | **Route-level mobile layouts** — dense teacher tables (`ClassHealthPanel`, `TeacherAssignmentDetailPage`) → responsive cards on phones. Last later-phase; then initiative complete. |
 | 2 | [Language Access — i18n en/हिंदी/मराठी](2026-language-access.md) | **Done-but-for-LA-10 (blocked)** | **LA-1..9 shipped.** Foundation + EN\|हिं switcher, `preferred_language` end-to-end, student/parent/public/teacher surfaces, AI content + emails in the reader's language, `Intl` date/number helper ([#308](https://github.com/openshiksha/openshiksha/pull/308)–[#326](https://github.com/openshiksha/openshiksha/pull/326)). **LA-9 closed 2026-06-13** — N-locale registry + pilot-coverage parity ([#349](https://github.com/openshiksha/openshiksha/pull/349)) then **Marathi (मरा)** as pure content across the anonymous journey, student loop, and parent dashboard + a backend mr→en AI fallback guard ([#350](https://github.com/openshiksha/openshiksha/pull/350)–[#353](https://github.com/openshiksha/openshiksha/pull/353)). The framework now makes a new language config + content, no code change. | **LA-10** (authored-content/question translation) — blocked on product design, do not start without promotion. Then **Mobile shell / PWA-offline** |
 | - | [AI Surface Activation](ai-surface-activation.md) | Done | **Closed 2026-06-11 — North Star reached.** ASA-1..9 shipped across [#285](https://github.com/openshiksha/openshiksha/pull/285)–[#289](https://github.com/openshiksha/openshiksha/pull/289), [#293](https://github.com/openshiksha/openshiksha/pull/293)–[#302](https://github.com/openshiksha/openshiksha/pull/302): all four dark `/ai/` endpoint groups lit (explanations, misconception clusters, assignment drafts, open-response grading), error-as-empty-state sweep complete, shared `AIBadge` provenance, server-side SRS guard. Close ([#303](https://github.com/openshiksha/openshiksha/pull/303)): [endpoint-consumer map](../ai-features/endpoint-consumer-map.md) + DoD audit — 17 endpoints directly consumed, 4 indirect by design, 1 API-only (`/ai/predictions/`). | `useAsyncGeneration` refactor carried to maintenance; `/ai/predictions/` surface is a future product call |
 | - | [Authoring Integrity & Versioning](authoring-integrity-versioning.md) | Done | **All three phases shipped 2026-06-08/09.** Phase 1 (AIV-1..3, [#270](https://github.com/openshiksha/openshiksha/pull/270)–[#274](https://github.com/openshiksha/openshiksha/pull/274)): snapshot foundation + grader/student readers + edit-safety UI. Phase 2 (AIV-4/5, [#276](https://github.com/openshiksha/openshiksha/pull/276)–[#277](https://github.com/openshiksha/openshiksha/pull/277)): editable preview + drift surface. Phase 3 (AIV-6/7/8, [#279](https://github.com/openshiksha/openshiksha/pull/279)–[#281](https://github.com/openshiksha/openshiksha/pull/281)): guarded re-sync + `ProblemSetVersion` dedup + version history & diff UI. DoD met end-to-end. | - |

--- a/docs/perf/2026-06-17-pwa-push-manual-test.md
+++ b/docs/perf/2026-06-17-pwa-push-manual-test.md
@@ -1,0 +1,65 @@
+# Manual test — PWA Web Push due-date reminders
+
+**Date:** 2026-06-17
+**Covers:** MPN-1..5 (web push for due-date reminders)
+
+Web push only works against a **production build / preview** — the dev server has
+the service worker disabled (`devOptions.enabled: false`). Test in Chrome (or any
+Chromium browser); on iOS, push requires an **installed** PWA on Safari 16.4+.
+
+## One-time setup
+
+1. Generate a VAPID keypair:
+   ```bash
+   cd backend && ./venv/Scripts/python.exe -m py_vapid --gen
+   ```
+   (or use any VAPID generator). Export the keys for the backend:
+   ```bash
+   export VAPID_PUBLIC_KEY=<base64url public key>
+   export VAPID_PRIVATE_KEY=<PEM or base64url private key>
+   export VAPID_ADMIN_EMAIL=admin@openshiksha.org
+   ```
+2. Build + serve the frontend so the SW is active:
+   ```bash
+   cd frontend_modern && npm run build && npm run preview
+   ```
+3. Run the backend (`runserver` / Docker) with the VAPID env vars set.
+
+## Test steps
+
+1. **Public key reachable** — `GET /api/v1/push/vapid-public-key/` returns a
+   non-empty `publicKey`. (Empty ⇒ the frontend hides the push affordance, by
+   design.)
+2. **Subscribe** — log in as a student, accept the "Get reminders on your phone"
+   prompt (MPN-4). Confirm a `PushSubscription` row appears in Django admin for
+   that user.
+   - Without MPN-4 merged, subscribe manually from DevTools console:
+     `navigator.serviceWorker.ready.then(r => r.pushManager.subscribe({userVisibleOnly:true, applicationServerKey:<key>}))`
+     then POST the result to `/api/v1/push/subscribe/`.
+3. **Trigger a reminder** — create an assignment due within 24h for the student,
+   then run the task:
+   ```bash
+   ./venv/Scripts/python.exe manage.py shell -c \
+     "from openshiksha.apps.core.tasks import send_due_date_reminders; print(send_due_date_reminders())"
+   ```
+4. **Notification fires** — with the tab **closed/backgrounded**, the OS shows a
+   notification: title "Assignment due soon", body naming the assignment + due
+   date (localized to the student's `preferred_language`).
+5. **Deep link on click** — tapping the notification focuses an open tab at, or
+   opens, `/student/assignments/<id>`.
+6. **Idempotency** — re-running the task does **not** fire a second notification
+   (an `AssignmentReminder` row already exists).
+7. **Stale prune** — unsubscribe in the browser, then trigger again; the backend
+   gets a 410 and deletes the stale `PushSubscription` row (no error in the task).
+8. **Opt-out** — set the student's reminders opt-out (ProfilePage toggle / admin);
+   trigger again → neither email nor push is sent.
+
+## Expected results checklist
+
+- [ ] vapid-public-key returns a key
+- [ ] subscribe creates a row; re-subscribe upserts (no duplicate)
+- [ ] notification appears with the app closed, localized
+- [ ] click deep-links to the assignment
+- [ ] re-run does not duplicate
+- [ ] unsubscribe → stale row pruned on next send
+- [ ] opt-out suppresses both channels


### PR DESCRIPTION
## MPN-5 — Wire due-date reminders to Web Push

Final backend PR of the web-push batch. **Stacked on #376 (MPN-2).** Re-targets to `modernization` once MPN-2 merges.

**Classification:** Improve.

### What changed
- `emails.build_due_reminder_push()` — localized `{title, body}` (en/hi) sharing `preferred_language` with the email path.
- `send_due_date_reminders` now fans push out alongside email, reusing the same cadence/eligibility/idempotency:
  - one `email_reminders_opt_out` governs **both** channels (v1);
  - eligibility broadened to **email OR push subscription** so a no-email home-screen install is still reminded;
  - payload adds `url` (`/student/assignments/<id>`) + `tag` (`assignment-<id>`);
  - delivery via `send_web_push`, which never raises into the task.

### Tests
`test_due_date_reminders.py` +3: push sent w/ correct payload, opted-out suppressed, no-email-but-subscribed still push-reminded. Full core suite + push API green.

Manual-test doc: `docs/perf/2026-06-17-pwa-push-manual-test.md`.

### How to verify
`cd backend && ./venv/Scripts/python.exe -m pytest openshiksha/apps/core/tests/test_due_date_reminders.py -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)