### PR TITLE
security: bump pydantic-settings 2.14.1 → 2.14.2 (GHSA-4xgf-cpjx-pc3j)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -27,7 +27,7 @@ daphne==4.2.2
 
 # Validation & Serialization
 pydantic==2.10.5
-pydantic-settings==2.14.1
+pydantic-settings==2.14.2
 jsonschema==4.25.1  # per-kind widget_config validation (DTB-1); also a drf-spectacular dep
 
 # HTTP Client (for Cabinet API)

--- a/docs/changes/2026-06-19-pydantic-settings-cve.md
+++ b/docs/changes/2026-06-19-pydantic-settings-cve.md
@@ -1,0 +1,45 @@
+# 2026-06-19 — Security: bump pydantic-settings 2.14.1 → 2.14.2 (GHSA-4xgf-cpjx-pc3j)
+
+## What
+
+Bumped the backend pin in `backend/requirements.txt`:
+
+```diff
+-pydantic-settings==2.14.1
++pydantic-settings==2.14.2
+```
+
+A patch-level bump within the 2.14 line. No code changes — `pydantic-settings`
+is consumed only through the existing settings/config plumbing, and the bump
+keeps the same `pydantic` (2.10.5) compatibility floor as 2.14.1.
+
+## Why
+
+A new advisory landed in the pip-audit / GitHub advisory database and started
+**failing the `security` (pip-audit) job in `ci-cd.yaml` on every push to
+`modernization`** — including docs-only commits (first observed on the
+`beacf336` plan commit, run 27859816141). The pipeline was red purely on this:
+
+```
+Found 1 known vulnerability in 1 package
+Name              Version ID                  Fix Versions
+pydantic-settings 2.14.1  GHSA-4xgf-cpjx-pc3j 2.14.2
+```
+
+- **GHSA-4xgf-cpjx-pc3j** (MODERATE): `NestedSecretsSettingsSource` follows
+  symlinks **outside** `secrets_dir`, enabling local file read and bypassing the
+  `secrets_dir_max_size` guard. Vulnerable range `>= 2.12.0, < 2.14.2`; fixed in
+  `2.14.2`.
+
+Bumping to the patched release clears the advisory and turns the pipeline green
+again. Unlike the two long-standing documented ignores in the `security` job
+(twisted `GHSA-grgv-6hw6-v9g4`, pyjwt `PYSEC-2025-183` — both have no usable
+stable fix), this one has a clean patch fix, so we take the fix rather than
+adding another `--ignore-vuln`.
+
+## Risk
+
+Very low. Patch-level dependency bump with a real upstream fix; no application
+code is touched. The full CI gate (lint, typecheck, **security**, test,
+frontend, e2e) re-runs on this PR and confirms the audit is clean and nothing
+regressed.


### PR DESCRIPTION
## What

Bumps `pydantic-settings` `2.14.1 → 2.14.2` in `backend/requirements.txt` (patch-level, no code change).

## Why

A newly-disclosed advisory started **failing the `security` (pip-audit) job in `ci-cd.yaml` on every push to `modernization`** — including docs-only commits (first seen on the `beacf336` plan commit, run [27859816141](https://github.com/openshiksha/openshiksha/actions/runs/27859816141)):

```
Found 1 known vulnerability in 1 package
Name              Version ID                  Fix Versions
pydantic-settings 2.14.1  GHSA-4xgf-cpjx-pc3j 2.14.2
```

**GHSA-4xgf-cpjx-pc3j** (MODERATE): `NestedSecretsSettingsSource` follows symlinks outside `secrets_dir`, enabling local file read and bypassing `secrets_dir_max_size`. Vulnerable range `>= 2.12.0, < 2.14.2`; fixed in `2.14.2`.

Unlike the two long-standing documented ignores in the `security` job (twisted, pyjwt — neither has a usable stable fix), this advisory has a clean patch fix, so we take the fix rather than adding another `--ignore-vuln`. This turns the pipeline green again.

## Compatibility

`2.14.2` requires `pydantic>=2.7.0` (we pin `2.10.5`) and Python `>=3.10` (CI uses 3.12) — no floor change.

## Risk

Very low. Patch-level dependency bump with a real upstream fix; no application code touched. Full CI gate re-runs on this PR and confirms the audit is clean.

See `docs/changes/2026-06-19-pydantic-settings-cve.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)