### PR TITLE
fix(a11y): StreakBadge secondary-label contrast (A11Y-7)

### DIFF
--- a/docs/changes/2026-06-20-a11y-streak-contrast.md
+++ b/docs/changes/2026-06-20-a11y-streak-contrast.md
@@ -1,0 +1,39 @@
+# 2026-06-20 — A11Y-7: StreakBadge secondary-label contrast
+
+## Summary
+Fixes the one student-core-loop colour-contrast finding the A11Y-6 axe inventory
+surfaced that isn't covered by A11Y-4: the `StreakBadge` secondary labels were
+de-emphasised with `opacity-70` / `opacity-60`, which dropped the tinted text
+below the WCAG AA 4.5 : 1 bar against the badge fill.
+
+## Classification
+**Improve** — frontend-only, one component. No API/schema change.
+
+## What changed
+- `src/features/student/StreakBadge.tsx`: removed `opacity-70` / `opacity-60`
+  from the three secondary `<span>`s (tier label, "best", grace note). They stay
+  de-emphasised by **weight** (`font-normal` vs the badge's `font-semibold`),
+  which carries the hierarchy without lowering contrast. The tier `textColor`
+  tokens already clear AA on their own fill at full opacity.
+
+## Why this was the finding
+The `StreakBadge` renders in the shared app chrome, so its labels appeared on
+every authenticated route's axe report. Measured (A11Y-6):
+`opacity-70` → 3.6 : 1, `opacity-60` → 2.9 : 1 (tinted text on the amber/brand
+badge fill). Removing the overlay restores the tokens' native AA-passing ratios.
+
+## Legacy reference
+None — net-new.
+
+## Tests / how to verify
+- `npm run type-check` + `npm run lint` — green.
+- `npx playwright test a11y` (with the A11Y-6 harness): the student-route
+  `color-contrast` blocking node count drops from 4 → 2 — the two remaining
+  (`.btn-brand`, small `text-brand-700`) are resolved by A11Y-4
+  ([#417](https://github.com/openshiksha/openshiksha/pull/417)).
+
+## Next steps
+A11Y-8: once A11Y-4 (#417) and this PR are merged to `modernization` and the
+student routes compute zero blocking, flip them to `gate: true` in
+`e2e/a11y.spec.ts`. (Gating before then would red-wall CI on the still-present
+brand contrast.)

--- a/frontend_modern/src/features/student/StreakBadge.tsx
+++ b/frontend_modern/src/features/student/StreakBadge.tsx
@@ -69,12 +69,17 @@ export const StreakBadge = ({ streak, tier, longestStreak, graceUsed }: StreakBa
     >
       <span>{config.icon}</span>
       <span>{t('streak.days', { count: streak })}</span>
-      <span className="font-normal opacity-70">· {t(config.labelKey)}</span>
+      {/* Secondary labels are de-emphasised by weight (`font-normal` vs the
+          badge's `font-semibold`), NOT opacity: an `opacity-70/60` overlay
+          dropped the tinted text below the 4.5:1 AA contrast bar against the
+          badge fill (A11Y-7). The tier `textColor` tokens clear AA on their own
+          fill at full opacity. */}
+      <span className="font-normal">· {t(config.labelKey)}</span>
       {longestStreak > streak && (
-        <span className="font-normal opacity-60">· {t('streak.best', { count: longestStreak })}</span>
+        <span className="font-normal">· {t('streak.best', { count: longestStreak })}</span>
       )}
       {graceUsed && (
-        <span className="font-normal opacity-60" title={t('streak.graceTitle')}>
+        <span className="font-normal" title={t('streak.graceTitle')}>
           · {t('streak.grace')}
         </span>
       )}


### PR DESCRIPTION
## Classification
**Improve** — Accessibility — WCAG 2.1 AA, Batch 2 (A11Y-7). Frontend-only, one component.

> **Stacked on [#419](https://github.com/openshiksha/openshiksha/pull/419) (A11Y-6 harness).** Base will retarget to `modernization` once #419 merges.

## What & why
The A11Y-6 axe inventory found the student core loop structurally clean — the
only blocking finding was `color-contrast`, and the one node **not** covered by
[#417](https://github.com/openshiksha/openshiksha/pull/417) (A11Y-4) was the
`StreakBadge` secondary labels. They were de-emphasised with `opacity-70/60`,
which dropped the tinted text to **3.6 : 1 / 2.9 : 1** against the badge fill —
below the AA 4.5 : 1 bar. Since the badge renders in shared chrome, it appeared
on every authenticated route.

Fix: drop the opacity overlay; keep the de-emphasis via **weight** (`font-normal`
vs the badge's `font-semibold`). The tier `textColor` tokens already pass AA on
their own fill at full opacity.

## How to verify
- `npm run type-check` + `npm run lint` — green.
- `npx playwright test a11y` (A11Y-6 harness): student-route `color-contrast`
  blocking nodes drop **4 → 2**; the remaining two (`.btn-brand`,
  `text-brand-700`) are resolved by #417.

Change doc: `docs/changes/2026-06-20-a11y-streak-contrast.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)