### PR TITLE
feat(a11y): A11Y-1 — per-route axe baseline + initiative doc

### DIFF
--- a/docs/initiatives/2026-accessibility-wcag-aa.md
+++ b/docs/initiatives/2026-accessibility-wcag-aa.md
@@ -1,0 +1,97 @@
+# Accessibility — WCAG 2.1 AA
+
+> **Status:** Active (promoted 2026-06-19) · **Owner routine:** `openshiksha-execute`
+> · **Tracking board:** [STATUS.md](STATUS.md) · **Batch 1 plan:**
+> [2026-06-19-plan.md](../daily-plans/2026-06-19-plan.md)
+
+## North Star
+
+Every **public** and **student-core** surface passes axe-core WCAG 2.1 AA with
+**zero serious/critical violations, enforced in CI**, and keyboard-only and
+screen-reader users can complete the core journeys (sign in, register, browse,
+practice, submit). Accessibility is a **measured, regression-gated contract** —
+not an aspiration.
+
+## Why now
+
+OpenShiksha serves K-12 students, teachers, and parents across a huge ability and
+device range in India: low-vision users, keyboard-only users, screen-reader users,
+and budget Android browsers. Accessibility here is not polish — it is **access**.
+
+The V2 design system already commits to "Accessible by default"
+([`2026-design-system-v2.md`](2026-design-system-v2.md) principle #7); this
+initiative turns that claim into something **measured and enforced**.
+
+The runway already exists — we are **activating** it, not inventing it:
+
+- devDeps `@axe-core/playwright` + `axe-core` are already present.
+- `e2e/a11y.spec.ts` already runs axe — but only on `/design`, in **reporting
+  mode** (`FAIL_ON_BLOCKING = false`).
+- CI's `frontend-e2e` job already runs `npm run test:e2e` and uploads the axe
+  report as an artifact; `deploy` gates on `frontend-e2e`.
+- **M6-01 (#202)** shipped a *focused* baseline (skip link + `#main-content`
+  landmark in `AppShell`, dialog semantics on the QuestionBank side-sheet, image
+  alt parity) and **explicitly deferred** the full audit "for a dedicated a11y
+  initiative." **This is that initiative.**
+
+## What exists / what to preserve
+
+- The M6-01 foundation: skip link, `#main-content` landmark, dialog pattern.
+- The V2 token system (warm paper / `ink-*`, `brand-600`) and the LA i18n
+  registry (en/hi/mr) — new labels localize through it for free.
+- The existing Playwright `frontend-e2e` CI job + axe artifact upload.
+
+There is nothing to *port*: legacy Django 1.11 templates had no a11y story at all
+(no ARIA, no contrast discipline, no automated checking). This is **net-new
+platform capability**.
+
+## Definition of Done (phased)
+
+1. **Per-route axe baseline measured** across the public surfaces (reporting mode).
+   *(A11Y-1)*
+2. **Static `eslint-plugin-jsx-a11y` lint gate** catches a11y regressions at lint
+   time, CI-enforced at `--max-warnings 0`. *(A11Y-2)*
+3. **Public surfaces remediated** to zero serious/critical blocking violations and
+   **gated** (`gate: true`) so the gain can't regress. *(A11Y-3, A11Y-4, A11Y-5)*
+4. *(future batch)* **Student core-loop surfaces** (assignment detail, dashboard,
+   SRS drill, proficiency) remediated + gated.
+5. *(future)* **Keyboard-only walkthrough + screen-reader spot-check** (NVDA /
+   VoiceOver) sign-off.
+6. *(future)* **Teacher / parent surfaces** remediated + gated; consider an axe CI
+   job that scans authenticated routes against the Docker stack.
+
+## Phase / batch plan
+
+- **Batch 1 (A11Y-1..5)** — *this batch, 2026-06-19*: per-route axe baseline →
+  static jsx-a11y gate → structural (label/landmark/heading) + colour-contrast
+  remediation on the public surfaces → **gate the clean routes**. Establishes the
+  measured, CI-enforced AA contract. (DoD items 1–3.)
+- **Batch 2** — student core-loop surfaces: remediate + gate. (DoD item 4.)
+- **Batch 3** — teacher / parent surfaces: remediate + gate. (DoD item 6.)
+- **Batch 4** — keyboard-only + screen-reader sign-off. (DoD item 5.)
+
+## Per-route axe harness contract
+
+`e2e/a11y.spec.ts` iterates a route table. Each entry:
+
+```ts
+{ name: 'login', path: '/login', gate: false }
+```
+
+For each route the spec navigates, waits for `networkidle` + `document.fonts.ready`
++ a visible `h1`, runs `AxeBuilder().withTags(['wcag2a','wcag2aa','wcag21a','wcag21aa'])`,
+and writes `axe-report/<name>.json` (summary + full violations). When `gate: true`
+the spec **asserts zero serious/critical violations** for that route, turning the
+`frontend-e2e` CI job into a regression gate. When `gate: false` it only records
+(reporting mode). Adding a new surface to the audit = one row in the table; locking
+it in = flip that row's `gate` once it's clean.
+
+## Ledger
+
+| PR | Increment | Class | Summary |
+|---|---|---|---|
+| _A11Y-1_ | Initiative doc + per-route axe baseline | New | This doc + parameterized `e2e/a11y.spec.ts` emitting per-route `axe-report/<route>.json` (reporting mode). |
+| _A11Y-2_ | `eslint-plugin-jsx-a11y` static gate | New | _(filled on merge)_ |
+| _A11Y-3_ | Form-label / landmark / heading-order fixes | Improve | _(filled on merge)_ |
+| _A11Y-4_ | Colour-contrast remediation on V2 tokens | Improve | _(filled on merge)_ |
+| _A11Y-5_ | Gate clean public routes + close-out | New + Docs | _(filled on merge)_ |

--- a/frontend_modern/e2e/a11y.spec.ts
+++ b/frontend_modern/e2e/a11y.spec.ts
@@ -3,66 +3,90 @@ import AxeBuilder from '@axe-core/playwright';
 import fs from 'node:fs';
 import path from 'node:path';
 
-// Accessibility baseline for the /design showcase.
+// Per-route accessibility baseline (axe-core, WCAG 2.1 AA).
 //
-// /design is the living catalog for every V2 "Chalk & Unlock" primitive
-// (docs/initiatives/2026-design-system-v2.md). Running axe-core here gives
-// us a stable place to measure a11y health as the design system grows.
+// Part of the Accessibility — WCAG 2.1 AA initiative
+// (docs/initiatives/2026-accessibility-wcag-aa.md). Every unauthenticated
+// surface gets its own axe scan; the result is written to
+// `axe-report/<name>.json` (uploaded as a CI artifact alongside the Playwright
+// HTML report) and the by-impact counts are logged to the test output.
 //
-// **Reporting mode (not gating).** A full WCAG 2.1 AA pass is a planned
-// future initiative (see docs/initiatives/STATUS.md backlog). Until that
-// initiative starts, this spec only records violations: it writes a JSON
-// summary to `axe-report/design.json` (uploaded as a CI artifact alongside
-// the Playwright HTML report) and logs counts to the test output. It does
-// not fail on findings — flip `FAIL_ON_BLOCKING` to `true` once the AA pass
-// begins and the known showcase noise (intentional low-contrast swatches,
-// sandboxed widget iframe) has been triaged.
-const FAIL_ON_BLOCKING = false;
+// **Gating is per-route.** A route with `gate: true` asserts zero
+// serious/critical (blocking) violations — turning CI's `frontend-e2e` job into
+// a regression gate for that surface. A route with `gate: false` only records
+// (reporting mode). Batch 1 (A11Y-1) lands every route in reporting mode to
+// produce the fix inventory; A11Y-5 flips the cleaned public routes to
+// `gate: true`. `/design` deliberately renders edge cases (intentional
+// low-contrast swatches, sandboxed widget iframe) so it stays reporting-mode
+// until that known noise is triaged/annotated.
+interface AuditRoute {
+  name: string;
+  path: string;
+  gate: boolean;
+}
 
-test.describe('/design — accessibility (axe-core baseline)', () => {
-  test('records axe-core violations', async ({ page }, testInfo) => {
-    await page.goto('/design');
-    await expect(page.locator('h1').first()).toBeVisible();
+const ROUTES: AuditRoute[] = [
+  { name: 'home', path: '/', gate: false },
+  { name: 'login', path: '/login', gate: false },
+  { name: 'register', path: '/register', gate: false },
+  { name: 'register-school', path: '/register/school', gate: false },
+  { name: 'register-open', path: '/register/open', gate: false },
+  { name: 'enquire', path: '/enquire', gate: false },
+  { name: 'design', path: '/design', gate: false },
+];
 
-    const results = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-      .analyze();
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
 
-    const byImpact: Record<string, number> = {};
-    for (const v of results.violations) {
-      const key = v.impact ?? 'unknown';
-      byImpact[key] = (byImpact[key] ?? 0) + 1;
-    }
-    const blocking = results.violations.filter(
-      (v) => v.impact === 'serious' || v.impact === 'critical',
-    );
+test.describe('public surfaces — accessibility (axe-core)', () => {
+  for (const route of ROUTES) {
+    test(`${route.name} (${route.path})`, async ({ page }, testInfo) => {
+      await page.goto(route.path);
+      // Settle async chrome (fonts, lazy chunks) before the scan so contrast
+      // and structure are measured against the final rendered UI, and keep a
+      // reporting spec from flaking on a slow paint.
+      await page.waitForLoadState('networkidle');
+      await page.evaluate(() => document.fonts.ready);
+      await expect(page.locator('h1').first()).toBeVisible();
 
-    const summary = {
-      url: '/design',
-      total: results.violations.length,
-      byImpact,
-      blocking: blocking.map((v) => ({
-        id: v.id,
-        impact: v.impact,
-        help: v.help,
-        nodes: v.nodes.length,
-      })),
-    };
+      const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
 
-    const reportDir = path.join(testInfo.project.outputDir, '..', 'axe-report');
-    fs.mkdirSync(reportDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(reportDir, 'design.json'),
-      JSON.stringify({ summary, violations: results.violations }, null, 2),
-    );
+      const byImpact: Record<string, number> = {};
+      for (const v of results.violations) {
+        const key = v.impact ?? 'unknown';
+        byImpact[key] = (byImpact[key] ?? 0) + 1;
+      }
+      const blocking = results.violations.filter(
+        (v) => v.impact === 'serious' || v.impact === 'critical',
+      );
 
-    console.log('[axe] /design summary:', JSON.stringify(summary, null, 2));
+      const summary = {
+        url: route.path,
+        gate: route.gate,
+        total: results.violations.length,
+        byImpact,
+        blocking: blocking.map((v) => ({
+          id: v.id,
+          impact: v.impact,
+          help: v.help,
+          nodes: v.nodes.length,
+        })),
+      };
 
-    if (FAIL_ON_BLOCKING) {
-      expect(
-        blocking,
-        `axe-core blocking violations on /design:\n${JSON.stringify(summary.blocking, null, 2)}`,
-      ).toEqual([]);
-    }
-  });
+      const reportDir = path.join(testInfo.project.outputDir, '..', 'axe-report');
+      fs.mkdirSync(reportDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(reportDir, `${route.name}.json`),
+        JSON.stringify({ summary, violations: results.violations }, null, 2),
+      );
+
+      console.log(`[axe] ${route.path} summary:`, JSON.stringify(summary, null, 2));
+
+      if (route.gate) {
+        expect(
+          blocking,
+          `axe-core blocking violations on ${route.path}:\n${JSON.stringify(summary.blocking, null, 2)}`,
+        ).toEqual([]);
+      }
+    });
+  }
 });


### PR DESCRIPTION
## Classification
**New** — net-new platform capability. Legacy Django 1.11 had no accessibility story to port.

## Summary
Promotes **Accessibility — WCAG 2.1 AA** to an active initiative (per the [2026-06-19 daily plan](../blob/modernization/docs/daily-plans/2026-06-19-plan.md)) and stands up the **per-route axe measurement runway**.

- **New** `docs/initiatives/2026-accessibility-wcag-aa.md` — North Star, phased DoD, per-route harness contract, batch plan, ledger.
- **Generalizes** `e2e/a11y.spec.ts` from the single `/design` test into a **parameterized route table** covering every unauthenticated surface: `/`, `/login`, `/register`, `/register/school`, `/register/open`, `/enquire`, `/design`.
  - Each route navigates, waits for `networkidle` + `document.fonts.ready` + a visible `h1`, runs axe with `['wcag2a','wcag2aa','wcag21a','wcag21aa']`, and writes `axe-report/<name>.json` (already uploaded by the CI `frontend-e2e` job).
  - Per-route **`gate`** flag — reporting-mode (`gate:false`) everywhere in this PR; A11Y-5 flips the cleaned public routes to `gate:true` to lock the gain.

## Baseline inventory (this run)
Public surfaces are **already clean** — `/`, `/login`, `/register`, `/register/school`, `/register/open`, `/enquire` all report **0 violations**. Only `/design` shows 2 blocking findings (6× `color-contrast` = intentional showcase swatches; 2× `label`), so it stays reporting-mode. This inventory drives the rest of the batch (a focused `/design` label fix + gating the clean routes).

## Tests
`npx playwright test a11y` — **7 passed** (all routes, reporting-mode). CI `frontend-e2e` stays green regardless of findings.

## How to verify
`cd frontend_modern && npx playwright test a11y` then inspect `axe-report/*.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)