### PR TITLE
feat(mobile): RML-1 — ResponsiveTable primitive + ClassHealthPanel

### DIFF
--- a/frontend_modern/src/features/design/DesignSystemPage.tsx
+++ b/frontend_modern/src/features/design/DesignSystemPage.tsx
@@ -12,6 +12,8 @@ import {
   Stat,
   SectionHeading,
   EmptyState,
+  ResponsiveTable,
+  type ResponsiveColumn,
 } from '@/shared/ui';
 import { InteractiveWidget } from '@/shared/ui/InteractiveWidget';
 import { RichContent } from '@/shared/ui/RichContent';
@@ -408,6 +410,31 @@ export const DesignSystemPage = () => (
           />
           <EmptyState title="No streak yet" description="Answer one question today to start the chain." />
         </div>
+      </Section>
+
+      <Section kicker="Components" title="Responsive table">
+        <Card>
+          <p className="mb-3 text-sm text-ink-500">
+            A real <code>&lt;table&gt;</code> at <code>sm:</code> and up; a stacked
+            label/value card list below it. Resize the viewport to switch.
+          </p>
+          <ResponsiveTable<{ id: number; chapter: string; avg: number; status: string }>
+            aria-label="Demo class health"
+            rows={[
+              { id: 1, chapter: 'Polynomials', avg: 82, status: 'Proficient' },
+              { id: 2, chapter: 'Triangles', avg: 54, status: 'At risk' },
+              { id: 3, chapter: 'Real Numbers', avg: 38, status: 'Struggling' },
+            ]}
+            rowKey={(r) => r.id}
+            columns={
+              [
+                { key: 'chapter', header: 'Chapter', primary: true, cell: (r) => r.chapter },
+                { key: 'avg', header: 'Avg', align: 'right', cell: (r) => `${r.avg}%` },
+                { key: 'status', header: 'Status', align: 'right', cell: (r) => r.status },
+              ] as ResponsiveColumn<{ id: number; chapter: string; avg: number; status: string }>[]
+            }
+          />
+        </Card>
       </Section>
 
       <Section kicker="Components" title="Skeleton (loading)">

--- a/frontend_modern/src/features/teacher/ClassHealthPanel.tsx
+++ b/frontend_modern/src/features/teacher/ClassHealthPanel.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { apiClient } from '@/api/client';
 import { useClassInsights } from './useClassInsights';
 import type { ClassInsight } from './useClassInsights';
-import { Button } from '@/shared/ui';
+import { Button, ResponsiveTable, type ResponsiveColumn } from '@/shared/ui';
 import { useI18n, type LocaleKey } from '@/shared/i18n';
 
 const STATUS_CONFIG: Record<ClassInsight['insight_type'], { dot: string; labelKey: LocaleKey }> = {
@@ -25,6 +25,47 @@ export const ClassHealthPanel = ({ subjectRoomId }: Props) => {
   const [isTriggering, setIsTriggering] = useState(false);
 
   const { data: insights, isLoading, refetch } = useClassInsights(subjectRoomId, isExpanded);
+
+  const columns: ResponsiveColumn<ClassInsight>[] = [
+    {
+      key: 'chapter',
+      header: t('teacher.thChapter'),
+      primary: true,
+      cell: (insight) => <span className="font-medium text-ink-800">{insight.chapter_name}</span>,
+    },
+    {
+      key: 'avg',
+      header: t('teacher.thAvg'),
+      align: 'right',
+      cell: (insight) => (
+        <span className="text-ink-600">{Math.round(insight.class_avg_score * 100)}%</span>
+      ),
+    },
+    {
+      key: 'struggling',
+      header: t('teacher.thStruggling'),
+      align: 'right',
+      cell: (insight) => (
+        <span className="text-ink-500">
+          {insight.students_struggling}/{insight.students_assessed}
+        </span>
+      ),
+    },
+    {
+      key: 'status',
+      header: t('teacher.thStatus'),
+      align: 'right',
+      cell: (insight) => {
+        const cfg = STATUS_CONFIG[insight.insight_type];
+        return (
+          <span className="inline-flex items-center gap-1">
+            <span aria-hidden className={`inline-block h-2 w-2 rounded-full ${cfg.dot}`} />
+            <span className="text-ink-600">{t(cfg.labelKey)}</span>
+          </span>
+        );
+      },
+    },
+  ];
 
   const handleRefresh = async () => {
     setIsTriggering(true);
@@ -77,48 +118,12 @@ export const ClassHealthPanel = ({ subjectRoomId }: Props) => {
 
           {insights && insights.length > 0 && (
             <>
-              <div className="-mx-1 overflow-x-auto">
-              <table className="w-full min-w-[22rem] text-xs">
-                <thead>
-                  <tr className="border-b border-ink-100 text-ink-500">
-                    <th className="pb-1.5 text-left font-display font-semibold">{t('teacher.thChapter')}</th>
-                    <th className="pb-1.5 text-right font-display font-semibold">{t('teacher.thAvg')}</th>
-                    <th className="pb-1.5 text-right font-display font-semibold">{t('teacher.thStruggling')}</th>
-                    <th className="pb-1.5 text-right font-display font-semibold">{t('teacher.thStatus')}</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {insights.map((insight) => {
-                    const cfg = STATUS_CONFIG[insight.insight_type];
-                    return (
-                      <tr
-                        key={insight.id}
-                        className="border-b border-ink-50 last:border-0"
-                      >
-                        <td className="py-1.5 font-medium text-ink-800">
-                          {insight.chapter_name}
-                        </td>
-                        <td className="py-1.5 text-right text-ink-600">
-                          {Math.round(insight.class_avg_score * 100)}%
-                        </td>
-                        <td className="py-1.5 text-right text-ink-500">
-                          {insight.students_struggling}/{insight.students_assessed}
-                        </td>
-                        <td className="py-1.5 text-right">
-                          <span className="inline-flex items-center gap-1">
-                            <span
-                              aria-hidden
-                              className={`inline-block h-2 w-2 rounded-full ${cfg.dot}`}
-                            />
-                            <span className="text-ink-600">{t(cfg.labelKey)}</span>
-                          </span>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-              </div>
+              <ResponsiveTable
+                aria-label={t('teacher.classHealth')}
+                rows={insights}
+                rowKey={(insight) => insight.id}
+                columns={columns}
+              />
               <div className="mt-2 flex items-center justify-between">
                 <p className="text-xs text-ink-400">
                   {t('teacher.lastUpdated', {

--- a/frontend_modern/src/shared/ui/ResponsiveTable.test.tsx
+++ b/frontend_modern/src/shared/ui/ResponsiveTable.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { ResponsiveTable, type ResponsiveColumn } from './ResponsiveTable';
+
+interface Row {
+  id: number;
+  chapter: string;
+  avg: number;
+}
+
+const columns: ResponsiveColumn<Row>[] = [
+  { key: 'chapter', header: 'Chapter', primary: true, cell: (r) => r.chapter },
+  { key: 'avg', header: 'Avg', align: 'right', cell: (r) => `${r.avg}%` },
+];
+
+const rows: Row[] = [
+  { id: 1, chapter: 'Polynomials', avg: 82 },
+  { id: 2, chapter: 'Triangles', avg: 54 },
+];
+
+describe('<ResponsiveTable />', () => {
+  it('renders a real table with headers and a row per item', () => {
+    render(<ResponsiveTable rows={rows} columns={columns} rowKey={(r) => r.id} />);
+    const table = screen.getByRole('table', { hidden: true });
+    expect(within(table).getByText('Chapter')).toBeInTheDocument();
+    expect(within(table).getByText('Avg')).toBeInTheDocument();
+    // one header row + one row per item
+    const bodyRows = within(table).getAllByRole('row', { hidden: true });
+    expect(bodyRows).toHaveLength(rows.length + 1);
+  });
+
+  it('renders both the table (hidden on mobile) and the card list (hidden on desktop)', () => {
+    const { container } = render(
+      <ResponsiveTable rows={rows} columns={columns} rowKey={(r) => r.id} />,
+    );
+    // JSDOM cannot evaluate the media query, so assert both structures exist with
+    // the correct breakpoint visibility classes.
+    const table = container.querySelector('table');
+    expect(table).not.toBeNull();
+    expect(table?.className).toContain('hidden');
+    expect(table?.className).toContain('sm:table');
+
+    const list = container.querySelector('ul');
+    expect(list).not.toBeNull();
+    expect(list?.className).toContain('sm:hidden');
+    expect(list?.querySelectorAll('li')).toHaveLength(rows.length);
+  });
+
+  it('renders the primary column as the card heading and the rest as label/value pairs', () => {
+    const { container } = render(
+      <ResponsiveTable rows={rows} columns={columns} rowKey={(r) => r.id} />,
+    );
+    const list = container.querySelector('ul')!;
+    // primary value appears as a heading (outside the <dl>); secondary as <dt>/<dd>
+    expect(within(list).getAllByText('Polynomials').length).toBeGreaterThan(0);
+    expect(list.querySelectorAll('dt')).toHaveLength(rows.length); // one "Avg" label per card
+    expect(within(list).getByText('82%')).toBeInTheDocument();
+  });
+
+  it('uses rowKey for keys without throwing on duplicate-looking content', () => {
+    const dupRows: Row[] = [
+      { id: 10, chapter: 'Same', avg: 50 },
+      { id: 11, chapter: 'Same', avg: 50 },
+    ];
+    const { container } = render(
+      <ResponsiveTable rows={dupRows} columns={columns} rowKey={(r) => r.id} />,
+    );
+    expect(container.querySelectorAll('ul > li')).toHaveLength(2);
+  });
+
+  it('renders only the caption/headers when rows is empty', () => {
+    const { container } = render(
+      <ResponsiveTable rows={[]} columns={columns} rowKey={(r) => r.id} caption="Empty demo" />,
+    );
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(0);
+    expect(container.querySelectorAll('ul > li')).toHaveLength(0);
+    expect(screen.getByText('Empty demo')).toBeInTheDocument();
+  });
+});

--- a/frontend_modern/src/shared/ui/ResponsiveTable.tsx
+++ b/frontend_modern/src/shared/ui/ResponsiveTable.tsx
@@ -1,0 +1,114 @@
+import { type ReactNode } from 'react';
+import clsx from 'clsx';
+
+export interface ResponsiveColumn<T> {
+  key: string;
+  header: ReactNode;
+  /** cell renderer for both the desktop table and the mobile card value */
+  cell: (row: T) => ReactNode;
+  align?: 'left' | 'right';
+  /**
+   * if true, this column is the card's title row on mobile — rendered
+   * prominently with no label. The first `primary` column wins.
+   */
+  primary?: boolean;
+}
+
+interface Props<T> {
+  columns: ResponsiveColumn<T>[];
+  rows: T[];
+  rowKey: (row: T) => string | number;
+  /** sr-only caption describing the table for assistive tech */
+  caption?: ReactNode;
+  'aria-label'?: string;
+  className?: string;
+}
+
+/**
+ * Dense data that reads as a real `<table>` on tablet/desktop (`sm:` and up) and
+ * a stacked label/value card list on phones — no horizontal scroll, no clipped
+ * columns. Follows the repo's `hidden sm:table` / `sm:hidden` dual-render
+ * convention (see `Navbar`, `BottomNav`) rather than a JS media-query hook, so
+ * there is no hydration flicker. Dependency-free; styled with the V2 `ink-*`
+ * tokens.
+ */
+export function ResponsiveTable<T>({
+  columns,
+  rows,
+  rowKey,
+  caption,
+  className,
+  'aria-label': ariaLabel,
+}: Props<T>) {
+  const primaryCol = columns.find((c) => c.primary);
+  const secondaryCols = columns.filter((c) => c !== primaryCol);
+
+  return (
+    <>
+      {/* Desktop / tablet: a real semantic table */}
+      <table
+        className={clsx('hidden w-full text-xs sm:table', className)}
+        aria-label={ariaLabel}
+      >
+        {caption && <caption className="sr-only">{caption}</caption>}
+        <thead>
+          <tr className="border-b border-ink-100 text-ink-500">
+            {columns.map((col) => (
+              <th
+                key={col.key}
+                scope="col"
+                className={clsx(
+                  'pb-1.5 font-display font-semibold',
+                  col.align === 'right' ? 'text-right' : 'text-left',
+                )}
+              >
+                {col.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={rowKey(row)} className="border-b border-ink-50 last:border-0">
+              {columns.map((col) => (
+                <td
+                  key={col.key}
+                  className={clsx(
+                    'py-1.5',
+                    col.align === 'right' ? 'text-right' : 'text-left',
+                  )}
+                >
+                  {col.cell(row)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {/* Mobile: a stacked label/value card list */}
+      <ul className={clsx('space-y-2 sm:hidden', className)} aria-label={ariaLabel}>
+        {rows.map((row) => (
+          <li
+            key={rowKey(row)}
+            className="rounded-lg border border-ink-100 bg-paper px-3 py-2.5"
+          >
+            {primaryCol && (
+              <div className="mb-1.5 font-display text-sm font-semibold text-ink-800">
+                {primaryCol.cell(row)}
+              </div>
+            )}
+            <dl className="space-y-1 text-xs">
+              {secondaryCols.map((col) => (
+                <div key={col.key} className="flex items-center justify-between gap-3">
+                  <dt className="text-ink-500">{col.header}</dt>
+                  <dd className="text-right text-ink-700">{col.cell(row)}</dd>
+                </div>
+              ))}
+            </dl>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/frontend_modern/src/shared/ui/index.ts
+++ b/frontend_modern/src/shared/ui/index.ts
@@ -23,3 +23,5 @@ export { Input, Textarea, Select } from './Input';
 export { Stat } from './Stat';
 export { SectionHeading } from './SectionHeading';
 export { EmptyState } from './EmptyState';
+export { ResponsiveTable } from './ResponsiveTable';
+export type { ResponsiveColumn } from './ResponsiveTable';


### PR DESCRIPTION
## RML-1 — `ResponsiveTable` shared primitive + ClassHealthPanel conversion

**Classification:** New (primitive) + Improve (panel)
**Initiative:** [Mobile Shell & PWA-Offline](../blob/modernization/docs/initiatives/2026-mobile-shell-pwa-offline.md) — Batch 4 (route-level mobile layouts), build-first item.

### What & why
Teacher data surfaces were ported table-first and band-aided with `overflow-x-auto`, which on a phone means pinch-zoom-and-scroll. This adds a shared primitive that renders a real semantic `<table>` on tablet/desktop (information density teachers want) and a stacked label/value card list on phones (every datum legible, no horizontal scroll).

- New `frontend_modern/src/shared/ui/ResponsiveTable.tsx` — generic, typed (`columns` + `rows` + `rowKey`), dependency-free. Uses the repo's `hidden sm:table` / `sm:hidden` dual-render convention (no `matchMedia` hook → no hydration flicker). `primary` column becomes the mobile card heading; the rest become `<dl>` label/value pairs.
- First consumer: `ClassHealthPanel.tsx` — replaced the `overflow-x-auto` + `min-w-[22rem]` table. Desktop table visually unchanged; reuses the existing `teacher.th*` i18n keys (no new strings).
- Exported from `shared/ui/index.ts` and demoed on the `/design` route.

### Legacy reference
Legacy OpenShiksha (Django 1.11, server-rendered) had no responsive teacher tables — pinch-zoom only. Responsive card stacking is net-new.

### Tests
- New `ResponsiveTable.test.tsx`: table + card-list both in the DOM with correct breakpoint classes; header/row counts; primary-as-heading vs label/value pairs; `rowKey`; empty state renders caption only.
- All 161 frontend tests pass.

### Verify
`npm run test` ✅ · `npx tsc --noEmit` ✅ · `npx eslint` ✅ · `npm run build` ✅ (entry chunk unchanged — primitive is tiny, imported only into already-lazy teacher routes). Resize `/design` "Responsive table" section across `sm:` to see the swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)