### PR TITLE
docs(oss): repo metadata + MPL-2.0 license badge — close initiative (OSS-10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ CBSE · Classes 7–10 · English & हिन्दी.
 
 [![CI/CD](https://github.com/openshiksha/openshiksha/workflows/CI/CD%20Pipeline/badge.svg?branch=qa)](https://github.com/openshiksha/openshiksha/actions)
 [![CodeQL](https://github.com/openshiksha/openshiksha/workflows/CodeQL/badge.svg)](https://github.com/openshiksha/openshiksha/actions)
-[![License](https://img.shields.io/badge/license-see%20LICENSE-blue)](LICENSE.md)
+[![License: MPL 2.0](https://img.shields.io/badge/license-MPL%202.0-brightgreen)](LICENSE.md)
 
 🌐 **[openshiksha.org](https://openshiksha.org)**
 
@@ -141,4 +141,5 @@ them with `pre-commit install`.
 
 ## License
 
-See [`LICENSE.md`](LICENSE.md).
+OpenShiksha is licensed under the **Mozilla Public License 2.0** (MPL-2.0) — see
+[`LICENSE.md`](LICENSE.md) for the full text.

--- a/docs/changes/2026-06-22-oss10-repo-metadata.md
+++ b/docs/changes/2026-06-22-oss10-repo-metadata.md
@@ -1,0 +1,43 @@
+# 2026-06-22 — OSS-10: repo metadata + license verification
+
+**Summary.** Set the GitHub repo's description, homepage, and topics; verify the
+license is auto-detected; badge it in the README. Closes the Open-Source
+Readiness initiative (DoD met).
+
+**Classification.** New + Verify.
+
+**Initiative.** Open-Source Readiness (Priority 1) — backlog item OSS-10 (final).
+
+## What changed
+
+- **Repo metadata** (via `gh repo edit`, admin scope was present — no manual
+  follow-up needed):
+  - description: *"Modern K-12 practice-learning platform for India — Django +
+    React, AI-assisted."*
+  - homepage: `https://openshiksha.org`
+  - topics: `education, edtech, k12, django, react, typescript, india,
+    learning-platform` (added alongside the pre-existing `hacktoberfest`).
+- **License verification.** `gh repo view --json licenseInfo` already reports
+  `mpl-2.0` (Mozilla Public License 2.0) — GitHub's licensee detector recognises
+  the existing `LICENSE.md`, so no plain-`LICENSE` copy was needed.
+- **README:**
+  - License badge upgraded from the generic "see LICENSE" to a proper
+    `MPL 2.0` shields.io badge.
+  - `## License` section now names MPL-2.0 explicitly and links `LICENSE.md`.
+- **Ledger / STATUS.** Marked OSS-6..10 shipped and the initiative **Done — DoD
+  met**; recorded that Accessibility (Priority 2) becomes the top active
+  initiative.
+
+## Tests
+
+- `gh repo view openshiksha/openshiksha --json description,homepageUrl,repositoryTopics`
+  confirms the new metadata.
+- `gh repo view --json licenseInfo` → `mpl-2.0` (sidebar will show the detected
+  license).
+- README badges render (shields.io). `pre-commit` green. Docs/metadata-only —
+  no CI regression risk.
+
+## Next steps
+
+Open-Source Readiness is complete. The board promotes **Accessibility — WCAG 2.1
+AA** (Batch 2 already planned in `docs/daily-plans/2026-06-20-plan.md`).

--- a/docs/initiatives/STATUS.md
+++ b/docs/initiatives/STATUS.md
@@ -11,17 +11,19 @@
 > it is the only thing with open work. It is intentionally **omitted from the
 > priority table below** so it is never picked as the "top active initiative."
 
-**Last updated:** 2026-06-22 (latest) — **Open-Source Readiness closing batch
-planned (OSS-6..10).** The [2026-06-22 plan](../daily-plans/2026-06-22-plan.md)
-scopes the five remaining backlog items as a low-risk, mostly-docs batch:
-OSS-6 (`.github/` issue + PR templates) → OSS-9 (README product screenshots,
-reusing existing shots) → OSS-8 (ASCII → rendered Mermaid architecture diagram) →
-OSS-7 (consolidate the loose root dev guides under `docs/dev/` + index, repoint
-links) → OSS-10 (repo metadata via `gh repo edit` + license detection/badge).
-Shipping it **reaches the initiative's Definition of Done**, after which
-Accessibility (Priority 2, Batch 2 already planned 2026-06-20) becomes the top
-active initiative. The `ai-features` routine fence is respected. *(Prior update
-below.)*
+**Last updated:** 2026-06-22 (latest) — **Open-Source Readiness CLOSED — DoD met.**
+The closing batch shipped: OSS-6 (`.github/` issue + PR templates,
+[#432](https://github.com/openshiksha/openshiksha/pull/432)) → OSS-9 (README
+product screenshots, [#433](https://github.com/openshiksha/openshiksha/pull/433))
+→ OSS-8 (ASCII → GitHub-rendered Mermaid architecture diagram,
+[#434](https://github.com/openshiksha/openshiksha/pull/434)) → OSS-7 (root dev
+guides consolidated under `docs/dev/` + index, links repointed,
+[#435](https://github.com/openshiksha/openshiksha/pull/435)) → OSS-10 (repo
+metadata via `gh repo edit` + auto-detected MPL-2.0 license badged, this PR).
+A clean-checkout newcomer can now understand, run, and contribute from the README
++ linked docs alone. **Accessibility (Priority 2, Batch 2 already planned
+2026-06-20) is now the top active initiative.** The `ai-features` routine fence
+is respected. *(Prior update below.)*
 
 **2026-06-21** — **Open-Source Readiness promoted to
 Priority 1 (Active).** With the modern stack live in production, the focus is
@@ -257,7 +259,7 @@ at 160 kB defends the cut.
 
 | Priority | Initiative | Status | Headline progress | Next increment |
 |:--:|---|---|---|---|
-| 1 | [Open-Source Readiness](open-source-readiness.md) | **Active** | **Batch 1 (OSS-1..5) shipped 2026-06-21** ([#425](https://github.com/openshiksha/openshiksha/pull/425)): archived the retired Django 1.11 monolith under `legacy/` (659 renames, history preserved), removed scratch/cruft + gitignored MCP artifacts, rewrote the root README (what-it-is + architecture + stack + quickstart + **real CI/CD pipeline & branch→env model** + deploy), added `CONTRIBUTING.md`/`SECURITY.md`/`CODE_OF_CONDUCT.md`. The repo root now reads as the modern stack only. | **OSS-6** `.github/` issue + PR templates → **OSS-7** consolidate the loose root dev docs (`CHEAT_SHEET`, `GIT_STRATEGY`, `LOCAL_DEVELOPMENT`, `SETUP_MODERNIZATION`) under `docs/` with an index → OSS-8 architecture diagram, OSS-9 README screenshots, OSS-10 repo metadata. |
+| - | [Open-Source Readiness](open-source-readiness.md) | **Done** | **DoD met 2026-06-22.** Batch 1 (OSS-1..5, [#425](https://github.com/openshiksha/openshiksha/pull/425)) archived the Django 1.11 monolith under `legacy/`, rewrote the README around the real CI/CD + branch→env model, added `CONTRIBUTING`/`SECURITY`/`CODE_OF_CONDUCT`. **Batch 2/3 (OSS-6..10) shipped 2026-06-22** ([#432](https://github.com/openshiksha/openshiksha/pull/432)–[#435](https://github.com/openshiksha/openshiksha/pull/435) + metadata PR): `.github/` issue+PR templates, README product screenshots, a GitHub-rendered Mermaid architecture diagram, the loose root dev guides consolidated under `docs/dev/` (kebab-cased, history preserved) + index, and repo metadata (description/topics/homepage via `gh repo edit`) with the auto-detected MPL-2.0 license badged. A clean-checkout newcomer can now understand, run, and contribute from the README + linked docs alone. | **Initiative complete.** Accessibility (Priority 2) becomes the top active initiative — Batch 2 already planned in [`2026-06-20-plan.md`](../daily-plans/2026-06-20-plan.md). |
 | 2 | [Accessibility — WCAG 2.1 AA](2026-accessibility-wcag-aa.md) | **Active** | **Promoted 2026-06-19; Batch 1 (A11Y-1..5) shipped** ([#389](https://github.com/openshiksha/openshiksha/pull/389), [#390](https://github.com/openshiksha/openshiksha/pull/390), + A11Y-5 gate/close-out). Per-route axe baseline over every public surface (`e2e/a11y.spec.ts` route table + `incomplete` capture); static `eslint-plugin-jsx-a11y` gate at `--max-warnings 0`; **gated** `/login`, `/register`, `/register/school`, `/register/open`, `/enquire` (`gate: true`, zero serious/critical). **Finding:** the public surfaces were already *structurally* clean (A11Y-3 no-op); the one contrast issue is systemic — `.btn-brand` white-on-`#FF6F00` ≈ 2.8:1 fails AA enabled (A11Y-4 **deferred**, needs a brand-shade design call). | **A11Y-4 — brand-button contrast** (design-shade decision, then token-usage sweep + gate `/`). Then **Batch 2:** student core-loop surfaces (assignment detail, dashboard, SRS drill, proficiency) — remediate + gate. |
 | - | [Mobile Shell & PWA-Offline](2026-mobile-shell-pwa-offline.md) | **Done** | **Batch 1 (MSO-1..5) shipped 2026-06-14** ([#358](https://github.com/openshiksha/openshiksha/pull/358)–[#362](https://github.com/openshiksha/openshiksha/pull/362)): installable PWA + offline *read*-tolerance. **Batch 2 (MSO-6..10) shipped 2026-06-15** ([#367](https://github.com/openshiksha/openshiksha/pull/367)–[#370](https://github.com/openshiksha/openshiksha/pull/370)): offline *write*-tolerance — queue + replay. **Batch 3 (MPN-1..5) shipped 2026-06-17** ([#375](https://github.com/openshiksha/openshiksha/pull/375)–[#379](https://github.com/openshiksha/openshiksha/pull/379)): web push due-date reminders. **Batch 4 (RML-1..5) shipped 2026-06-18** ([#382](https://github.com/openshiksha/openshiksha/pull/382)–[#385](https://github.com/openshiksha/openshiksha/pull/385)): route-level mobile layouts — `ResponsiveTable` primitive + dense teacher tables/forms → responsive on phones. **First-phase DoD + both later phases done → initiative complete.** | **No unblocked next bet.** The next planning run promotes a fresh top initiative — candidates: **AI-tutor rebase** (`ai/2026-06-04-ai-tutor-chat`, ~5k-line diverged branch), an **`/ai/predictions/` teacher surface**, or an **accessibility audit (WCAG 2.1 AA)**. LA-10 (authored-content translation) stays blocked on product design. |
 | 2 | [Language Access — i18n en/हिंदी/मराठी](2026-language-access.md) | **Done-but-for-LA-10 (blocked)** | **LA-1..9 shipped.** Foundation + EN\|हिं switcher, `preferred_language` end-to-end, student/parent/public/teacher surfaces, AI content + emails in the reader's language, `Intl` date/number helper ([#308](https://github.com/openshiksha/openshiksha/pull/308)–[#326](https://github.com/openshiksha/openshiksha/pull/326)). **LA-9 closed 2026-06-13** — N-locale registry + pilot-coverage parity ([#349](https://github.com/openshiksha/openshiksha/pull/349)) then **Marathi (मरा)** as pure content across the anonymous journey, student loop, and parent dashboard + a backend mr→en AI fallback guard ([#350](https://github.com/openshiksha/openshiksha/pull/350)–[#353](https://github.com/openshiksha/openshiksha/pull/353)). The framework now makes a new language config + content, no code change. | **LA-10** (authored-content/question translation) — blocked on product design, do not start without promotion. Then **Mobile shell / PWA-offline** |

--- a/docs/initiatives/open-source-readiness.md
+++ b/docs/initiatives/open-source-readiness.md
@@ -99,8 +99,17 @@ missing badge, or improve one `.env.example` comment.
 | OSS-3 CONTRIBUTING.md | ✅ shipped | (this PR) | 2026-06-21 | Pulled forward to keep README links clean. |
 | OSS-4 SECURITY.md | ✅ shipped | (this PR) | 2026-06-21 | Private disclosure via GitHub advisories + security@openshiksha.org. |
 | OSS-5 CODE_OF_CONDUCT.md | ✅ shipped | (this PR) | 2026-06-21 | Contributor Covenant 2.1. |
+| OSS-6 `.github/` issue + PR templates | ✅ shipped | [#432](https://github.com/openshiksha/openshiksha/pull/432) | 2026-06-22 | Bug/feature issue templates + PR template; `config.yml` routes vulns to the security policy, not public issues. |
+| OSS-9 README product screenshots | ✅ shipped | [#433](https://github.com/openshiksha/openshiksha/pull/433) | 2026-06-22 | 3 V2 shots copied into a stable `docs/screenshots/` (not the churning initiative folder) + a demo-login note (`demo1234`). |
+| OSS-8 Mermaid architecture diagram | ✅ shipped | [#434](https://github.com/openshiksha/openshiksha/pull/434) | 2026-06-22 | ASCII → GitHub-rendered Mermaid `flowchart`; ASCII kept as a `<details>` fallback; stack table retained. |
+| OSS-7 consolidate root dev docs | ✅ shipped | [#435](https://github.com/openshiksha/openshiksha/pull/435) | 2026-06-22 | `git mv` four guides into `docs/dev/` (kebab-cased, history preserved) + index; repointed all hyperlinks. Remaining grep hits are historical ASCII trees, not links. |
+| OSS-10 repo metadata + license badge | ✅ shipped | (this PR) | 2026-06-22 | `gh repo edit` set description/homepage/topics (admin scope present); license already auto-detected as MPL-2.0; README license badge + `## License` updated. |
 
-**Remaining:** OSS-6 (`.github/` issue + PR templates), OSS-7 (consolidate root
-dev docs under `docs/`), OSS-8 (architecture diagram), OSS-9 (README screenshots),
-OSS-10 (repo metadata). The `security@`/`conduct@openshiksha.org` addresses assume
-an ImprovMX catch-all is configured — verify or adjust.
+**Definition of Done met (2026-06-22).** All of OSS-1..10 shipped. A
+clean-checkout newcomer can understand, run, and contribute from the README +
+linked docs alone: decluttered root, rewritten README with screenshots + a
+rendered architecture diagram, consolidated `docs/dev/` index, contributor
+templates, and discoverable repo metadata with a detected MPL-2.0 license.
+
+**Open follow-up (not blocking DoD):** the `security@`/`conduct@openshiksha.org`
+addresses assume an ImprovMX catch-all is configured — verify or adjust.


### PR DESCRIPTION
## Summary

Sets the GitHub repo metadata, badges the auto-detected MPL-2.0 license, and marks the **Open-Source Readiness** initiative **Done (DoD met)** — the final OSS-10 backlog item.

## Type

- [x] New (repo metadata) + Verify (license detection)

## Initiative / increment

Open-Source Readiness — **OSS-10** (closes the initiative)

## What changed

- **Metadata** via `gh repo edit` (admin scope present — already applied, no manual follow-up needed): description, homepage `https://openshiksha.org`, topics (`education, edtech, k12, django, react, typescript, india, learning-platform`).
- **License:** `gh repo view --json licenseInfo` already reports `mpl-2.0` — GitHub detects the existing `LICENSE.md`, so no plain-`LICENSE` copy needed. README license badge upgraded to a proper `MPL 2.0` badge; `## License` names it.
- **Ledger / STATUS:** OSS-6..10 marked shipped, initiative **Done**; Accessibility (Priority 2) promoted to top active initiative.

## How tested

- `gh repo view --json description,homepageUrl,repositoryTopics,licenseInfo` confirms metadata + `mpl-2.0`.
- README badges render. `pre-commit` green. Docs/metadata-only — no CI regression risk.

> **Independent** of the README stack (#433/#434/#435) — edits only the header badge + `## License` section. Closes the batch.

Change doc: `docs/changes/2026-06-22-oss10-repo-metadata.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)