### PR TITLE
fix(home): mobile header — brand wordmark overlaps language switcher

### DIFF
--- a/frontend_modern/src/features/home/HomePage.tsx
+++ b/frontend_modern/src/features/home/HomePage.tsx
@@ -48,7 +48,7 @@ export const HomePage = () => {
       <header className="absolute inset-x-0 top-0 z-20">
         <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-5">
           <Link to="/" aria-label="OpenShiksha home">
-            <Logo size="md" wordmarkClassName="text-white" />
+            <Logo size="md" wordmarkClassName="text-white" hideWordmarkOnMobile />
           </Link>
           <div className="flex items-center gap-4">
             <LanguageSwitcher />

--- a/frontend_modern/src/shared/ui/Logo.tsx
+++ b/frontend_modern/src/shared/ui/Logo.tsx
@@ -8,6 +8,8 @@ interface LogoProps {
   wordmarkClassName?: string;
   /** Gentle float — hero marks only. */
   float?: boolean;
+  /** Hide the wordmark below the `sm` breakpoint (icon-only brand on phones). */
+  hideWordmarkOnMobile?: boolean;
   className?: string;
 }
 
@@ -26,6 +28,7 @@ export const Logo = ({
   size = 'md',
   wordmarkClassName,
   float = false,
+  hideWordmarkOnMobile = false,
   className,
 }: LogoProps) => {
   const s = SIZES[size];
@@ -44,6 +47,7 @@ export const Logo = ({
           className={clsx(
             'font-display font-semibold tracking-tight leading-none',
             s.text,
+            hideWordmarkOnMobile && 'hidden sm:inline',
             wordmarkClassName ?? 'text-ink-900',
           )}
         >


### PR DESCRIPTION
## Problem
On phones the landing-page header is overlapping: the **OpenShiksha** wordmark collides with the EN/हिं language pill (see mobile screenshot). It's the first thing a mobile visitor sees.

## Fix
Show the **brand icon only below `sm`** (wordmark returns at `sm`+) via a new opt-in `hideWordmarkOnMobile` prop on `Logo`, used in the landing header. Icon-only is the standard mobile brand treatment and guarantees no collision. No change to tablet/desktop.

- `Logo.tsx`: new `hideWordmarkOnMobile?` prop → `hidden sm:inline` on the wordmark.
- `HomePage.tsx`: pass the prop in the header.

tsc passes locally. Targets `qa` (→ deploys to prod) as a hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)