### PR TITLE
feat(a11y): brand-shade decision + contrast token sweep + gate home (A11Y-4)

### DIFF
--- a/docs/changes/2026-06-20-a11y-brand-contrast.md
+++ b/docs/changes/2026-06-20-a11y-brand-contrast.md
@@ -1,0 +1,50 @@
+# 2026-06-20 — A11Y-4: Brand-shade decision + contrast token sweep + gate `/`
+
+## Summary
+Resolves the one systemic colour-contrast finding deferred from Accessibility
+Batch 1: white text on `.btn-brand` (`#FF6F00`, ≈ 2.8 : 1) failed WCAG 2.1 AA.
+Makes the brand-shade decision concretely, sweeps small brand-text usages to the
+on-text shade, documents the rule, and flips the home route (`/`) to a gated axe
+surface now that its enabled hero CTA passes.
+
+## Classification
+**Improve** — extends the V2 token system with a documented, enforced contrast
+rule. Frontend-only; no API or schema change.
+
+## The decision
+- `brand-600` (`#FF6F00`) is preserved as the **decorative / large-element
+  anchor** (logo, chalk-underline, large display numerals, borders, focus rings,
+  icon glyphs, big badges) — WCAG only needs 3 : 1 (large/non-text) or nothing
+  (decoration) there, so the vivid brand identity is untouched.
+- `brand-700` is retuned from `#CC5800` (≈ 4.2 : 1, short of AA) to **`#C05300`
+  (≈ 4.7 : 1 white)** — the on-text / CTA brand shade. `brand-800 #9E4500`
+  (≈ 6.1 : 1) stays the hover target.
+
+## What changed
+- `tailwind.config.js`: `brand-700` `#CC5800` → `#C05300`.
+- `src/index.css`: `.btn-brand` fill `bg-brand-600` → `bg-brand-700`, hover
+  `brand-700` → `brand-800`; `.prose-osh a` `text-brand-600` → `text-brand-700`
+  (hover `brand-800`).
+- Swept small brand text (uppercase kickers, text links ≤ `text-sm`) from
+  `text-brand-600` → `text-brand-700` across `HomePage`, `SectionHeading`,
+  `DesignSystemPage`, `CreateAssignmentPage`, `CreateProblemSetPage`,
+  `CreateQuestionPage`, `QuestionBankPage`, `QuestionPreviewPanel`,
+  `WidgetGalleryPanel`, `WidgetDevPage`. Left `text-brand-600` on large display
+  text (`NotFoundPage` 404), decorative SVG icon glyphs, and native form-control
+  accent colours (checkbox/radio `text-brand-600`, a UI-component boundary).
+- `e2e/a11y.spec.ts`: flipped `home` (`/`) to `gate: true`.
+- `docs/initiatives/2026-design-system-v2.md`: documented the Contrast rules +
+  retuned the colour-token table.
+
+## Legacy reference
+None — legacy Django 1.11 had no contrast/accessibility story. Net-new.
+
+## Tests
+- `npm run type-check`, `npm run lint` (`--max-warnings 0`), `npm run build` — green.
+- `npx vitest run` — 77 files / 467 tests pass.
+- Contrast verified by relative-luminance math: white on `#C05300` ≈ 4.69 : 1 (AA pass).
+- The axe gate on `/` runs in CI `frontend-e2e` (Playwright).
+
+## Next steps
+A11Y-FV (focus-visible audit), then the authenticated axe harness (A11Y-6) +
+student core-loop remediation/gating (A11Y-7/8).

--- a/docs/initiatives/2026-design-system-v2.md
+++ b/docs/initiatives/2026-design-system-v2.md
@@ -89,8 +89,9 @@ Established in the kickoff session (2026-05-30):
 
 | Token | Hex | Use |
 |---|---|---|
-| `brand-600` | `#FF6F00` | Primary actions, active state, progress fill, the mark. The "unlock" colour. |
-| `brand-500/700` | `#FB7705` / `#CC5800` | Hover / pressed. |
+| `brand-600` | `#FF6F00` | **Decorative / large-element anchor only** (logo, chalk-underline, large hero numerals, borders, focus rings, big badges, progress fill). White text on it is ≈ 2.8 : 1 — **never `text-white` on `brand-600` for text.** |
+| `brand-700` | `#C05300` | **The on-text / CTA brand shade** — ≥ 4.5 : 1 with white *and* on paper. `.btn-brand` fill and all small brand text/links (`text-brand-700`). |
+| `brand-500/800` | `#FB7705` / `#9E4500` | Decorative accent / hover-pressed (`.btn-brand` hovers to `brand-800`). |
 | `brand-50/100` | `#FFF8F1` / `#FFEEDC` | Tinted backgrounds, soft highlights, app paper. |
 | `ink-900/800` | `#0F0E0D` / `#1A1816` | Headings, chalkboard surfaces. |
 | `ink-600/500` | `#34302B` / `#4A463F` | Body text. |
@@ -101,6 +102,16 @@ Established in the kickoff session (2026-05-30):
 > **Rule:** components reference **tokens only** — never a raw hex. If a needed
 > shade is missing, add it to the token scale (and note it in the ledger), don't
 > inline it.
+
+> **Contrast rules (WCAG 2.1 AA — A11Y-4).**
+> - `brand-600` (`#FF6F00`) is **decorative / large-element only**: the logo,
+>   `chalk-underline`, large display numerals (≥ 24 px, or ≥ 19 px bold → 3 : 1
+>   suffices), borders, focus rings, icon glyphs, big badges. It is **not** an
+>   on-text colour.
+> - For **white text on a brand fill** (`.btn-brand`) and **small brand text/links
+>   on paper**, use **`brand-700` (`#C05300`, ≥ 4.5 : 1)** — `text-brand-700`.
+>   Hover/pressed deepens to `brand-800`.
+> - Never put `text-white` on `brand-600` for text.
 
 ### Typography
 

--- a/frontend_modern/e2e/a11y.spec.ts
+++ b/frontend_modern/e2e/a11y.spec.ts
@@ -42,9 +42,9 @@ const ROUTES: AuditRoute[] = [
   { name: 'register-school', path: '/register/school', gate: true },
   { name: 'register-open', path: '/register/open', gate: true },
   { name: 'enquire', path: '/enquire', gate: true },
-  // Enabled hero `.btn-brand` → contrast lands in `incomplete`; reporting-mode
-  // until the brand-button contrast fix (A11Y-4) lands.
-  { name: 'home', path: '/', gate: false },
+  // A11Y-4 landed: `.btn-brand` repainted to `bg-brand-700` (#C05300, ≥4.5:1
+  // white) so the enabled hero CTA now clears AA — `/` is gated.
+  { name: 'home', path: '/', gate: true },
   // Deliberate showcase edge cases + widget iframes → reporting-mode.
   { name: 'design', path: '/design', gate: false },
 ];

--- a/frontend_modern/src/features/design/DesignSystemPage.tsx
+++ b/frontend_modern/src/features/design/DesignSystemPage.tsx
@@ -52,7 +52,7 @@ const INK_SCALE: Array<[string, string]> = [
 const Section = ({ title, kicker, children }: { title: string; kicker?: string; children: React.ReactNode }) => (
   <section className="animate-fade-up">
     <div className="mb-5">
-      {kicker && <p className="text-xs font-semibold uppercase tracking-widest text-brand-600">{kicker}</p>}
+      {kicker && <p className="text-xs font-semibold uppercase tracking-widest text-brand-700">{kicker}</p>}
       <h2 className="font-display text-2xl font-semibold text-ink-900">{title}</h2>
     </div>
     {children}

--- a/frontend_modern/src/features/home/HomePage.tsx
+++ b/frontend_modern/src/features/home/HomePage.tsx
@@ -120,7 +120,7 @@ export const HomePage = () => {
             <img src="/home/teacher.jpg" alt={t('home.teacherAlt')} className="h-full w-full object-cover" />
           </div>
           <div>
-            <p className="text-sm font-semibold uppercase tracking-widest text-brand-600">
+            <p className="text-sm font-semibold uppercase tracking-widest text-brand-700">
               {t('home.missionKicker')}
             </p>
             <h2 className="mt-3 font-display text-3xl font-semibold text-ink-900 text-balance">

--- a/frontend_modern/src/features/teacher/CreateAssignmentPage.tsx
+++ b/frontend_modern/src/features/teacher/CreateAssignmentPage.tsx
@@ -557,7 +557,7 @@ const AssignmentPreview = ({ room, set, dueDate, valid, submitting, error }: Ass
       <div className="flex-1 space-y-4">
         {/* What students will see */}
         <div className="rounded-xl border border-ink-100 bg-paper p-4">
-          <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-brand-600">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-brand-700">
             {t('assignForm.whatStudentsSee')}
           </p>
           {set ? (

--- a/frontend_modern/src/features/teacher/CreateProblemSetPage.tsx
+++ b/frontend_modern/src/features/teacher/CreateProblemSetPage.tsx
@@ -500,7 +500,7 @@ export const CreateProblemSetPage = () => {
                 <button
                   type="button"
                   onClick={() => navigate('/teacher/questions/new')}
-                  className="mt-2 text-sm font-medium text-brand-600 hover:text-brand-700"
+                  className="mt-2 text-sm font-medium text-brand-700 hover:text-brand-800"
                 >
                   {t('setForm.authorOne')}
                 </button>

--- a/frontend_modern/src/features/teacher/CreateQuestionPage.tsx
+++ b/frontend_modern/src/features/teacher/CreateQuestionPage.tsx
@@ -842,7 +842,7 @@ export const CreateQuestionPage = ({ editMode = false }: { editMode?: boolean })
             ))}
             <button
               onClick={addSubpart}
-              className="flex min-h-[44px] items-end pb-3 px-3 text-sm text-brand-600 hover:text-brand-800 whitespace-nowrap"
+              className="flex min-h-[44px] items-end pb-3 px-3 text-sm text-brand-700 hover:text-brand-800 whitespace-nowrap"
             >
               {t('cqp.addPart')}
             </button>

--- a/frontend_modern/src/features/teacher/QuestionBankPage.tsx
+++ b/frontend_modern/src/features/teacher/QuestionBankPage.tsx
@@ -158,7 +158,7 @@ const AddToProblemSetSheet = ({
       >
         <div className="flex items-center justify-between border-b border-ink-100 px-6 py-5">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-widest text-brand-600">
+            <p className="text-xs font-semibold uppercase tracking-widest text-brand-700">
               {t('addToSet.eyebrow')}
             </p>
             <h3

--- a/frontend_modern/src/features/teacher/QuestionPreviewPanel.tsx
+++ b/frontend_modern/src/features/teacher/QuestionPreviewPanel.tsx
@@ -45,7 +45,7 @@ const SubpartPreview = ({
   return (
     <div className="rounded-xl border border-ink-100 bg-white p-5 shadow-soft">
       {total > 1 && (
-        <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-brand-600">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-brand-700">
           {t('qpreview.part', { letter: String.fromCharCode(97 + index) })}
         </p>
       )}

--- a/frontend_modern/src/features/teacher/WidgetGalleryPanel.tsx
+++ b/frontend_modern/src/features/teacher/WidgetGalleryPanel.tsx
@@ -423,11 +423,11 @@ export function WidgetGalleryPanel({
 
       <div className="grid gap-4 md:grid-cols-2">
         <div className="grid gap-2">
-          <p className="text-xs font-semibold uppercase tracking-widest text-brand-600">{t('widgetGallery.config')}</p>
+          <p className="text-xs font-semibold uppercase tracking-widest text-brand-700">{t('widgetGallery.config')}</p>
           <ConfigForm schema={schema} config={config} onChange={setConfig} />
         </div>
         <div className="grid gap-2">
-          <p className="text-xs font-semibold uppercase tracking-widest text-brand-600">{t('widgetGallery.preview')}</p>
+          <p className="text-xs font-semibold uppercase tracking-widest text-brand-700">{t('widgetGallery.preview')}</p>
           <InteractiveWidget
             kind={selected.kind}
             config={config}

--- a/frontend_modern/src/features/widgets/WidgetDevPage.tsx
+++ b/frontend_modern/src/features/widgets/WidgetDevPage.tsx
@@ -229,7 +229,7 @@ export function WidgetDevPage() {
     <div className="min-h-screen bg-paper">
       <header className="border-b border-ink-100 bg-white">
         <div className="mx-auto max-w-6xl px-6 py-7">
-          <p className="text-xs font-semibold uppercase tracking-widest text-brand-600">
+          <p className="text-xs font-semibold uppercase tracking-widest text-brand-700">
             Interactive Widgets
           </p>
           <h1 className="font-display text-3xl font-semibold text-ink-900">Widget dev playground</h1>

--- a/frontend_modern/src/index.css
+++ b/frontend_modern/src/index.css
@@ -60,9 +60,9 @@
   /* Primary action — the "unlock" button. One per screen, ideally. */
   .btn-brand {
     @apply inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-xl
-           bg-brand-600 text-white font-semibold shadow-soft
+           bg-brand-700 text-white font-semibold shadow-soft
            transition-all duration-150
-           hover:bg-brand-700 hover:shadow-lift
+           hover:bg-brand-800 hover:shadow-lift
            active:translate-y-px
            disabled:bg-brand-300 disabled:shadow-none disabled:cursor-not-allowed;
   }
@@ -124,7 +124,7 @@
     @apply italic;
   }
   .prose-osh a {
-    @apply text-brand-600 underline decoration-brand-300 hover:text-brand-700;
+    @apply text-brand-700 underline decoration-brand-300 hover:text-brand-800;
   }
   .prose-osh code {
     @apply px-1 py-0.5 rounded bg-ink-50 text-ink-800 text-[0.9em];

--- a/frontend_modern/src/shared/ui/SectionHeading.tsx
+++ b/frontend_modern/src/shared/ui/SectionHeading.tsx
@@ -31,7 +31,7 @@ export const SectionHeading = ({
     <div className={clsx('flex items-end justify-between gap-4', className)} {...props}>
       <div className="min-w-0">
         {eyebrow && (
-          <p className="mb-1 text-xs font-semibold uppercase tracking-widest text-brand-600">
+          <p className="mb-1 text-xs font-semibold uppercase tracking-widest text-brand-700">
             {eyebrow}
           </p>
         )}

--- a/frontend_modern/tailwind.config.js
+++ b/frontend_modern/tailwind.config.js
@@ -18,8 +18,8 @@ export default {
           300: '#FDBA74',
           400: '#FB8E3C',
           500: '#FB7705',
-          600: '#FF6F00', // ← brand anchor (legacy logo orange)
-          700: '#CC5800',
+          600: '#FF6F00', // ← brand anchor (legacy logo orange) — decorative/large only (≥3:1)
+          700: '#C05300', // ← on-text/CTA brand shade — ≥4.5:1 on white & on paper (A11Y-4)
           800: '#9E4500',
           900: '#7A3500',
         },


### PR DESCRIPTION
## Classification
**Improve** — Accessibility — WCAG 2.1 AA, Batch 2 (A11Y-4). Frontend-only.

## What & why
Batch 1 found the public surfaces structurally clean but deferred one systemic
contrast finding: white text on `.btn-brand` (`#FF6F00`) is ≈ 2.8 : 1, failing
WCAG AA. This makes the brand-shade decision and ships it mechanically.

- **Decision:** keep `brand-600` `#FF6F00` as the **decorative / large-element
  anchor** (logo, chalk-underline, large numerals, borders, focus rings, icons,
  big badges — 3 : 1 or decoration). Use a darker shade for on-text.
- Retune `brand-700` `#CC5800` (≈ 4.2 : 1) → **`#C05300`** (≈ 4.7 : 1 white).
- `.btn-brand` fill → `bg-brand-700`, hover → `brand-800`. `.prose-osh a` and
  small brand kickers/links → `text-brand-700`.
- Left `brand-600` on large display text, decorative SVG icons, and native
  form-control accent colours.
- Flip `/` (home) to `gate: true` in `e2e/a11y.spec.ts` — the enabled hero CTA
  now passes, so its contrast no longer hides in axe `incomplete`.
- Documented the **Contrast rules** in `docs/initiatives/2026-design-system-v2.md`.

## Tests / how to verify
- `npm run type-check` + `npm run lint` (`--max-warnings 0`) + `npm run build` — green.
- `npx vitest run` — 77 files / 467 tests pass.
- `npx playwright test a11y` — `/` now asserts `blocking === []` (runs in CI `frontend-e2e`).
- Ratio check: white on `#C05300` ≈ 4.69 : 1 (AA pass).

Change doc: `docs/changes/2026-06-20-a11y-brand-contrast.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)