### PR TITLE
feat(mobile): RML-3 — Create-Question form responsive density

### DIFF
--- a/frontend_modern/src/features/teacher/CreateQuestionPage.test.tsx
+++ b/frontend_modern/src/features/teacher/CreateQuestionPage.test.tsx
@@ -46,4 +46,12 @@ describe('<CreateQuestionPage />', () => {
       expect(screen.getByRole('heading', { name: 'प्रश्न बनाएँ' })).toBeInTheDocument();
     });
   });
+
+  it('stacks the chapter selectors into one column on phones (mobile-first grid)', () => {
+    const { container } = renderPage('en');
+    // The subject/standard grid must carry the base `grid-cols-1` class so it is
+    // single-column below `sm:` (JSDOM can't compute the grid; assert the class).
+    const grids = container.querySelectorAll('div.grid-cols-1.sm\\:grid-cols-2');
+    expect(grids.length).toBeGreaterThan(0);
+  });
 });

--- a/frontend_modern/src/features/teacher/CreateQuestionPage.tsx
+++ b/frontend_modern/src/features/teacher/CreateQuestionPage.tsx
@@ -360,7 +360,7 @@ const AIGenerationPanel = ({
             />
           </div>
 
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
             <div>
               <label className="block text-xs font-medium text-brand-800 mb-1">{t('cqp.typeLabelShort')}</label>
               <select
@@ -758,7 +758,7 @@ export const CreateQuestionPage = ({ editMode = false }: { editMode?: boolean })
         <div className="bg-white rounded-xl border border-ink-100 p-5 space-y-4">
           <h2 className="font-semibold text-ink-800">{t('cqp.chapter')}</h2>
 
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div>
               <label className="block text-xs font-medium text-ink-600 mb-1">{t('cqp.subject')}</label>
               <select
@@ -831,7 +831,7 @@ export const CreateQuestionPage = ({ editMode = false }: { editMode?: boolean })
               <button
                 key={i}
                 onClick={() => setActiveSubpart(i)}
-                className={`pb-3 px-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
+                className={`flex min-h-[44px] items-end pb-3 px-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
                   activeSubpart === i
                     ? 'border-brand-600 text-brand-700'
                     : 'border-transparent text-ink-500 hover:text-ink-700'
@@ -842,7 +842,7 @@ export const CreateQuestionPage = ({ editMode = false }: { editMode?: boolean })
             ))}
             <button
               onClick={addSubpart}
-              className="pb-3 px-3 text-sm text-brand-600 hover:text-brand-800 whitespace-nowrap"
+              className="flex min-h-[44px] items-end pb-3 px-3 text-sm text-brand-600 hover:text-brand-800 whitespace-nowrap"
             >
               {t('cqp.addPart')}
             </button>


### PR DESCRIPTION
## RML-3 — Create-Question form responsive density

**Classification:** Improve
**Initiative:** Mobile Shell & PWA-Offline — Batch 4 (route-level mobile layouts). Independent of RML-1/2.

### What & why
`CreateQuestionPage` had two fixed multi-column grids that squeeze illegibly on a 360 px phone:
- AI-panel **type / difficulty / count** selectors: `grid-cols-3` → `grid-cols-1 sm:grid-cols-3`
- Chapter **subject / standard** selectors: `grid-cols-2` → `grid-cols-1 sm:grid-cols-2`

Also gave the subpart **tab strip** buttons a `min-h-[44px]` touch target (the strip already scrolls horizontally with `overflow-x-auto whitespace-nowrap`).

Pure presentation pass — no form logic touched. Audited the rest of the file: the variable-constraint rows already `flex-wrap`, and the KaTeX preview already stacks below the editor (single column), so no further change was needed.

### Tests
- Existing `CreateQuestionPage.test.tsx` passes; added a class-presence assertion that the chapter grid carries the mobile-first `grid-cols-1 sm:grid-cols-2` base.

### Verify
`npm run test` ✅ · `npx tsc --noEmit` ✅ · `npx eslint` ✅ · `npm run build` ✅ (entry chunk unchanged). At ≤360 px the selectors stack to one column per row; tabs remain a horizontal scroll with ≥44 px targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)