### PR TITLE
ci(dependabot): merge after CI instead of broken native auto-merge

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -1,74 +1,98 @@
 name: Dependabot auto-merge
-# Auto-approves and enables auto-merge for Dependabot version-update PRs that
-# are *minor* or *patch* bumps. Majors (e.g. django 4.2 → 6.0, eslint 8 → 10)
-# are runtime/API upgrades that need a human to review against CI and mypy, so
-# they are deliberately left for manual handling — this workflow takes no
-# action on them.
+# Auto-merges Dependabot version-update PRs that are *minor* or *patch* bumps,
+# once the full CI pipeline is green. Majors (e.g. django 4.2 → 6.0, eslint 8 →
+# 10) are runtime/API upgrades that need a human to review against CI and mypy,
+# so they are deliberately left for manual handling.
 #
-# Why this exists: the dependabot config (.github/dependabot.yml) groups routine
-# minor/patch bumps, but they still pile up unattended (20+ open at one point).
-# Every PR already runs the full CI gate (lint, typecheck, security, test,
-# frontend, e2e, dependency-review) plus branch protection, so a green
-# minor/patch bump is safe to land without manual clicks. Auto-merge only
-# completes once those required checks pass — this workflow just queues it.
+# Why this exists: routine minor/patch bumps otherwise pile up unattended (20+
+# open at one point). Every PR already runs the full CI gate (lint, typecheck,
+# security, test, frontend, e2e, lighthouse), so a green minor/patch bump is
+# safe to land without manual clicks.
 #
-# ── Prerequisites (configured once by a repo admin) ──────────────────────────
-#   1. Settings → General → "Allow auto-merge"  → enabled.
-#   2. Settings → Actions → General → "Allow GitHub Actions to create and
-#      approve pull requests" → enabled (so the auto-approve step below
-#      satisfies the "Require approvals: 1" branch-protection rule — see
-#      docs/infra/branch-protection.md).
-#   3. Branch protection on `modernization` with required status checks (already
-#      documented). Without required checks, `--auto` merges immediately rather
-#      than waiting for CI.
+# Why we wait-then-merge instead of `gh pr merge --auto`: GitHub's native
+# auto-merge can only be *enabled* while a PR is blocked by **required status
+# checks** — i.e. the base branch has branch protection. Our integration branch
+# `modernization` is intentionally unprotected (the build routines push to it
+# directly, which required checks would reject), so `--auto` fails with
+# "Pull request is in unstable status (enablePullRequestAutoMerge)" and nothing
+# ever merges. Instead we watch this commit's "CI/CD Pipeline" run and, when it
+# succeeds, merge directly. Same CI gate — we just poll for it rather than
+# delegating to a branch-protection rule that doesn't exist.
 #
-# This is a separate workflow from ci-cd.yaml because it must trigger on the
-# `pull_request` event (ci-cd.yaml is push-triggered) and is scoped to the
-# Dependabot actor.
+# Trigger is `pull_request` (not push) so `dependabot/fetch-metadata` has the PR
+# context it needs to classify the bump (it also handles grouped updates). For
+# Dependabot-authored runs GitHub honours the elevated `permissions` below.
 
 on: pull_request
 
-# Least-privilege: only what's needed to approve and queue the merge.
+# Cancel a stale auto-merge run if Dependabot force-pushes (rebase) a newer
+# commit onto the same PR — we only ever want to act on the latest head.
+concurrency:
+    group: dependabot-automerge-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
+# Least-privilege: only what's needed to approve and merge.
 permissions:
     contents: write
     pull-requests: write
 
 jobs:
     dependabot-automerge:
-        name: Approve + enable auto-merge (minor/patch)
+        name: Approve + auto-merge after CI (minor/patch)
         runs-on: ubuntu-latest
-        # Only act on Dependabot-authored PRs. For these runs GitHub grants the
-        # GITHUB_TOKEN the permissions declared above (no repo secrets are
-        # exposed), which is enough to approve and enable auto-merge.
+        # Only act on Dependabot-authored PRs.
         if: github.actor == 'dependabot[bot]'
+        # Cap the CI wait so a hung/cancelled pipeline never pins a runner.
+        timeout-minutes: 30
         steps:
             - name: Fetch Dependabot metadata
-              # Exposes the semver update-type and other facts about the bump
-              # without parsing the PR title ourselves.
+              # Exposes the semver update-type (incl. for grouped updates, where
+              # it reports the highest bump in the group) without parsing titles.
               id: metadata
               uses: dependabot/fetch-metadata@v2
               with:
                 github-token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Approve the PR
-              # Satisfies the "Require approvals: 1" rule so auto-merge can
-              # complete once checks are green. Scoped to minor/patch only.
+              # A record of automated approval. Not required to merge an
+              # unprotected branch, so never let it block the merge.
               if: |
                 steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
                 steps.metadata.outputs.update-type == 'version-update:semver-patch'
+              continue-on-error: true
               env:
                 PR_URL: ${{ github.event.pull_request.html_url }}
                 GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: gh pr review --approve "$PR_URL"
 
-            - name: Enable auto-merge for minor/patch updates
-              # `--auto` queues the merge; GitHub completes it only after all
-              # required status checks pass. `--squash` keeps the dep history to
-              # a single commit per bump.
+            - name: Wait for CI to pass, then squash-merge
               if: |
                 steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
                 steps.metadata.outputs.update-type == 'version-update:semver-patch'
               env:
+                REPO: ${{ github.repository }}
+                BRANCH: ${{ github.event.pull_request.head.ref }}
+                SHA: ${{ github.event.pull_request.head.sha }}
                 PR_URL: ${{ github.event.pull_request.html_url }}
                 GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: gh pr merge --auto --squash "$PR_URL"
+              run: |
+                set -euo pipefail
+                echo "Waiting for the CI/CD Pipeline run on ${SHA} ..."
+                conclusion=""
+                for _ in $(seq 1 60); do
+                  run=$(gh run list --repo "$REPO" --workflow "CI/CD Pipeline" \
+                          --branch "$BRANCH" --limit 20 \
+                          --json headSha,status,conclusion \
+                          --jq "map(select(.headSha == \"$SHA\")) | .[0] // empty")
+                  if [ -n "$run" ] && [ "$(echo "$run" | jq -r '.status')" = "completed" ]; then
+                    conclusion=$(echo "$run" | jq -r '.conclusion')
+                    break
+                  fi
+                  sleep 20
+                done
+                if [ "$conclusion" != "success" ]; then
+                  echo "CI did not pass (conclusion='${conclusion:-timeout}') — leaving the PR for manual handling."
+                  exit 0
+                fi
+                echo "CI is green — squash-merging."
+                gh pr merge --squash --delete-branch "$PR_URL"


### PR DESCRIPTION
## Problem

The `Dependabot auto-merge` job approves each PR but then fails at
`gh pr merge --auto`:

```
GraphQL: Pull request is in unstable status (enablePullRequestAutoMerge)
```

So green minor/patch Dependabot PRs **never merged** and piled up (the recent batch of #392–#414 all had a red "Approve + enable auto-merge" check and sat until merged by hand).

## Root cause

GitHub can only **enable native auto-merge** while a PR is *blocked by required status checks* — i.e. the base branch has branch protection. `modernization` is intentionally **unprotected** (the scheduled build routines `git push` to it directly, which required-status-checks would reject). With nothing to gate on, the PR sits in `unstable` state and `enablePullRequestAutoMerge` errors. The workflow's old header even listed "branch protection on modernization" as a prerequisite that was never (and can't be) configured here.

## Fix

Keep `dependabot/fetch-metadata` (still classifies the bump, including grouped updates) and the approval record, but replace the `--auto` step with one that **watches this commit's `CI/CD Pipeline` run and squash-merges directly once it concludes `success`**. Same CI gate — we poll for it rather than delegating to a branch-protection rule that doesn't exist.

Also:
- `concurrency` guard cancels a stale run if Dependabot force-pushes a rebase.
- `timeout-minutes: 30` so a hung/cancelled pipeline never pins a runner.
- `approve` is now `continue-on-error` (it's a record, not a merge requirement on an unprotected branch).

Majors are still left untouched for manual review.

## Validation

- `actionlint` (the repo's Workflow Lint gate) passes clean on the file.
- YAML parses; 3 steps (metadata → approve → wait-and-merge).
- Can't fully exercise an Actions workflow locally — the real end-to-end test is the next Dependabot minor/patch PR after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)