### PR TITLE
feat(mobile): RML-4 — Open-Response grading responsive layout

### DIFF
--- a/frontend_modern/src/features/teacher/OpenResponseGradingPage.test.tsx
+++ b/frontend_modern/src/features/teacher/OpenResponseGradingPage.test.tsx
@@ -262,4 +262,15 @@ describe('OpenResponseGradingPage', () => {
     await waitFor(() => expect(screen.getByText(/no responses to grade yet/i)).toBeDefined());
     expect(screen.getByText(/AI will suggest a grade for your review/i)).toBeDefined();
   });
+
+  it('stacks the review form fields into one column on phones (mobile-first)', async () => {
+    mockApi([GRADE]);
+    const { container } = renderPage();
+
+    await waitFor(() => expect(screen.getByText('Asha Rao')).toBeDefined());
+    // The marks/comment row must be flex-col at the base breakpoint so the
+    // fields stack on a phone (JSDOM can't compute the layout; assert the class).
+    const row = container.querySelector('form .flex.flex-col.sm\\:flex-row');
+    expect(row).not.toBeNull();
+  });
 });

--- a/frontend_modern/src/features/teacher/OpenResponseGradingPage.tsx
+++ b/frontend_modern/src/features/teacher/OpenResponseGradingPage.tsx
@@ -66,7 +66,7 @@ const ReviewForm = ({ grade }: ReviewFormProps) => {
         });
       }}
     >
-      <div className="flex flex-wrap items-end gap-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
         <label className="block text-xs text-ink-600">
           {t('grading.finalMarks', { max: grade.max_marks })}
           <input
@@ -76,10 +76,10 @@ const ReviewForm = ({ grade }: ReviewFormProps) => {
             step={0.5}
             value={score}
             onChange={(e) => setScore(e.target.value)}
-            className="input-brand mt-1 block w-24 text-sm"
+            className="input-brand mt-1 block w-full text-sm sm:w-24"
           />
         </label>
-        <label className="block flex-1 min-w-[12rem] text-xs text-ink-600">
+        <label className="block flex-1 text-xs text-ink-600 sm:min-w-[12rem]">
           {t('grading.commentLabel')} <span className="text-ink-400">{t('grading.optional')}</span>
           <input
             type="text"
@@ -137,7 +137,7 @@ const GradeCard = ({ grade }: { grade: OpenResponseGrade }) => {
       <p className="mt-3 text-xs text-ink-500">
         <span className="font-semibold">{t('grading.questionLabel')}</span> {grade.question_text}
       </p>
-      <blockquote className="mt-2 rounded-lg border border-ink-100 bg-ink-50/60 p-3 text-sm text-ink-800 leading-relaxed whitespace-pre-line">
+      <blockquote className="mt-2 rounded-lg border border-ink-100 bg-ink-50/60 p-3 text-sm text-ink-800 leading-relaxed whitespace-pre-line break-words">
         {grade.response_text}
       </blockquote>
 


### PR DESCRIPTION
## RML-4 — Open-Response grading responsive layout

**Classification:** Improve
**Initiative:** Mobile Shell & PWA-Offline — Batch 4 (route-level mobile layouts). Independent of RML-1/2/3.

### What & why
The `ReviewForm` in the open-response grading queue placed the **marks input** (`w-24`) and the **comment field** (`flex-1 min-w-[12rem]`) side-by-side in a `flex-wrap` row, which crowds a 360 px phone. Made it mobile-first:
- Row: `flex flex-wrap items-end` → `flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end`
- Marks input: `w-24` → `w-full sm:w-24` (thumb-reachable on mobile)
- Comment label: `min-w-[12rem]` → `sm:min-w-[12rem]` (no forced 12 rem width below `sm:`)
- Response blockquote: added `break-words` so a long unbroken token can't force horizontal scroll

The page itself is already a single-column card list, so no other layout change was needed. Presentation only — the AI-suggest / teacher-finalise flow and the `AIBadge` provenance row are untouched.

### Tests
- Existing `OpenResponseGradingPage.test.tsx` (13 cases) passes; added an assertion that the review-form field row carries the mobile-first `flex-col sm:flex-row` base classes.

### Verify
`npm run test` ✅ · `npx tsc --noEmit` ✅ · `npx eslint` ✅ · `npm run build` ✅ (entry chunk unchanged). At ≤360 px the marks + comment fields stack full-width; a very long response wraps instead of scrolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)