### PR TITLE
fix(admin): Django admin at /django-admin/ (superuser-only)

### DIFF
--- a/backend/openshiksha/apps/concierge/emails.py
+++ b/backend/openshiksha/apps/concierge/emails.py
@@ -55,7 +55,7 @@ def notify_enquiry_received(enquirer) -> None:
             heading=f"New enquiry from {school}",
             body_html=body_html,
             cta_label="View in admin",
-            cta_url=f"{app_url}/admin/concierge/enquirer/{enquirer.pk}/change/",
+            cta_url=f"{app_url}/django-admin/concierge/enquirer/{enquirer.pk}/change/",
         )
 
         mail_admins(

--- a/backend/openshiksha/settings/base.py
+++ b/backend/openshiksha/settings/base.py
@@ -252,7 +252,7 @@ VAPID_ADMIN_EMAIL = os.getenv("VAPID_ADMIN_EMAIL", "admin@openshiksha.org")
 # optionally with "Name <email>" entries:
 #   OPENSHIKSHA_ADMIN_EMAILS="Ops Team <ops@example.com>,founder@example.com"
 # Without this, mail_admins() silently no-ops — enquiries still land in the
-# DB (admin at /admin/concierge/enquirer/) but no email is sent.
+# DB (admin at /django-admin/concierge/enquirer/) but no email is sent.
 def _parse_admin_emails(raw: str) -> list[tuple[str, str]]:
     out: list[tuple[str, str]] = []
     for entry in raw.split(","):

--- a/backend/openshiksha/tests/test_admin_access.py
+++ b/backend/openshiksha/tests/test_admin_access.py
@@ -1,0 +1,37 @@
+"""The Django admin (/django-admin/) is restricted to superusers only."""
+
+import pytest
+
+from django.test import Client
+
+from openshiksha.apps.core.models import User, UserRole
+
+
+@pytest.mark.django_db
+def test_django_admin_blocks_non_superuser_staff():
+    """A school 'admin' (is_staff but not superuser) must not reach Django admin."""
+    staff = User.objects.create_user(username="staffy", password="pw12345", role=UserRole.ADMIN)
+    staff.is_staff = True
+    staff.save()
+
+    client = Client()
+    client.force_login(staff)
+    resp = client.get("/django-admin/")
+
+    # has_permission() is False -> the admin bounces to its own login page.
+    assert resp.status_code == 302
+    assert "/django-admin/login" in resp.headers.get("Location", "")
+
+
+@pytest.mark.django_db
+def test_django_admin_allows_superuser():
+    su = User.objects.create_user(username="super", password="pw12345", role=UserRole.ADMIN)
+    su.is_staff = True
+    su.is_superuser = True
+    su.save()
+
+    client = Client()
+    client.force_login(su)
+    resp = client.get("/django-admin/")
+
+    assert resp.status_code == 200

--- a/backend/openshiksha/urls.py
+++ b/backend/openshiksha/urls.py
@@ -28,8 +28,10 @@ def healthz(_request):
 urlpatterns = [
     # Cheap liveness probe — no DB / Redis / auth. See healthz() above.
     path("healthz/", healthz, name="healthz"),
-    # Django Admin
-    path("admin/", admin.site.urls),
+    # Django admin — mounted at /django-admin/ so it doesn't collide with the
+    # React app's /admin route (the in-app school-admin dashboard). Superuser-only
+    # gate is applied below.
+    path("django-admin/", admin.site.urls),
     # API v1 endpoints
     path("api/v1/", include("openshiksha.apps.api.urls")),
     # API Documentation
@@ -57,3 +59,9 @@ if settings.DEBUG:
 admin.site.site_header = "OpenShiksha Administration"
 admin.site.site_title = "OpenShiksha Admin"
 admin.site.index_title = "Welcome to OpenShiksha Admin Portal"
+
+# Restrict the Django admin to platform SUPERUSERS only. By default any
+# is_staff user can reach it — but the "admin" role (school admins) are is_staff
+# and must NOT, they use the in-app /admin dashboard. Overriding has_permission
+# blocks login/access at the door for non-superusers.
+admin.site.has_permission = lambda request: bool(request.user and request.user.is_active and request.user.is_superuser)

--- a/backend/openshiksha/urls.py
+++ b/backend/openshiksha/urls.py
@@ -60,8 +60,13 @@ admin.site.site_header = "OpenShiksha Administration"
 admin.site.site_title = "OpenShiksha Admin"
 admin.site.index_title = "Welcome to OpenShiksha Admin Portal"
 
+
 # Restrict the Django admin to platform SUPERUSERS only. By default any
 # is_staff user can reach it — but the "admin" role (school admins) are is_staff
 # and must NOT, they use the in-app /admin dashboard. Overriding has_permission
 # blocks login/access at the door for non-superusers.
-admin.site.has_permission = lambda request: bool(request.user and request.user.is_active and request.user.is_superuser)
+def _admin_superuser_only(request) -> bool:
+    return bool(request.user and request.user.is_active and request.user.is_superuser)
+
+
+admin.site.has_permission = _admin_superuser_only  # type: ignore[method-assign]

--- a/frontend_modern/vite.config.ts
+++ b/frontend_modern/vite.config.ts
@@ -93,9 +93,10 @@ export default defineConfig(async ({ mode }) => ({
         importScripts: ['push-handler.js'],
         // Deep links boot offline from the precached shell. /api must never be
         // served the shell (principle 2) — the persisted React Query cache
-        // (MSO-4), not Workbox, owns API read-tolerance.
+        // (MSO-4), not Workbox, owns API read-tolerance. /django-admin is the
+        // backend-served Django admin — it must hit the network, not the SPA.
         navigateFallback: 'index.html',
-        navigateFallbackDenylist: [/^\/api/],
+        navigateFallbackDenylist: [/^\/api/, /^\/django-admin/],
         runtimeCaching: [
           {
             // Google Fonts binaries (Inter / Fraunces / Noto Devanagari) so

--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -17,7 +17,9 @@ spec:
     - host: PLACEHOLDER.openshiksha.org
       http:
         paths:
-          # /api/* and /admin/* go to the Django backend.
+          # /api/*, /django-admin/* and /static/* go to the Django backend.
+          # NB: /admin (no prefix here) falls through to the frontend — that's the
+          # React in-app school-admin dashboard, distinct from /django-admin.
           - path: /api
             pathType: Prefix
             backend:
@@ -25,7 +27,7 @@ spec:
                 name: backend
                 port:
                   number: 8000
-          - path: /admin
+          - path: /django-admin
             pathType: Prefix
             backend:
               service:

--- a/k8s/overlays/prod/ingress-patch.yaml
+++ b/k8s/overlays/prod/ingress-patch.yaml
@@ -20,7 +20,7 @@ spec:
                 name: backend
                 port:
                   number: 8000
-          - path: /admin
+          - path: /django-admin
             pathType: Prefix
             backend:
               service:
@@ -51,7 +51,7 @@ spec:
                 name: backend
                 port:
                   number: 8000
-          - path: /admin
+          - path: /django-admin
             pathType: Prefix
             backend:
               service:

--- a/k8s/overlays/qa/ingress-patch.yaml
+++ b/k8s/overlays/qa/ingress-patch.yaml
@@ -14,7 +14,7 @@ spec:
                 name: backend
                 port:
                   number: 8000
-          - path: /admin
+          - path: /django-admin
             pathType: Prefix
             backend:
               service:


### PR DESCRIPTION
## Problem
You couldn't reach the Django admin: `/admin/` collided with the React app's own `/admin` route (the in-app **school-admin dashboard**, which admins are redirected to on login), and the **PWA service worker** served the SPA shell for `/admin` — so Django admin was shadowed entirely.

## Fix
- **Move Django admin to `/django-admin/`** (`urls.py`) so it no longer collides; `/admin` now belongs to the React school-admin dashboard.
- **Gate it to superusers only** — by default any `is_staff` user can enter, and your school 'admin' role users *are* `is_staff`. Overrode `admin.site.has_permission` to require `is_superuser`. So only platform superusers (e.g. `admin@openshiksha.org`) get in. + test (`test_admin_access.py`).
- **Ingress** (base + qa/prod overlays): route `/django-admin` → backend; `/admin` falls through to the frontend.
- **PWA**: add `/django-admin` to `navigateFallbackDenylist` so it hits the network, not the SPA.
- Repointed the enquiry email's *View in admin* link.

After deploy: **https://openshiksha.org/django-admin/** → Django login → superuser only.

Verified: ingress renders `/django-admin` (not `/admin`), superuser-gate test passes, tsc + lint clean. Targets `qa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)