### PR TITLE
feat(a11y): A11Y-2 — eslint-plugin-jsx-a11y static gate

### DIFF
--- a/frontend_modern/eslint.config.js
+++ b/frontend_modern/eslint.config.js
@@ -4,12 +4,21 @@ import tsParser from '@typescript-eslint/parser';
 import tsPlugin from '@typescript-eslint/eslint-plugin';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
 
 /**
  * Flat config (ESLint 9+/10). ESLint 10 removed the legacy `.eslintrc` format
  * entirely, so this replaces the old `.eslintrc.cjs`. It is the faithful
  * equivalent: eslint:recommended + @typescript-eslint/recommended +
- * react-hooks/recommended + the react-refresh and unused-vars tweaks.
+ * react-hooks/recommended + jsx-a11y/recommended + the react-refresh and
+ * unused-vars tweaks.
+ *
+ * jsx-a11y is the static accessibility gate for the WCAG 2.1 AA initiative
+ * (docs/initiatives/2026-accessibility-wcag-aa.md, A11Y-2). It complements the
+ * runtime axe audit (e2e/a11y.spec.ts): the lint rules catch a11y regressions
+ * at author time, on every file, before they can reach a route the axe spec
+ * scans. `lint` runs at `--max-warnings 0`, so every rule that fires must be
+ * fixed or carry a one-line rationale below.
  */
 export default [
   // Match the previous `--ext ts,tsx` scope: only TypeScript sources are
@@ -19,6 +28,7 @@ export default [
   js.configs.recommended,
   ...tsPlugin.configs['flat/recommended'],
   reactHooks.configs.flat['recommended-latest'],
+  jsxA11y.flatConfigs.recommended,
   {
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
@@ -33,6 +43,12 @@ export default [
     rules: {
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+      // Our nested `<label>`s wrap the control plus a styled multi-`<span>` text
+      // block (e.g. a bold title over a muted hint), so the accessible text sits
+      // a level deeper than the rule's default `depth: 2`. These are valid,
+      // correctly-associated labels — widen the text search depth rather than
+      // forcing redundant htmlFor/id pairs onto already-correct markup.
+      'jsx-a11y/label-has-associated-control': ['error', { depth: 3 }],
     },
   },
 ];

--- a/frontend_modern/package-lock.json
+++ b/frontend_modern/package-lock.json
@@ -42,6 +42,7 @@
         "autoprefixer": "^10.5.0",
         "axe-core": "^4.12.1",
         "eslint": "^10.5.0",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.4.5",
         "globals": "^17.6.0",
@@ -3785,6 +3786,67 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
@@ -3816,6 +3878,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ast-v8-to-istanbul": {
       "version": "1.0.3",
@@ -3942,6 +4011,16 @@
         "form-data": "^4.0.5",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -4347,6 +4426,13 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -4432,6 +4518,13 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -4848,6 +4941,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-to-primitive": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
@@ -4946,6 +5052,77 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
@@ -6567,6 +6744,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/katex": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.17.0.tgz",
@@ -6591,6 +6784,26 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/leven": {
@@ -7219,6 +7432,44 @@
         "es-object-atoms": "^1.0.0",
         "has-symbols": "^1.1.0",
         "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8632,6 +8883,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/string.prototype.matchall": {

--- a/frontend_modern/package.json
+++ b/frontend_modern/package.json
@@ -57,6 +57,7 @@
     "autoprefixer": "^10.5.0",
     "axe-core": "^4.12.1",
     "eslint": "^10.5.0",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.4.5",
     "globals": "^17.6.0",
@@ -73,5 +74,10 @@
   "engines": {
     "node": ">=20.19.0",
     "npm": ">=10.0.0"
+  },
+  "overrides": {
+    "eslint-plugin-jsx-a11y": {
+      "eslint": "$eslint"
+    }
   }
 }

--- a/frontend_modern/src/features/design/DesignSystemPage.tsx
+++ b/frontend_modern/src/features/design/DesignSystemPage.tsx
@@ -395,7 +395,7 @@ export const DesignSystemPage = () => (
 
       <Section kicker="Components" title="Section heading">
         <Card className="space-y-6">
-          <SectionHeading eyebrow="Today" title="Practice queue" description="Pick something to work on right now." action={<a href="#" className="text-sm font-semibold text-brand-700 hover:text-brand-800">View all</a>} />
+          <SectionHeading eyebrow="Today" title="Practice queue" description="Pick something to work on right now." action={<button type="button" className="text-sm font-semibold text-brand-700 hover:text-brand-800">View all</button>} />
           <div className="border-t border-ink-100" />
           <SectionHeading title="Recent activity" />
         </Card>

--- a/frontend_modern/src/features/teacher/ProblemSetVersionsPage.tsx
+++ b/frontend_modern/src/features/teacher/ProblemSetVersionsPage.tsx
@@ -100,62 +100,66 @@ export const ProblemSetVersionsPage = () => {
           {rows.map((v) => {
             const state = stateForRow(v.id);
             return (
-              <li
-                key={v.id}
-                data-testid={`version-row-${v.id}`}
-                data-state={state}
-                className={`flex cursor-pointer items-center justify-between gap-3 border-b border-ink-100 px-4 py-3 last:border-b-0 transition-colors ${
-                  state === 'target'
-                    ? 'bg-brand-50'
-                    : state === 'against'
-                      ? 'bg-amber-50'
-                      : 'hover:bg-ink-50'
-                }`}
-                onClick={() => handleRowClick(v)}
-              >
-                <div>
-                  <p className="text-sm font-semibold text-ink-900">
-                    {t('psVersions.version', { number: v.version_number })}
-                    {state === 'target' && (
-                      <span className="ml-2 rounded bg-brand-200 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-brand-900">
-                        {t('psVersions.target')}
-                      </span>
-                    )}
-                    {state === 'against' && (
-                      <span className="ml-2 rounded bg-amber-200 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-amber-900">
-                        {t('psVersions.against')}
-                      </span>
-                    )}
-                  </p>
-                  <p className="mt-0.5 text-xs text-ink-500">
-                    {formatDate(v.created_at, {
-                      day: 'numeric',
-                      month: 'short',
-                      year: 'numeric',
-                      hour: '2-digit',
-                      minute: '2-digit',
-                    })}
-                    {v.created_by_name && <> · {v.created_by_name}</>}
-                  </p>
-                </div>
-                <div className="text-right text-xs text-ink-500">
-                  <p>
-                    {t(
-                      v.question_count === 1
-                        ? 'psVersions.questionsCountOne'
-                        : 'psVersions.questionsCountMany',
-                      { count: v.question_count },
-                    )}
-                  </p>
-                  <p
-                    className={`mt-0.5 ${v.assignment_count > 0 ? 'font-semibold text-ink-700' : ''}`}
-                  >
-                    {t(
-                      v.assignment_count === 1 ? 'psVersions.pinnedOne' : 'psVersions.pinnedMany',
-                      { count: v.assignment_count },
-                    )}
-                  </p>
-                </div>
+              <li key={v.id} className="border-b border-ink-100 last:border-b-0">
+                {/* Native <button> for built-in keyboard/focus semantics; the
+                    row content is all non-interactive text. */}
+                <button
+                  type="button"
+                  data-testid={`version-row-${v.id}`}
+                  data-state={state}
+                  onClick={() => handleRowClick(v)}
+                  className={`flex w-full cursor-pointer items-center justify-between gap-3 px-4 py-3 text-left transition-colors ${
+                    state === 'target'
+                      ? 'bg-brand-50'
+                      : state === 'against'
+                        ? 'bg-amber-50'
+                        : 'hover:bg-ink-50'
+                  }`}
+                >
+                  <span className="block">
+                    <span className="block text-sm font-semibold text-ink-900">
+                      {t('psVersions.version', { number: v.version_number })}
+                      {state === 'target' && (
+                        <span className="ml-2 rounded bg-brand-200 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-brand-900">
+                          {t('psVersions.target')}
+                        </span>
+                      )}
+                      {state === 'against' && (
+                        <span className="ml-2 rounded bg-amber-200 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-amber-900">
+                          {t('psVersions.against')}
+                        </span>
+                      )}
+                    </span>
+                    <span className="mt-0.5 block text-xs text-ink-500">
+                      {formatDate(v.created_at, {
+                        day: 'numeric',
+                        month: 'short',
+                        year: 'numeric',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}
+                      {v.created_by_name && <> · {v.created_by_name}</>}
+                    </span>
+                  </span>
+                  <span className="block text-right text-xs text-ink-500">
+                    <span className="block">
+                      {t(
+                        v.question_count === 1
+                          ? 'psVersions.questionsCountOne'
+                          : 'psVersions.questionsCountMany',
+                        { count: v.question_count },
+                      )}
+                    </span>
+                    <span
+                      className={`mt-0.5 block ${v.assignment_count > 0 ? 'font-semibold text-ink-700' : ''}`}
+                    >
+                      {t(
+                        v.assignment_count === 1 ? 'psVersions.pinnedOne' : 'psVersions.pinnedMany',
+                        { count: v.assignment_count },
+                      )}
+                    </span>
+                  </span>
+                </button>
               </li>
             );
           })}

--- a/frontend_modern/src/features/teacher/QuestionBankPage.tsx
+++ b/frontend_modern/src/features/teacher/QuestionBankPage.tsx
@@ -142,6 +142,10 @@ const AddToProblemSetSheet = ({
   };
 
   return (
+    // Backdrop click-to-dismiss is a pointer-only convenience; keyboard users
+    // close via Escape (handled in the effect above) or the panel's own close
+    // control, so no key handler is needed on the overlay itself.
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
     <div
       className="fixed inset-0 z-50 flex justify-end bg-ink-900/40 backdrop-blur-sm"
       onClick={(e) => e.target === e.currentTarget && onClose()}

--- a/frontend_modern/src/features/teacher/ResyncAssignmentModal.tsx
+++ b/frontend_modern/src/features/teacher/ResyncAssignmentModal.tsx
@@ -53,6 +53,10 @@ export function ResyncAssignmentModal({ assignmentId, open, onClose, onApplied }
   };
 
   return (
+    // Backdrop click-to-dismiss is a pointer-only convenience; keyboard users
+    // close via Escape (handled in the effect above) or the dialog's own close
+    // control, so no key handler is needed on the overlay itself.
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events
     <div
       role="dialog"
       aria-modal="true"


### PR DESCRIPTION
## Classification
**New** — net-new platform capability (static a11y lint gate). Nothing to port from legacy.

## Summary
Adds the **static accessibility lint gate** for the [WCAG 2.1 AA initiative](../blob/modernization/docs/initiatives/2026-accessibility-wcag-aa.md) (A11Y-2). It complements the runtime axe audit (A11Y-1, #389): `eslint-plugin-jsx-a11y` catches a11y regressions **at author time, on every file**, before they can reach a route the axe spec scans. CI-enforced at `--max-warnings 0`.

### Changes
- Wire `jsxA11y.flatConfigs.recommended` into the flat ESLint config.
- npm **`overrides`** pins jsx-a11y's stale `eslint` peer range (caps at `^9`) to the repo's eslint (`$eslint` = `^10`), so `npm ci` / `npm install` resolve cleanly **without `--legacy-peer-deps`**. Dev-only dep — **zero runtime/bundle impact**.
- Fix the **11 hits** it surfaced (8 files):
  - `label-has-associated-control` → widen rule `depth` to 3. Our nested `<label>`s wrap the control plus a styled multi-`<span>` text block — valid, correctly-associated labels whose text just sits a level deeper than the rule's default.
  - `ProblemSetVersionsPage` clickable `<li>` row → native full-width `<button>` (built-in keyboard/focus); `<p>` content → `<span class="block">` for valid button content. `testid`/`data-state`/`onClick` stay on the same element so existing tests are unaffected.
  - `DesignSystemPage` demo `<a href="#">` → `<button>` (`anchor-is-valid`).
  - Resync / QuestionBank modal backdrops → line-level disable **with rationale**: backdrop click-to-dismiss is a pointer-only convenience; both already close on **Escape**, so the overlay needs no key handler.

## Tests
- `npm run lint` — green at `--max-warnings 0`.
- `npx tsc --noEmit` — clean.
- `npx vitest run` — **467 passed** (incl. `ProblemSetVersionsPage.test.tsx`).
- `npm run build` + budget — entry **152.36 kB** < 160 kB guard.

## How to verify
`cd frontend_modern && npm ci && npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)