### PR TITLE
ci: least-privilege GITHUB_TOKEN floor on ci-cd.yaml

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -13,6 +13,18 @@ concurrency:
     group: ci-${{ github.ref }}
     cancel-in-progress: ${{ github.ref != 'refs/heads/modernization' && github.ref != 'refs/heads/qa' && github.ref != 'refs/heads/prod' }}
 
+# Least-privilege default for the GITHUB_TOKEN. Without an explicit block the
+# token inherits the repository/org default, which can be the legacy
+# read/write-all scope — far more than any of these jobs need. Most jobs only
+# check out the repo, so `contents: read` covers them. The two jobs that need
+# more declare their own (overriding) block:
+#   - `test` adds `pull-requests: write` to post the coverage comment
+#   - `build-publish` adds `packages: write` to push images to GHCR
+# Setting the floor here keeps every other job (lint, typecheck, security,
+# frontend, frontend-e2e, lighthouse, deploy-*) read-only on contents.
+permissions:
+    contents: read
+
 jobs:
     workflow-lint:
         name: Workflow Lint (actionlint)

--- a/docs/changes/2026-06-18-ci-token-permissions-floor.md
+++ b/docs/changes/2026-06-18-ci-token-permissions-floor.md
@@ -1,0 +1,46 @@
+# 2026-06-18 — CI: least-privilege GITHUB_TOKEN floor on ci-cd.yaml
+
+## What
+
+Added a top-level `permissions:` block to `.github/workflows/ci-cd.yaml`:
+
+```yaml
+permissions:
+    contents: read
+```
+
+This sets the default `GITHUB_TOKEN` scope for every job in the workflow to
+read-only on repository contents. The two jobs that need more already declare
+their own (overriding) block and are unchanged:
+
+- `test` → `contents: read` + `pull-requests: write` (posts the coverage comment)
+- `build-publish` → `contents: read` + `packages: write` (pushes images to GHCR)
+
+The other nine jobs (`workflow-lint`, `lint`, `typecheck`, `security`,
+`frontend`, `frontend-e2e`, `lighthouse`, `deploy-qa`, `deploy-prod`) only
+check out the repo and run tools/manifests, so `contents: read` is sufficient.
+
+## Why
+
+Without an explicit `permissions:` block, a workflow inherits the
+repository/organization default token scope. On older repos that default is
+**read/write all** — a token far more powerful than any of these jobs need. If
+a build step (or a transitively-pulled dependency / action) were compromised,
+that broad token could push commits, edit issues/PRs, or alter releases.
+
+Setting an explicit least-privilege floor is the GitHub-recommended hardening
+and is the convention the repo already follows on its newer workflows
+(`dependabot-automerge.yaml`, `dependency-review.yaml` both set top-level
+`permissions:`). This change brings the main pipeline in line with them.
+`codeql.yaml` was intentionally left as-is: its single `analyze` job already
+declares an explicit job-level block, so a top-level floor would be redundant.
+
+## Risk
+
+Very low. No application code is touched, and no job loses a permission it
+relies on — the only two jobs that need elevated scopes already grant them to
+themselves, and per-job `permissions:` fully override the top-level block
+rather than merging with it. The change is validated by the existing
+`workflow-lint` (actionlint) job. The worst realistic failure mode would be a
+job that silently needed a scope it no longer has; that would surface as a
+clear 403 in the affected step, not as a hard-to-diagnose data issue.


### PR DESCRIPTION
## What

Adds a top-level `permissions: contents: read` block to `.github/workflows/ci-cd.yaml`, setting a least-privilege default `GITHUB_TOKEN` scope for the whole pipeline.

```yaml
permissions:
    contents: read
```

The two jobs that need more already declare their own (overriding) blocks and are untouched:
- **`test`** → `pull-requests: write` (posts the sticky coverage comment)
- **`build-publish`** → `packages: write` (pushes images to GHCR)

The other nine jobs only check out the repo and run tools/manifests, so `contents: read` is all they need.

## Why

Without an explicit `permissions:` block a workflow inherits the repo/org default token scope — on older repos that's **read/write-all**, far more than any of these jobs require. An explicit least-privilege floor is GitHub's recommended hardening and matches the convention the repo's newer workflows already follow (`dependabot-automerge.yaml`, `dependency-review.yaml`).

`codeql.yaml` is intentionally **not** changed: its single `analyze` job already declares an explicit job-level permissions block, so a top-level floor there would be redundant.

## Risk

Very low. No application code touched. Per-job `permissions:` fully override the top-level block (they don't merge), so the only two jobs needing elevated scopes keep them. Validated by the existing `workflow-lint` (actionlint) job. A missed scope would surface as a clear `403` in the affected step.

See `docs/changes/2026-06-18-ci-token-permissions-floor.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)