### PR TITLE
fix(frontend): prod API base URL — login/API broken in production

### DIFF
--- a/frontend_modern/Dockerfile.prod
+++ b/frontend_modern/Dockerfile.prod
@@ -19,6 +19,14 @@ RUN npm ci
 
 COPY . .
 
+# The frontend is served same-origin behind the ingress (/api/* -> backend), so
+# the API base must be a RELATIVE path. Vite inlines VITE_* vars at build time;
+# without this the bundle falls back to the dev default
+# (http://localhost:8000/api/v1) and every visitor's browser calls its own
+# localhost — i.e. the whole API (login included) appears dead in production.
+ARG VITE_API_BASE_URL=/api/v1
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+
 RUN npm run build
 # Defend the entry-chunk ceiling — fails the image build if it's blown.
 RUN npm run check:budget


### PR DESCRIPTION
## Problem (prod-down)
The deployed frontend bundle hardcodes `http://localhost:8000/api/v1`, so every visitor's browser calls **its own localhost** — the entire API, login included, is dead in production. Root cause: `VITE_API_BASE_URL` was never set at build time, so Vite inlined the dev fallback in [`src/api/client.ts`](frontend_modern/src/api/client.ts).

> Server side is fine — `POST https://openshiksha.org/api/v1/auth/login/` with `student_demo`/`demo1234` returns 200. Only the bundle's target was wrong.

## Fix
Set `ARG/ENV VITE_API_BASE_URL=/api/v1` in [`Dockerfile.prod`](frontend_modern/Dockerfile.prod) before `npm run build`, so the bundle uses a **relative** base → same-origin `https://openshiksha.org/api/v1` through the ingress (`/api/*` → backend). Overridable via `--build-arg`.

Hotfix → `qa` (deploys to prod). After merge + deploy, login works in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)