### PR TITLE
fix(student-home): duplicate navbar logo + practice-plans/today 404

### DIFF
--- a/backend/openshiksha/apps/ai/tests/test_practice_plan_today.py
+++ b/backend/openshiksha/apps/ai/tests/test_practice_plan_today.py
@@ -1,0 +1,32 @@
+"""Tests for GET /api/v1/ai/practice-plans/today/."""
+
+import pytest
+
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from openshiksha.apps.core.models import User, UserRole
+
+
+@pytest.mark.django_db
+def test_today_returns_204_when_no_plan():
+    """A student with no plan for today gets 204 (empty state), not 404."""
+    student = User.objects.create_user(username="pp_student", password="pw12345", role=UserRole.STUDENT)
+    client = APIClient()
+    client.force_authenticate(user=student)
+
+    resp = client.get("/api/v1/ai/practice-plans/today/")
+
+    assert resp.status_code == status.HTTP_204_NO_CONTENT
+    assert not resp.data
+
+
+@pytest.mark.django_db
+def test_today_forbidden_for_non_student():
+    teacher = User.objects.create_user(username="pp_teacher", password="pw12345", role=UserRole.TEACHER)
+    client = APIClient()
+    client.force_authenticate(user=teacher)
+
+    resp = client.get("/api/v1/ai/practice-plans/today/")
+
+    assert resp.status_code == status.HTTP_403_FORBIDDEN

--- a/backend/openshiksha/apps/ai/views.py
+++ b/backend/openshiksha/apps/ai/views.py
@@ -401,10 +401,11 @@ class PracticePlanViewSet(ReadOnlyModelViewSet):
             )
             return Response(self.get_serializer(plan).data)
         except PracticePlan.DoesNotExist:
-            return Response(
-                {"detail": "No practice plan for today yet. Trigger generation via POST /ai/trigger/recommendations/."},
-                status=status.HTTP_404_NOT_FOUND,
-            )
+            # "No plan yet" is an empty state, not an error — 204 keeps it out of
+            # the client's error path / network-tab noise (a new student with no
+            # activity simply has nothing to practise yet). A plan is generated
+            # from activity via POST /ai/trigger/recommendations/.
+            return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/frontend_modern/src/features/layout/Navbar.tsx
+++ b/frontend_modern/src/features/layout/Navbar.tsx
@@ -80,8 +80,10 @@ export const Navbar = () => {
               className="flex items-center rounded focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-brand-500"
               aria-label="OpenShiksha home"
             >
-              <Logo size="sm" className="hidden sm:inline-flex" />
-              <Logo size="sm" variant="mark" className="sm:hidden" />
+              {/* One Logo: icon-only on phones, full wordmark at sm+. The old
+                  two-Logo approach rendered BOTH on mobile because the Logo's
+                  own `inline-flex` overrode the `hidden` utility. */}
+              <Logo size="sm" hideWordmarkOnMobile />
             </Link>
 
             {/* Desktop nav — hidden on mobile */}

--- a/frontend_modern/src/features/student/usePracticePlan.ts
+++ b/frontend_modern/src/features/student/usePracticePlan.ts
@@ -15,9 +15,11 @@ export interface PracticePlan {
 const fetchTodaysPlan = async (): Promise<PracticePlan | null> => {
   try {
     const response = await apiClient.get<PracticePlan>('/ai/practice-plans/today/');
+    // 204 No Content = no plan for today yet (the empty state).
+    if (response.status === 204 || !response.data) return null;
     return response.data;
   } catch (err: unknown) {
-    // 404 means no plan yet — not an error for display purposes
+    // Tolerate the legacy 404 empty-state response during the rollout window.
     if (err && typeof err === 'object' && 'response' in err) {
       const axiosErr = err as { response?: { status?: number } };
       if (axiosErr.response?.status === 404) return null;


### PR DESCRIPTION
Two student-home fixes you spotted.

## 1. Duplicate logo in the navbar
The navbar rendered **two** `<Logo>` elements (full + icon-only) meant to swap via `hidden sm:inline-flex` / `sm:hidden` — but the Logo's own root `inline-flex` class overrode the `hidden` utility, so **both showed on mobile** (the double logo). Replaced with a single `<Logo hideWordmarkOnMobile />` (the prop added in #423) → icon-only on phones, full wordmark at `sm`+. No change on desktop.

## 2. `GET /ai/practice-plans/today/` → 404
The endpoint **exists**; it was returning **404 for the normal 'no plan yet' empty state** (a new student with no activity simply has no plan). That's semantically wrong — 404 implies the resource/route is missing — and it shows up as a red error in the network tab even though the app handles it. Now returns **204 No Content** (matches the method's own docstring + REST semantics). Frontend treats 204 as 'no plan' and keeps the 404 fallback so it works during the rollout. Added backend tests (204 for student-with-no-plan, 403 for non-student).

How practice plans work, for context: they're generated from a student's activity (answered questions → detected gaps) via `POST /ai/trigger/recommendations/`; until then 'What to Practice Next' correctly shows the empty state. Nothing else to build here — just the wrong status code.

Both verified locally (backend tests pass, tsc clean). Targets `qa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)