### PR TITLE
docs(mobile): RML-5 — Batch 4 close-out + Mobile Shell initiative complete

### DIFF
--- a/docs/changes/2026-06-18-rml-mobile-layouts.md
+++ b/docs/changes/2026-06-18-rml-mobile-layouts.md
@@ -1,0 +1,97 @@
+# 2026-06-18 — RML-1..5: Route-level mobile layouts (Mobile Shell Batch 4)
+
+**Initiative:** [Mobile Shell & PWA-Offline](../initiatives/2026-mobile-shell-pwa-offline.md) — Batch 4, the final later-phase. **This batch completes the initiative.**
+
+**Classification:** New (RML-1 primitive) + Improve (RML-2..4) + Docs (RML-5).
+
+## Summary
+
+The student core loop has been mobile-first since the V2 overhaul, but several
+**teacher** surfaces were ported table-first for desktop and only band-aided with
+`overflow-x-auto` — which on a phone means pinch-zoom-and-scroll. This batch makes
+the dense teacher surfaces readable and usable on a 360 px screen, via a small
+shared `ResponsiveTable` primitive and per-surface mobile-first stacking.
+
+| PR | Item | Surface |
+|---|---|---|
+| [#382](https://github.com/openshiksha/openshiksha/pull/382) | RML-1 | `shared/ui/ResponsiveTable` + ClassHealthPanel |
+| [#383](https://github.com/openshiksha/openshiksha/pull/383) | RML-2 | Assignment-detail submissions (+ localize) |
+| [#384](https://github.com/openshiksha/openshiksha/pull/384) | RML-3 | Create-Question form density |
+| [#385](https://github.com/openshiksha/openshiksha/pull/385) | RML-4 | Open-Response grading layout |
+| (this) | RML-5 | docs + ledger + STATUS close-out |
+
+## The `ResponsiveTable` contract
+
+`frontend_modern/src/shared/ui/ResponsiveTable.tsx` — generic, typed, dependency-free:
+
+```tsx
+interface ResponsiveColumn<T> {
+  key: string;
+  header: ReactNode;
+  cell: (row: T) => ReactNode;   // renders both the desktop cell and the card value
+  align?: 'left' | 'right';
+  primary?: boolean;             // becomes the mobile card heading (no label)
+}
+<ResponsiveTable columns rows rowKey caption? aria-label? />
+```
+
+- **≥ `sm` (640 px):** a real semantic `<table>` (`hidden sm:table`) styled with the
+  V2 `ink-*` tokens — `thead`, row borders, right-alignable columns.
+- **< `sm`:** a `<ul className="sm:hidden">` where each row is a card — the `primary`
+  column as the heading, every other column as a `<dl>` label/value pair.
+
+It follows the repo's established `hidden sm:table` / `sm:hidden` **dual-render**
+convention (`Navbar`, `BottomNav`, `DueForReviewPanel`) rather than a runtime
+`matchMedia`/`useIsMobile` hook — so there is no hydration/SSR-style flicker and no
+JS cost. Exported from `shared/ui/index.ts` and demoed on the `/design` route.
+
+## What changed per surface
+
+- **RML-1 / ClassHealthPanel** — replaced the `-mx-1 overflow-x-auto` + `min-w-[22rem]`
+  table with `<ResponsiveTable>` (Chapter [primary] / Avg / Struggling / Status). The
+  status dot + label and the `n/m struggling` cell moved into `cell` renderers; the
+  existing `teacher.th*` i18n keys are reused — no new strings.
+- **RML-2 / TeacherAssignmentDetailPage** — converted the submissions `<table>` to
+  `<ResponsiveTable>` (student name = `primary`; `ScoreBadge` + status pills
+  preserved). **Localization decision:** this page had slipped the LA-6
+  teacher-chrome pass and carried hardcoded English, a regression against the
+  Language Access parity contract — so while in the file we routed every string
+  through `useI18n()`, added `teacher.ad*` keys in **en + hi** (the only two locales
+  after the Marathi pilot was removed), and moved the two date renders to the
+  locale-aware `useFormat()` helper. The i18n surface was small enough to keep in the
+  same PR (the plan allowed splitting to RML-2b if it ballooned — it didn't).
+- **RML-3 / CreateQuestionPage** — mobile-first grids: AI panel `grid-cols-3` →
+  `grid-cols-1 sm:grid-cols-3`, chapter `grid-cols-2` → `grid-cols-1 sm:grid-cols-2`;
+  subpart tab buttons given a `min-h-[44px]` touch target. The variable-constraint
+  rows already `flex-wrap` and the KaTeX preview already stacks below the editor, so
+  no change was needed there. No form logic touched.
+- **RML-4 / OpenResponseGradingPage** — review-form field row `flex-wrap` →
+  `flex-col sm:flex-row`; marks input `w-full sm:w-24`; comment `sm:min-w-[12rem]`;
+  response blockquote `break-words`. The AI-suggest / teacher-finalise flow is
+  untouched.
+
+## Tests
+
+- New `ResponsiveTable.test.tsx`: table + card list both present with the correct
+  breakpoint classes; header/row counts; primary-as-heading vs label/value pairs;
+  `rowKey`; empty state.
+- New `TeacherAssignmentDetailPage.test.tsx`: submissions render as table + cards;
+  graded vs pending badges; empty state; Hindi heading (dynamic-import dict awaited).
+- `CreateQuestionPage.test.tsx` / `OpenResponseGradingPage.test.tsx`: existing suites
+  pass + a class-presence assertion for the mobile-first grid/flex base classes.
+- i18n key-parity guard green (en + hi both carry every new `teacher.ad*` key).
+- Each PR: `npm run test` / `tsc --noEmit` / `eslint` / `npm run build` — entry chunk
+  unchanged vs the 160 kB CI guard.
+
+## Migration notes
+
+None — frontend-only; no backend, no dependency, no schema.
+
+## Next steps
+
+Mobile Shell & PWA-Offline is **complete** (first-phase DoD + both later phases).
+The STATUS board has **no unblocked next bet** — the next planning run promotes a
+fresh top initiative. Candidates: **AI-tutor rebase** (`ai/2026-06-04-ai-tutor-chat`,
+a ~5k-line diverged branch), an **`/ai/predictions/` teacher surface**, or a formal
+**accessibility audit** (WCAG 2.1 AA). Language Access **LA-10** (authored-content
+translation) remains blocked on product design.

--- a/docs/initiatives/2026-mobile-shell-pwa-offline.md
+++ b/docs/initiatives/2026-mobile-shell-pwa-offline.md
@@ -99,12 +99,16 @@ not the exception, and an installable PWA removes the app-store barrier entirely
 - **MSO-10 — Batch 2 close-out.** Manual offline-write test doc + ledger + STATUS.
   **Docs.**
 
-### Later phases (not yet scoped)
+### Later phases
 
-- **Route-level mobile layouts:** per-route mobile-first layouts beyond the shared
-  shell, where dense teacher tables still overflow on phones. **← next batch.**
+- ~~**Route-level mobile layouts:** per-route mobile-first layouts beyond the
+  shared shell, where dense teacher tables still overflow on phones.~~ **SHIPPED
+  2026-06-18 (Batch 4, RML-1..5, #382–#385)** — see ledger below.
 - ~~**Push notifications:** due-date reminders as web push.~~ **SHIPPED 2026-06-17
   (Batch 3, MPN-1..5, #375–#379)** — see ledger below.
+
+**Both later phases are now shipped. With the first-phase DoD met (Batch 1), this
+initiative is complete.**
 
 ## Ledger
 
@@ -126,6 +130,22 @@ _(append one row per merged PR)_
 | #377 | MPN-3 | `public/push-handler.js` (`push` → showNotification, `notificationclick` → deep-link) layered via `workbox.importScripts` on the generateSW output; SW-presence guard. Entry chunk unchanged. **New** |
 | #379 | MPN-4 | `usePushSubscription` hook (key-gated supported, requestPermission → subscribe → POST) + dismissible `PushBanner` + ProfilePage toggle + `push.*` i18n (en/hi). **New** |
 | #378 | MPN-5 | `send_due_date_reminders` fans web push alongside email (one opt-out governs both; eligibility broadened to email OR push; deep-link url + collapse tag); `emails.build_due_reminder_push` localized copy. Manual-test doc. **Improve** |
+| #382 | RML-1 | `shared/ui/ResponsiveTable` primitive — real `<table>` at `sm:`+, stacked label/value card list below `sm:` from one `columns`/`rows` def; repo `hidden sm:table` / `sm:hidden` dual-render (no `matchMedia`). First consumer: `ClassHealthPanel` (drops `overflow-x-auto` + `min-w-[22rem]`). On `/design`. Entry chunk unchanged. **New** |
+| #383 | RML-2 | `TeacherAssignmentDetailPage` submissions `<table>` → `ResponsiveTable`; opportunistically localized the page's hardcoded English (it had slipped LA-6) — `teacher.ad*` keys in en+hi, dates via `useFormat()`. **Improve** |
+| #384 | RML-3 | `CreateQuestionPage` fixed grids → mobile-first: AI panel `grid-cols-3` → `grid-cols-1 sm:grid-cols-3`, chapter `grid-cols-2` → `grid-cols-1 sm:grid-cols-2`; subpart tab buttons `min-h-[44px]` touch target. Presentation only. **Improve** |
+| #385 | RML-4 | `OpenResponseGradingPage` review-form row `flex-wrap` → `flex-col sm:flex-row`; marks input `w-full sm:w-24`, comment `sm:min-w-[12rem]`; response blockquote `break-words`. AI-suggest/finalise flow untouched. **Improve** |
+
+**Batch 4 shipped 2026-06-18** — route-level mobile layouts. The dense teacher
+surfaces that still overflowed horizontally on a phone (Class Health and
+Assignment-detail submissions tables, the Create-Question multi-column grids, and
+the Open-Response grading form) are now readable and usable on a 360 px screen with
+no horizontal scroll — via a small reusable `ResponsiveTable` primitive (RML-1) and
+per-surface mobile-first stacking. RML-2 also folded the assignment-detail page back
+into the LA i18n registry (en+hi) while it was open. The **"route-level mobile
+layouts" later-phase item is shipped**; manual test in
+`docs/perf/2026-06-18-mobile-layouts-manual-test.md`. **With this batch, both later
+phases and the first-phase DoD are done — the Mobile Shell & PWA-Offline initiative
+is complete.**
 
 **Batch 3 shipped 2026-06-17** — web push due-date reminders. A student who
 installs OpenShiksha to their home screen can opt in (banner / ProfilePage

--- a/docs/initiatives/STATUS.md
+++ b/docs/initiatives/STATUS.md
@@ -11,20 +11,30 @@
 > it is the only thing with open work. It is intentionally **omitted from the
 > priority table below** so it is never picked as the "top active initiative."
 
-**Last updated:** 2026-06-17 (latest) — **Mobile Shell & PWA-Offline — Batch 3
+**Last updated:** 2026-06-18 (latest) — **Mobile Shell & PWA-Offline — Batch 4
+(RML-1..5) SHIPPED: route-level mobile layouts — INITIATIVE COMPLETE**
+([plan](../daily-plans/2026-06-18-plan.md), [#382](https://github.com/openshiksha/openshiksha/pull/382)–[#385](https://github.com/openshiksha/openshiksha/pull/385)).
+The dense teacher surfaces that still overflowed horizontally on a phone are now
+readable at 360 px: a reusable `shared/ui/ResponsiveTable` primitive (real `<table>`
+at `sm:`+, stacked label/value cards below — repo `hidden sm:table`/`sm:hidden`
+dual-render, no `matchMedia`) — first consumer ClassHealthPanel (RML-1, #382) →
+assignment-detail submissions table → cards, plus the page localized back into the
+LA registry (it had slipped LA-6) (RML-2, #383) → CreateQuestionPage fixed grids →
+mobile-first `grid-cols-1 sm:grid-cols-*` + 44 px tab targets (RML-3, #384) →
+OpenResponseGradingPage review form stacks `flex-col sm:flex-row` + `break-words`
+(RML-4, #385). Frontend-only, entry chunk unchanged. **With both later phases (web
+push, route-level layouts) and the first-phase DoD done, the Mobile Shell &
+PWA-Offline initiative is COMPLETE.** No unblocked next bet — the next planning run
+promotes a fresh top initiative (candidates below).
+
+**Earlier (2026-06-17)** — **Mobile Shell & PWA-Offline — Batch 3
 (MPN-1..5) SHIPPED: web push due-date reminders**
 ([plan](../daily-plans/2026-06-17-plan.md), [#375](https://github.com/openshiksha/openshiksha/pull/375)–[#379](https://github.com/openshiksha/openshiksha/pull/379)).
-The **mobile-native notification channel** is now live: `PushSubscription` model +
-VAPID config + `pywebpush` (MPN-1, #375) → subscribe/unsubscribe API +
-`send_web_push` stale-pruning helper (MPN-2, #376) → `public/push-handler.js`
-(`push`+`notificationclick`) layered on the MSO-3 SW via `workbox.importScripts`,
-no strategy change (MPN-3, #377) → `usePushSubscription` hook + localized opt-in
-banner + ProfilePage toggle (MPN-4, #379) → web push fanned out from the existing
-`send_due_date_reminders` task (MPN-5, #378). Reused MSO-3's service worker,
-MSO-1's icons, the LA i18n registry, and the existing reminder task — every piece
-rode shipped infra. Email stays source of truth; push is additive and never fails
-the reminder run. **Only the final later-phase remains: route-level mobile
-layouts** (dense teacher tables → cards) before the initiative is complete.
+The **mobile-native notification channel**: `PushSubscription` model + VAPID +
+`pywebpush` (MPN-1) → subscribe/unsubscribe API + `send_web_push` (MPN-2) →
+`public/push-handler.js` on the MSO-3 SW (MPN-3) → `usePushSubscription` hook +
+opt-in banner + ProfilePage toggle (MPN-4) → web push fanned from
+`send_due_date_reminders` (MPN-5). Email stays source of truth; push is additive.
 
 **Earlier (2026-06-15)** — **Mobile Shell & PWA-Offline — Batch 2
 (MSO-6..10) SHIPPED: offline *write*-tolerance**
@@ -195,7 +205,7 @@ at 160 kB defends the cut.
 
 | Priority | Initiative | Status | Headline progress | Next increment |
 |:--:|---|---|---|---|
-| 1 | [Mobile Shell & PWA-Offline](2026-mobile-shell-pwa-offline.md) | **Active** | **Batch 1 (MSO-1..5) shipped 2026-06-14** ([#358](https://github.com/openshiksha/openshiksha/pull/358)–[#362](https://github.com/openshiksha/openshiksha/pull/362)): installable PWA + offline *read*-tolerance (manifest/maskable icons, service worker precache, persisted React Query cache, localized offline banner, A2HS prompt). **Batch 2 (MSO-6..10) shipped 2026-06-15** ([#367](https://github.com/openshiksha/openshiksha/pull/367)–[#370](https://github.com/openshiksha/openshiksha/pull/370)): offline *write*-tolerance — queue + replay auto-saves/submissions. **Batch 3 (MPN-1..5) shipped 2026-06-17** ([#375](https://github.com/openshiksha/openshiksha/pull/375)–[#379](https://github.com/openshiksha/openshiksha/pull/379)): web push due-date reminders (PushSubscription + VAPID, subscribe/unsubscribe API + send_web_push, SW push handler, opt-in hook/banner/toggle, reminder fan-out). | **Route-level mobile layouts** — dense teacher tables (`ClassHealthPanel`, `TeacherAssignmentDetailPage`) → responsive cards on phones. Last later-phase; then initiative complete. |
+| 1 | [Mobile Shell & PWA-Offline](2026-mobile-shell-pwa-offline.md) | **Done** | **Batch 1 (MSO-1..5) shipped 2026-06-14** ([#358](https://github.com/openshiksha/openshiksha/pull/358)–[#362](https://github.com/openshiksha/openshiksha/pull/362)): installable PWA + offline *read*-tolerance. **Batch 2 (MSO-6..10) shipped 2026-06-15** ([#367](https://github.com/openshiksha/openshiksha/pull/367)–[#370](https://github.com/openshiksha/openshiksha/pull/370)): offline *write*-tolerance — queue + replay. **Batch 3 (MPN-1..5) shipped 2026-06-17** ([#375](https://github.com/openshiksha/openshiksha/pull/375)–[#379](https://github.com/openshiksha/openshiksha/pull/379)): web push due-date reminders. **Batch 4 (RML-1..5) shipped 2026-06-18** ([#382](https://github.com/openshiksha/openshiksha/pull/382)–[#385](https://github.com/openshiksha/openshiksha/pull/385)): route-level mobile layouts — `ResponsiveTable` primitive + dense teacher tables/forms → responsive on phones. **First-phase DoD + both later phases done → initiative complete.** | **No unblocked next bet.** The next planning run promotes a fresh top initiative — candidates: **AI-tutor rebase** (`ai/2026-06-04-ai-tutor-chat`, ~5k-line diverged branch), an **`/ai/predictions/` teacher surface**, or an **accessibility audit (WCAG 2.1 AA)**. LA-10 (authored-content translation) stays blocked on product design. |
 | 2 | [Language Access — i18n en/हिंदी/मराठी](2026-language-access.md) | **Done-but-for-LA-10 (blocked)** | **LA-1..9 shipped.** Foundation + EN\|हिं switcher, `preferred_language` end-to-end, student/parent/public/teacher surfaces, AI content + emails in the reader's language, `Intl` date/number helper ([#308](https://github.com/openshiksha/openshiksha/pull/308)–[#326](https://github.com/openshiksha/openshiksha/pull/326)). **LA-9 closed 2026-06-13** — N-locale registry + pilot-coverage parity ([#349](https://github.com/openshiksha/openshiksha/pull/349)) then **Marathi (मरा)** as pure content across the anonymous journey, student loop, and parent dashboard + a backend mr→en AI fallback guard ([#350](https://github.com/openshiksha/openshiksha/pull/350)–[#353](https://github.com/openshiksha/openshiksha/pull/353)). The framework now makes a new language config + content, no code change. | **LA-10** (authored-content/question translation) — blocked on product design, do not start without promotion. Then **Mobile shell / PWA-offline** |
 | - | [AI Surface Activation](ai-surface-activation.md) | Done | **Closed 2026-06-11 — North Star reached.** ASA-1..9 shipped across [#285](https://github.com/openshiksha/openshiksha/pull/285)–[#289](https://github.com/openshiksha/openshiksha/pull/289), [#293](https://github.com/openshiksha/openshiksha/pull/293)–[#302](https://github.com/openshiksha/openshiksha/pull/302): all four dark `/ai/` endpoint groups lit (explanations, misconception clusters, assignment drafts, open-response grading), error-as-empty-state sweep complete, shared `AIBadge` provenance, server-side SRS guard. Close ([#303](https://github.com/openshiksha/openshiksha/pull/303)): [endpoint-consumer map](../ai-features/endpoint-consumer-map.md) + DoD audit — 17 endpoints directly consumed, 4 indirect by design, 1 API-only (`/ai/predictions/`). | `useAsyncGeneration` refactor carried to maintenance; `/ai/predictions/` surface is a future product call |
 | - | [Authoring Integrity & Versioning](authoring-integrity-versioning.md) | Done | **All three phases shipped 2026-06-08/09.** Phase 1 (AIV-1..3, [#270](https://github.com/openshiksha/openshiksha/pull/270)–[#274](https://github.com/openshiksha/openshiksha/pull/274)): snapshot foundation + grader/student readers + edit-safety UI. Phase 2 (AIV-4/5, [#276](https://github.com/openshiksha/openshiksha/pull/276)–[#277](https://github.com/openshiksha/openshiksha/pull/277)): editable preview + drift surface. Phase 3 (AIV-6/7/8, [#279](https://github.com/openshiksha/openshiksha/pull/279)–[#281](https://github.com/openshiksha/openshiksha/pull/281)): guarded re-sync + `ProblemSetVersion` dedup + version history & diff UI. DoD met end-to-end. | - |

--- a/docs/perf/2026-06-18-mobile-layouts-manual-test.md
+++ b/docs/perf/2026-06-18-mobile-layouts-manual-test.md
@@ -1,0 +1,81 @@
+# Manual test — Route-level mobile layouts (Batch 4)
+
+**Date:** 2026-06-18
+**Covers:** RML-1..4 (#382–#385) — dense teacher surfaces made readable on a phone.
+
+These are pure responsive-layout changes behind the Tailwind `sm:` breakpoint
+(640 px). Verify in Chrome DevTools **device toolbar** at a phone width
+(**360–390 px**, e.g. "iPhone SE" / a 360 px custom width) and again at a desktop
+width to confirm the desktop layout is unchanged.
+
+## How to run
+
+```bash
+cd frontend_modern && npm run dev
+```
+
+Log in as a **teacher** (the affected surfaces are all teacher routes). Open
+DevTools → toggle the device toolbar → set the viewport to 360 px wide.
+
+## Acceptance — for every surface below
+
+- [ ] **No horizontal scroll** at 360 px (the page never scrolls sideways; no
+      pinch-zoom needed).
+- [ ] **Every column / field is legible** — nothing clipped or truncated to
+      illegibility.
+- [ ] **Touch targets ≥ 44 px** for interactive controls (tabs, buttons, inputs).
+- [ ] At `≥ sm` (≥ 640 px) the surface looks **identical to before** (these are
+      refactors, not redesigns).
+
+## Surfaces
+
+### 1. Class Health (RML-1) — `ResponsiveTable`
+
+- Teacher dashboard → a subject-room card → expand **"Class Health"** (needs
+  class-insight data; trigger from the panel if empty).
+- [ ] At 360 px the Chapter / Avg / Struggling / Status table renders as a
+      **stacked card list** — chapter name as the card heading, the other three as
+      label/value rows. No horizontal scroll.
+- [ ] At ≥ 640 px it is the **original 4-column table** (header row, hover, status
+      dot + label).
+- [ ] The `/design` route → "Responsive table" section shows the same swap as you
+      cross 640 px.
+
+### 2. Assignment-detail submissions (RML-2)
+
+- Teacher dashboard → an assignment → **"Student Submissions"**.
+- [ ] At 360 px each submission is a **card**: student name heading, then
+      Submitted / Score / Status as label/value rows. No horizontal scroll.
+- [ ] At ≥ 640 px it is the original Student / Submitted / Score / Status table.
+- [ ] Score badge colours (green ≥70 / amber ≥40 / rose) and the ✓ Submitted /
+      ⏳ Pending status pills are preserved.
+- [ ] **Localization:** switch the language to **हिं** — the page heading
+      ("छात्रों के सबमिशन"), stat labels, badges, and dates all render in Hindi
+      (this page previously had hardcoded English).
+
+### 3. Create-Question form (RML-3)
+
+- Teacher → **Create Question** (`/teacher/questions/new`).
+- [ ] At 360 px the AI-panel **Type / Difficulty / Count** selectors stack into
+      one column per row (not three squeezed columns).
+- [ ] The **Subject / Standard** chapter selectors stack into one column per row.
+- [ ] The subpart **tab strip** scrolls horizontally and each tab is ≥ 44 px tall
+      / easily tappable.
+- [ ] The KaTeX preview sits **below** the question-text input (single column).
+
+### 4. Open-Response grading (RML-4)
+
+- Teacher → **Open-response grading** queue → an `ai_graded` item.
+- [ ] At 360 px the review form's **Final marks** input and **Comment** field
+      stack into one full-width column each (not crowded side-by-side).
+- [ ] The Accept / Save button is full-width-reachable and the AI provenance row
+      (`✨ AI-generated` badge, confidence) is not clipped.
+- [ ] A very long student response **wraps** inside the blockquote (no horizontal
+      scroll from an unbroken token).
+
+## Notes
+
+- No backend, no new dependency, no schema change — frontend-only.
+- Every PR ran `npm run test` / `tsc --noEmit` / `eslint` / `npm run build`; the
+  entry chunk is unchanged against the 160 kB CI guard (the `ResponsiveTable`
+  primitive is tiny and imported only into already-lazy teacher routes).


### PR DESCRIPTION
## RML-5 — Route-level mobile layouts: batch close-out

**Classification:** Docs
**Initiative:** Mobile Shell & PWA-Offline — Batch 4 close-out. Docs-only; build/parity CI stays green.

Records the route-level mobile-layouts batch (RML-1..4, [#382](https://github.com/openshiksha/openshiksha/pull/382)–[#385](https://github.com/openshiksha/openshiksha/pull/385)) and **closes the Mobile Shell & PWA-Offline initiative**.

### Changes
- **`docs/initiatives/2026-mobile-shell-pwa-offline.md`** — ledger rows for RML-1..4 + a "Batch 4 shipped 2026-06-18" summary; flipped the "route-level mobile layouts" later-phase to **shipped**; noted both later phases + first-phase DoD are done → **initiative complete**.
- **`docs/perf/2026-06-18-mobile-layouts-manual-test.md`** — new phone-width (360–390 px) manual-test checklist per surface (Class Health, Assignment detail, Create Question, Open-Response grading): no horizontal scroll, legible, ≥44 px touch targets.
- **`docs/changes/2026-06-18-rml-mobile-layouts.md`** — change doc: the `ResponsiveTable` contract + the RML-2 localization decision.
- **`docs/initiatives/STATUS.md`** — Mobile Shell & PWA-Offline → **Done**; headline + priority row updated with a "no unblocked next bet" note (candidates: AI-tutor rebase, `/ai/predictions/` teacher surface, accessibility audit; LA-10 still blocked on product design) so the next planning run picks a fresh top initiative.

> Per the batch's plan, the initiative is marked complete on the strength of #382–#385 (all green: test / tsc / eslint / build, entry chunk unchanged). If any of those PRs slips in review, this close-out should be walked back to leave the initiative Active with the remaining surface noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)