### PR TITLE
feat(pwa-push): MPN-4 — push opt-in hook + banner + ProfilePage toggle

### DIFF
--- a/docs/changes/2026-06-17-mpn4-push-optin.md
+++ b/docs/changes/2026-06-17-mpn4-push-optin.md
@@ -1,0 +1,50 @@
+# MPN-4 — Frontend push opt-in + settings toggle
+
+**Date:** 2026-06-17
+**Initiative:** Mobile Shell & PWA-Offline → web-push later-phase
+**Classification:** New
+**Depends on:** MPN-2 (subscribe API + vapid-public-key) and MPN-3 (SW handler).
+
+## Summary
+
+The user-facing half of web push: a student can now opt in to push reminders
+and the subscription is registered with the backend. Completes the loop —
+MPN-3's SW handler now has something to receive, MPN-5's reminder task has
+someone to deliver to.
+
+## What changed
+
+- **`features/pwa/usePushSubscription.ts`** — the bridge hook:
+  - Fetches the server VAPID public key (`GET /push/vapid-public-key/`). An
+    empty key (push not configured) ⇒ `supported = false` and the UI hides.
+  - `subscribe()`: `Notification.requestPermission()` → `pushManager.subscribe`
+    with the decoded VAPID key → `POST /push/subscribe/` with the browser's
+    serialized subscription (`toJSON()` → `{endpoint, keys}`).
+  - `unsubscribe()`: `POST /push/unsubscribe/` (best-effort) then
+    `subscription.unsubscribe()`.
+  - Reflects any existing browser subscription into `isSubscribed`.
+  - **Honest UX** (principle 4): degrades to hidden where push can't work — no
+    browser support, no server key, or iOS Safari before the PWA is installed.
+- **`features/pwa/PushBanner.tsx`** — dismissible "Get reminders on your phone"
+  banner mirroring the MSO-5 `InstallBanner`; rendered in `AppShell`. Shows only
+  when `supported && !isSubscribed && permission !== 'denied' && !dismissed`.
+- **`features/shared/ProfilePage.tsx`** — a **Push notifications** toggle next to
+  the existing email-reminders control (subscribe/unsubscribe; shows a
+  "blocked in browser" hint when permission is denied).
+- **i18n** — `push.*` keys in `en` + `hi` (parity guard green).
+
+## Tests / verification
+
+- `usePushSubscription.test.ts` (6): `urlBase64ToUint8Array` decode; unsupported
+  when key blank; supported with key; subscribe posts the serialized payload;
+  subscribe aborts when permission not granted; existing-subscription reflect +
+  unsubscribe clears.
+- `PushBanner.test.tsx` (4): visible when eligible; hidden when unsupported /
+  already subscribed / permission denied.
+- Full suite **446 passed**; `type-check` + `lint` clean; build clean, entry
+  chunk **149 kB** (< 160 kB budget).
+
+## Next steps
+
+Batch complete (MPN-1..5). Remaining initiative later-phase: route-level mobile
+layouts.

--- a/frontend_modern/src/features/layout/AppShell.tsx
+++ b/frontend_modern/src/features/layout/AppShell.tsx
@@ -2,6 +2,7 @@ import { BottomNav } from './BottomNav';
 import { Navbar } from './Navbar';
 import { OfflineBanner } from './OfflineBanner';
 import { InstallBanner } from '@/features/pwa/InstallBanner';
+import { PushBanner } from '@/features/pwa/PushBanner';
 import { PendingSyncBadge } from '@/features/student/SyncStatus';
 
 interface AppShellProps {
@@ -22,6 +23,7 @@ export const AppShell = ({ children }: AppShellProps) => (
     <OfflineBanner />
     <PendingSyncBadge />
     <InstallBanner />
+    <PushBanner />
     <main
       id="main-content"
       tabIndex={-1}

--- a/frontend_modern/src/features/pwa/PushBanner.test.tsx
+++ b/frontend_modern/src/features/pwa/PushBanner.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { PushBanner } from './PushBanner';
+import { I18nProvider } from '@/shared/i18n/I18nProvider';
+import * as hook from './usePushSubscription';
+
+const renderBanner = () =>
+  render(
+    <I18nProvider initialLocale="en">
+      <PushBanner />
+    </I18nProvider>,
+  );
+
+const state = (over: Partial<hook.PushSubscriptionState> = {}): hook.PushSubscriptionState => ({
+  supported: true,
+  permission: 'default',
+  isSubscribed: false,
+  busy: false,
+  subscribe: vi.fn(),
+  unsubscribe: vi.fn(),
+  ...over,
+});
+
+beforeEach(() => localStorage.clear());
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe('<PushBanner /> (MPN-4)', () => {
+  it('renders the enable prompt when push is supported and not subscribed', () => {
+    vi.spyOn(hook, 'usePushSubscription').mockReturnValue(state());
+    renderBanner();
+    expect(screen.getByText(/get reminders on your phone/i)).toBeInTheDocument();
+  });
+
+  it('hides when push is unsupported', () => {
+    vi.spyOn(hook, 'usePushSubscription').mockReturnValue(state({ supported: false }));
+    const { container } = renderBanner();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('hides when already subscribed', () => {
+    vi.spyOn(hook, 'usePushSubscription').mockReturnValue(state({ isSubscribed: true }));
+    const { container } = renderBanner();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('hides when permission is denied', () => {
+    vi.spyOn(hook, 'usePushSubscription').mockReturnValue(state({ permission: 'denied' }));
+    const { container } = renderBanner();
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend_modern/src/features/pwa/PushBanner.tsx
+++ b/frontend_modern/src/features/pwa/PushBanner.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { usePushSubscription } from './usePushSubscription';
+import { useT } from '@/shared/i18n/useT';
+
+/** localStorage key recording that the user dismissed the push affordance. */
+export const PUSH_DISMISSED_KEY = 'os-push-dismissed';
+
+const isDismissed = (): boolean => {
+  try {
+    return localStorage.getItem(PUSH_DISMISSED_KEY) === '1';
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * MPN-4 — dismissible "Get reminders on your phone" affordance, mirroring the
+ * MSO-5 InstallBanner. Shown only when push is usable (browser support + server
+ * VAPID key), not already granted/subscribed, not blocked, and not dismissed.
+ */
+export const PushBanner = () => {
+  const { supported, permission, isSubscribed, busy, subscribe } = usePushSubscription();
+  const t = useT();
+  const [dismissed, setDismissed] = useState(isDismissed);
+
+  if (!supported || isSubscribed || permission === 'denied' || dismissed) return null;
+
+  const dismiss = () => {
+    try {
+      localStorage.setItem(PUSH_DISMISSED_KEY, '1');
+    } catch {
+      /* private mode — the prompt simply reappears later */
+    }
+    setDismissed(true);
+  };
+
+  return (
+    <div className="flex items-center justify-center gap-3 bg-ink-50 px-4 py-2 text-center text-sm text-ink-700">
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="h-4 w-4 shrink-0 text-brand-600"
+      >
+        <path d="M10.268 21a2 2 0 0 0 3.464 0" />
+        <path d="M3.262 15.326A1 1 0 0 0 4 17h16a1 1 0 0 0 .74-1.673C19.41 13.956 18 12.499 18 8A6 6 0 0 0 6 8c0 4.499-1.411 5.956-2.738 7.326" />
+      </svg>
+      <span className="font-medium">{t('push.prompt')}</span>
+      <button
+        type="button"
+        onClick={subscribe}
+        disabled={busy}
+        className="rounded-md bg-brand-600 px-3 py-1 text-sm font-semibold text-white transition hover:bg-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-300 disabled:opacity-60"
+      >
+        {t('push.enable')}
+      </button>
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label={t('push.dismiss')}
+        className="rounded-md px-2 py-1 text-ink-500 transition hover:text-ink-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-300"
+      >
+        ✕
+      </button>
+    </div>
+  );
+};

--- a/frontend_modern/src/features/pwa/usePushSubscription.test.ts
+++ b/frontend_modern/src/features/pwa/usePushSubscription.test.ts
@@ -1,0 +1,135 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { urlBase64ToUint8Array, usePushSubscription } from './usePushSubscription';
+import { apiClient } from '@/api/client';
+
+vi.mock('@/api/client', () => ({
+  apiClient: { get: vi.fn(), post: vi.fn() },
+}));
+
+const mockGet = vi.mocked(apiClient.get);
+const mockPost = vi.mocked(apiClient.post);
+
+// A fake PushManager whose subscribe() returns a subscription with a
+// browser-shaped toJSON().
+function installPushGlobals(opts: { existing?: boolean; permission?: NotificationPermission } = {}) {
+  const fakeSub = {
+    endpoint: 'https://push.example.com/abc',
+    toJSON: () => ({ endpoint: 'https://push.example.com/abc', keys: { p256dh: 'p', auth: 'a' } }),
+    unsubscribe: vi.fn(async () => true),
+  };
+  const pushManager = {
+    subscribe: vi.fn(async () => fakeSub),
+    getSubscription: vi.fn(async () => (opts.existing ? fakeSub : null)),
+  };
+  Object.defineProperty(navigator, 'serviceWorker', {
+    configurable: true,
+    value: { ready: Promise.resolve({ pushManager }) },
+  });
+  // @ts-expect-error test stub
+  window.PushManager = function () {};
+  // @ts-expect-error test stub
+  window.Notification = { permission: opts.permission ?? 'default', requestPermission: vi.fn() };
+  return { fakeSub, pushManager };
+}
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockPost.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  // @ts-expect-error cleanup
+  delete window.PushManager;
+  // @ts-expect-error cleanup
+  delete window.Notification;
+});
+
+describe('urlBase64ToUint8Array', () => {
+  it('decodes a base64url key into bytes', () => {
+    const out = urlBase64ToUint8Array(btoa('hello').replace(/\+/g, '-').replace(/\//g, '_'));
+    expect(out).toBeInstanceOf(Uint8Array);
+    expect(String.fromCharCode(...out)).toBe('hello');
+  });
+});
+
+describe('usePushSubscription', () => {
+  it('is unsupported when the server VAPID key is blank', async () => {
+    installPushGlobals();
+    mockGet.mockResolvedValue({ data: { publicKey: '' } } as never);
+    const { result } = renderHook(() => usePushSubscription());
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+    expect(result.current.supported).toBe(false);
+  });
+
+  it('is supported when a VAPID key is present', async () => {
+    installPushGlobals();
+    mockGet.mockResolvedValue({ data: { publicKey: 'BPK' } } as never);
+    const { result } = renderHook(() => usePushSubscription());
+    await waitFor(() => expect(result.current.supported).toBe(true));
+  });
+
+  it('subscribe() posts the serialized subscription payload', async () => {
+    const { pushManager } = installPushGlobals({ permission: 'granted' });
+    // @ts-expect-error stub returns granted
+    window.Notification.requestPermission = vi.fn(async () => 'granted');
+    mockGet.mockResolvedValue({ data: { publicKey: btoa('key').replace(/=+$/, '') } } as never);
+    mockPost.mockResolvedValue({ data: {} } as never);
+
+    const { result } = renderHook(() => usePushSubscription());
+    await waitFor(() => expect(result.current.supported).toBe(true));
+
+    await act(async () => {
+      await result.current.subscribe();
+    });
+
+    expect(pushManager.subscribe).toHaveBeenCalledWith(
+      expect.objectContaining({ userVisibleOnly: true }),
+    );
+    expect(mockPost).toHaveBeenCalledWith(
+      '/push/subscribe/',
+      expect.objectContaining({
+        endpoint: 'https://push.example.com/abc',
+        keys: { p256dh: 'p', auth: 'a' },
+      }),
+    );
+    expect(result.current.isSubscribed).toBe(true);
+  });
+
+  it('subscribe() aborts when permission is not granted', async () => {
+    installPushGlobals();
+    // @ts-expect-error stub returns denied
+    window.Notification.requestPermission = vi.fn(async () => 'denied');
+    mockGet.mockResolvedValue({ data: { publicKey: 'BPK' } } as never);
+
+    const { result } = renderHook(() => usePushSubscription());
+    await waitFor(() => expect(result.current.supported).toBe(true));
+
+    await act(async () => {
+      await result.current.subscribe();
+    });
+
+    expect(mockPost).not.toHaveBeenCalled();
+    expect(result.current.isSubscribed).toBe(false);
+  });
+
+  it('reflects an existing subscription and unsubscribe() clears it', async () => {
+    const { fakeSub } = installPushGlobals({ existing: true });
+    mockGet.mockResolvedValue({ data: { publicKey: 'BPK' } } as never);
+    mockPost.mockResolvedValue({ data: {} } as never);
+
+    const { result } = renderHook(() => usePushSubscription());
+    await waitFor(() => expect(result.current.isSubscribed).toBe(true));
+
+    await act(async () => {
+      await result.current.unsubscribe();
+    });
+
+    expect(mockPost).toHaveBeenCalledWith('/push/unsubscribe/', {
+      endpoint: 'https://push.example.com/abc',
+    });
+    expect(fakeSub.unsubscribe).toHaveBeenCalled();
+    expect(result.current.isSubscribed).toBe(false);
+  });
+});

--- a/frontend_modern/src/features/pwa/usePushSubscription.ts
+++ b/frontend_modern/src/features/pwa/usePushSubscription.ts
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useState } from 'react';
+import { apiClient } from '@/api/client';
+
+/**
+ * MPN-4 — Web Push opt-in.
+ *
+ * Bridges the browser Push API to the backend (MPN-2):
+ *   subscribe()   → Notification.requestPermission → pushManager.subscribe
+ *                   (with the server VAPID public key) → POST /push/subscribe/
+ *   unsubscribe() → pushManager.unsubscribe → POST /push/unsubscribe/
+ *
+ * Honest UX (initiative principle 4): if the browser lacks push support, or the
+ * server has no VAPID key configured (empty publicKey), `supported` stays false
+ * and the UI hides the affordance rather than promising something that can't
+ * work. iOS Safari only supports push for *installed* PWAs (16.4+); there the
+ * APIs are present only once installed, so this degrades the same way.
+ */
+
+const SUBSCRIBE_URL = '/push/subscribe/';
+const UNSUBSCRIBE_URL = '/push/unsubscribe/';
+const VAPID_KEY_URL = '/push/vapid-public-key/';
+
+/** Decode a base64url VAPID public key into the Uint8Array `subscribe` wants. */
+export function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(base64);
+  // Allocate over a concrete ArrayBuffer so the type is Uint8Array<ArrayBuffer>,
+  // which is what PushManager.subscribe's applicationServerKey requires.
+  const output = new Uint8Array(new ArrayBuffer(raw.length));
+  for (let i = 0; i < raw.length; i += 1) output[i] = raw.charCodeAt(i);
+  return output;
+}
+
+function browserSupportsPush(): boolean {
+  return (
+    typeof navigator !== 'undefined' &&
+    'serviceWorker' in navigator &&
+    typeof window !== 'undefined' &&
+    'PushManager' in window &&
+    'Notification' in window
+  );
+}
+
+export interface PushSubscriptionState {
+  /** Push is usable here: browser support AND a server VAPID key. */
+  supported: boolean;
+  /** Current Notification permission ('default' | 'granted' | 'denied'). */
+  permission: NotificationPermission;
+  /** True when this browser currently holds a push subscription. */
+  isSubscribed: boolean;
+  /** True while subscribe()/unsubscribe() is in flight. */
+  busy: boolean;
+  subscribe: () => Promise<void>;
+  unsubscribe: () => Promise<void>;
+}
+
+export function usePushSubscription(): PushSubscriptionState {
+  const browserSupported = browserSupportsPush();
+  const [publicKey, setPublicKey] = useState<string | null>(null);
+  const [isSubscribed, setIsSubscribed] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [permission, setPermission] = useState<NotificationPermission>(
+    browserSupported ? Notification.permission : 'default',
+  );
+
+  // Fetch the server VAPID public key once; an empty key disables push.
+  useEffect(() => {
+    if (!browserSupported) return;
+    let cancelled = false;
+    apiClient
+      .get<{ publicKey: string }>(VAPID_KEY_URL)
+      .then((res) => {
+        if (!cancelled) setPublicKey(res.data.publicKey ?? '');
+      })
+      .catch(() => {
+        if (!cancelled) setPublicKey('');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [browserSupported]);
+
+  // Reflect any existing browser subscription into state.
+  useEffect(() => {
+    if (!browserSupported) return;
+    let cancelled = false;
+    navigator.serviceWorker.ready
+      .then((reg) => reg.pushManager.getSubscription())
+      .then((sub) => {
+        if (!cancelled) setIsSubscribed(!!sub);
+      })
+      .catch(() => {
+        /* no SW (dev) — leave isSubscribed false */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [browserSupported]);
+
+  const subscribe = useCallback(async () => {
+    if (!browserSupported || !publicKey) return;
+    setBusy(true);
+    try {
+      const perm = await Notification.requestPermission();
+      setPermission(perm);
+      if (perm !== 'granted') return;
+
+      const reg = await navigator.serviceWorker.ready;
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(publicKey),
+      });
+      // toJSON() yields { endpoint, keys: { p256dh, auth } } — exactly the
+      // shape POST /push/subscribe/ expects.
+      await apiClient.post(SUBSCRIBE_URL, sub.toJSON());
+      setIsSubscribed(true);
+    } finally {
+      setBusy(false);
+    }
+  }, [browserSupported, publicKey]);
+
+  const unsubscribe = useCallback(async () => {
+    if (!browserSupported) return;
+    setBusy(true);
+    try {
+      const reg = await navigator.serviceWorker.ready;
+      const sub = await reg.pushManager.getSubscription();
+      if (sub) {
+        await apiClient
+          .post(UNSUBSCRIBE_URL, { endpoint: sub.endpoint })
+          .catch(() => {
+            /* best-effort server prune; still unsubscribe locally */
+          });
+        await sub.unsubscribe();
+      }
+      setIsSubscribed(false);
+    } finally {
+      setBusy(false);
+    }
+  }, [browserSupported]);
+
+  return {
+    // publicKey === null means "still loading"; treat only a non-empty key as supported.
+    supported: browserSupported && !!publicKey,
+    permission,
+    isSubscribed,
+    busy,
+    subscribe,
+    unsubscribe,
+  };
+}

--- a/frontend_modern/src/features/shared/ProfilePage.tsx
+++ b/frontend_modern/src/features/shared/ProfilePage.tsx
@@ -5,6 +5,8 @@ import { authApi } from '@/api/auth';
 import { UserRole } from '@/types/index';
 import { Button, Card, Input, Select, SectionHeading } from '@/shared/ui';
 import { useI18n, type Locale } from '@/shared/i18n';
+import { useT } from '@/shared/i18n/useT';
+import { usePushSubscription } from '@/features/pwa/usePushSubscription';
 import type { AxiosError } from 'axios';
 
 function extractError(err: unknown, fallback = 'Save failed. Please try again.'): string {
@@ -21,6 +23,8 @@ export const ProfilePage = () => {
   const { user } = useAuth();
   const queryClient = useQueryClient();
   const { setLocale } = useI18n();
+  const t = useT();
+  const push = usePushSubscription();
 
   const [form, setForm] = useState({
     first_name: '',
@@ -197,6 +201,28 @@ export const ProfilePage = () => {
                     </span>
                   </span>
                 </label>
+
+                {push.supported && (
+                  <label className="flex items-start gap-3 cursor-pointer mt-4">
+                    <input
+                      type="checkbox"
+                      checked={push.isSubscribed}
+                      disabled={push.busy || push.permission === 'denied'}
+                      onChange={(e) =>
+                        e.target.checked ? push.subscribe() : push.unsubscribe()
+                      }
+                      className="mt-0.5 w-4 h-4 rounded border-ink-300 text-brand-600 focus:ring-brand-500"
+                    />
+                    <span>
+                      <span className="block text-sm font-medium text-ink-900">
+                        {t('push.label')}
+                      </span>
+                      <span className="block text-xs text-ink-500 mt-0.5">
+                        {push.permission === 'denied' ? t('push.blocked') : t('push.description')}
+                      </span>
+                    </span>
+                  </label>
+                )}
               </div>
             )}
 

--- a/frontend_modern/src/shared/i18n/locales/en.ts
+++ b/frontend_modern/src/shared/i18n/locales/en.ts
@@ -956,6 +956,14 @@ export const en = {
   // ── PWA (service worker update prompt) ───────────────────────────────
   'pwa.updateAvailable': 'A new version is available.',
   'pwa.refresh': 'Refresh',
+  // ── Web Push notifications (due-date reminders) ──────────────────────
+  'push.prompt': 'Get reminders on your phone.',
+  'push.enable': 'Turn on',
+  'push.dismiss': 'Dismiss notification prompt',
+  'push.enabled': 'Reminders on',
+  'push.label': 'Push notifications',
+  'push.description': 'Get a notification on this device when an assignment is due soon.',
+  'push.blocked': 'Notifications are blocked in your browser settings.',
 } as const;
 
 /** Every valid i18n key. Derived from the English dictionary. */

--- a/frontend_modern/src/shared/i18n/locales/hi.ts
+++ b/frontend_modern/src/shared/i18n/locales/hi.ts
@@ -951,4 +951,12 @@ export const hi: LocaleDict = {
   // ── PWA (service worker update prompt) ───────────────────────────────
   'pwa.updateAvailable': 'नया वर्शन उपलब्ध है।',
   'pwa.refresh': 'रिफ़्रेश करें',
+  // ── Web Push notifications (due-date reminders) ──────────────────────
+  'push.prompt': 'अपने फ़ोन पर रिमाइंडर पाएँ।',
+  'push.enable': 'चालू करें',
+  'push.dismiss': 'सूचना अनुरोध बंद करें',
+  'push.enabled': 'रिमाइंडर चालू',
+  'push.label': 'पुश सूचनाएँ',
+  'push.description': 'असाइनमेंट जल्द देय होने पर इस डिवाइस पर सूचना पाएँ।',
+  'push.blocked': 'आपके ब्राउज़र सेटिंग्स में सूचनाएँ अवरुद्ध हैं।',
 };


### PR DESCRIPTION
## MPN-4 — Frontend push opt-in + settings toggle

The user-facing half of web push. **Stacked on #377 (MPN-3).** Runtime-depends on #376 (MPN-2) endpoints. Re-targets to `modernization` once MPN-3 merges.

**Classification:** New.

### What changed
- `usePushSubscription` — fetches VAPID key (empty ⇒ `supported=false`, UI hidden), `requestPermission` → `pushManager.subscribe` → `POST /push/subscribe/`; `unsubscribe` mirrors; reflects existing subscription. Honest UX: hides where push can't work.
- `PushBanner` — dismissible "Get reminders on your phone" affordance (mirrors MSO-5 InstallBanner), mounted in `AppShell`.
- `ProfilePage` — push notifications toggle next to email reminders (blocked-hint when denied).
- i18n `push.*` keys in en + hi (parity green).

### Tests / verification
- `usePushSubscription.test.ts` (6) + `PushBanner.test.tsx` (4).
- Full suite **446 passed**; type-check + lint clean; build clean, entry chunk **149 kB** (< 160 kB).

### How to verify
`cd frontend_modern && npm test -- --run src/features/pwa && npm run build`

> Push only works against a prod build/preview (dev SW disabled). See `docs/perf/2026-06-17-pwa-push-manual-test.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)