### PR TITLE
docs(oss): GitHub issue & PR templates (OSS-6)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Report something that is broken or behaving unexpectedly
+title: "[Bug]: "
+labels: bug
+assignees: ''
+---
+
+## What happened
+
+<!-- A clear, concise description of the bug. -->
+
+## Expected behaviour
+
+<!-- What did you expect to happen instead? -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Environment
+
+- **Browser / device:** <!-- e.g. Chrome 124 on Windows, Safari on iPhone -->
+- **Role:** <!-- student / teacher / parent / admin / open student -->
+- **URL or page:** <!-- where it happened, if applicable -->
+
+## Screenshots / logs
+
+<!-- Drag-and-drop screenshots, or paste console/network errors. -->
+
+## Severity
+
+<!-- blocker / major / minor / cosmetic -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/openshiksha/openshiksha/security/policy
+    about: Please report security issues privately — see SECURITY.md, do not file a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability
+title: "[Feature]: "
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+<!-- What problem does this solve? What is painful or missing today? -->
+
+## Proposed solution
+
+<!-- Describe the change you'd like. Be as concrete as you can. -->
+
+## Who benefits
+
+<!-- Which role(s) does this help? student / teacher / parent / admin / school -->
+
+## Alternatives considered
+
+<!-- Other approaches you thought about, and why you prefer this one. -->
+
+## Additional context
+
+<!-- Mockups, links, related issues, anything else. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+<!--
+Thanks for contributing to OpenShiksha! Keep PRs atomic — one logical change.
+See CONTRIBUTING.md for the branch model and commit conventions.
+-->
+
+## Summary
+
+<!-- What does this PR do and why? One or two sentences. -->
+
+## Type
+
+<!-- Check all that apply. -->
+
+- [ ] Port (legacy → modern stack)
+- [ ] Improve (existing modern feature)
+- [ ] New (net-new capability)
+- [ ] Fix (bug fix)
+- [ ] Docs / chore
+
+## Initiative / increment
+
+<!-- e.g. "Open-Source Readiness — OSS-6", or a docs/initiatives reference. Optional. -->
+
+## How tested
+
+<!-- Commands run, manual steps, screenshots for UI changes. -->
+
+## Checklist
+
+- [ ] Targets the **`modernization`** branch
+- [ ] CI is green (lint, type-check, tests, build)
+- [ ] Migrations created if models changed (`makemigrations --check` clean)
+- [ ] Docs / change log / initiative ledger updated if relevant
+- [ ] No secrets or credentials committed
+- [ ] Follows the commit conventions in `CONTRIBUTING.md` (`feat(scope): …`)

--- a/docs/changes/2026-06-22-oss6-github-templates.md
+++ b/docs/changes/2026-06-22-oss6-github-templates.md
@@ -1,0 +1,40 @@
+# 2026-06-22 — OSS-6: GitHub issue & PR templates
+
+**Summary.** Add community contribution scaffolding to `.github/`: two issue
+templates (bug report, feature request), an issue-chooser config that routes
+security reports privately, and a pull-request template mirroring the repo's
+real conventions.
+
+**Classification.** New.
+
+**Initiative.** Open-Source Readiness (Priority 1) — backlog item OSS-6.
+
+## Legacy reference
+
+None — the archived Django 1.11 monolith was a private internal repo with no
+community scaffolding. Net-new repository capability.
+
+## What changed
+
+- `.github/ISSUE_TEMPLATE/bug_report.md` — front-matter (`labels: bug`,
+  `title: "[Bug]: "`); sections for what happened / expected / repro steps /
+  environment (browser + role) / screenshots / severity.
+- `.github/ISSUE_TEMPLATE/feature_request.md` — (`labels: enhancement`,
+  `title: "[Feature]: "`); problem / proposed solution / who benefits (role) /
+  alternatives.
+- `.github/ISSUE_TEMPLATE/config.yml` — `blank_issues_enabled: false` with a
+  `contact_links` entry routing vulnerabilities to the security policy
+  (SECURITY.md) instead of public issues.
+- `.github/pull_request_template.md` — summary / type (port/improve/new/fix/docs) /
+  initiative+increment / how tested / checklist (targets `modernization`, CI green,
+  migration drift, no secrets, commit conventions).
+
+## Tests
+
+- YAML front-matter of each template validated with `yaml.safe_load`.
+- Chooser rendering is GitHub-side (cannot be tested locally).
+- Docs-only — no backend/frontend code touched, no CI regression risk.
+
+## Next steps
+
+OSS-9 (README screenshots) next in the batch.


### PR DESCRIPTION
## Summary

Adds community contribution scaffolding under `.github/` — the OSS-6 backlog item of the **Open-Source Readiness** initiative (Priority 1).

## Type

- [x] New (net-new repository capability)

## Initiative / increment

Open-Source Readiness — **OSS-6** (`docs/initiatives/open-source-readiness.md`)

## What changed

- `.github/ISSUE_TEMPLATE/bug_report.md` — what happened / expected / repro / environment (browser + role) / screenshots / severity.
- `.github/ISSUE_TEMPLATE/feature_request.md` — problem / proposed solution / who benefits (role) / alternatives.
- `.github/ISSUE_TEMPLATE/config.yml` — `blank_issues_enabled: false`; routes security reports to the security policy (not public issues).
- `.github/pull_request_template.md` — summary / type / initiative+increment / how tested / checklist mirroring `CONTRIBUTING.md`.

## How tested

- YAML front-matter of each template validated with `yaml.safe_load`.
- `pre-commit` (trailing-whitespace, EOF, check-yaml) green.
- Chooser rendering is GitHub-side. Docs-only — no code paths, no CI regression risk.

Change doc: `docs/changes/2026-06-22-oss6-github-templates.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)