### PR TITLE
ci: repoint Dependabot + SAST off the retired `modernization` branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: "/backend"
     schedule:
       interval: "weekly"
-    target-branch: "modernization"
+    target-branch: "qa"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -28,7 +28,7 @@ updates:
     directory: "/frontend_modern"
     schedule:
       interval: "weekly"
-    target-branch: "modernization"
+    target-branch: "qa"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -47,7 +47,7 @@ updates:
     directory: "/backend"
     schedule:
       interval: "monthly"
-    target-branch: "modernization"
+    target-branch: "qa"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -69,7 +69,7 @@ updates:
     directory: "/frontend_modern"
     schedule:
       interval: "monthly"
-    target-branch: "modernization"
+    target-branch: "qa"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -88,7 +88,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    target-branch: "modernization"
+    target-branch: "qa"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,7 +27,7 @@ See CONTRIBUTING.md for the branch model and commit conventions.
 
 ## Checklist
 
-- [ ] Targets the **`modernization`** branch
+- [ ] Targets the **`qa`** branch
 - [ ] CI is green (lint, type-check, tests, build)
 - [ ] Migrations created if models changed (`makemigrations --check` clean)
 - [ ] Docs / change log / initiative ledger updated if relevant

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -5,13 +5,13 @@ on: push
 # Cancel in-progress CI runs when a newer commit lands on the same feature
 # branch — the older run's results are stale anyway, and waiting on them
 # burns minutes and delays feedback. Long-lived branches that gate deploys
-# (modernization / qa / prod) are excluded: their runs build and publish
+# (qa / prod) are excluded: their runs build and publish
 # images and roll out to k3s, so cancelling mid-flight could leave the
 # cluster pointing at a half-pushed image. For those, each push runs to
 # completion and the most recent one wins by ordering.
 concurrency:
     group: ci-${{ github.ref }}
-    cancel-in-progress: ${{ github.ref != 'refs/heads/modernization' && github.ref != 'refs/heads/qa' && github.ref != 'refs/heads/prod' }}
+    cancel-in-progress: ${{ github.ref != 'refs/heads/qa' && github.ref != 'refs/heads/prod' }}
 
 # Least-privilege default for the GITHUB_TOKEN. Without an explicit block the
 # token inherits the repository/org default, which can be the legacy
@@ -181,7 +181,7 @@ jobs:
               # Push-triggered workflow: look up the PR for this branch (if any) and
               # post / update a sticky coverage summary so it shows in code review
               # without opening the artifact zip.
-              if: github.ref != 'refs/heads/modernization' && github.ref != 'refs/heads/qa' && github.ref != 'refs/heads/prod'
+              if: github.ref != 'refs/heads/qa' && github.ref != 'refs/heads/prod'
               working-directory: backend
               env:
                 GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -429,11 +429,13 @@ jobs:
     # ─── Deploy to QA env ────────────────────────────────────────────────────
     # DISABLED for now: there is no dedicated qa cluster yet. The single droplet
     # currently serves the PROD env, deployed from the `qa` branch (see deploy-prod
-    # below). The wiring here is the intended future state — `modernization`
-    # branch -> qa env — but gated off by the `QA_ENV_ENABLED` repo variable
-    # (currently unset, so this job never runs). To activate: provision a qa
-    # cluster + its `openshiksha-qa` secret, then set the repo Actions variable
-    # QA_ENV_ENABLED=true.
+    # below). The wiring here is a stale future-state sketch — it still triggers on
+    # the retired `modernization` branch, so the `if` below can never match. Before
+    # activating, decide which branch should feed a dedicated qa env (the old
+    # modernization -> qa flow no longer exists) and update the trigger. Gated off
+    # by the `QA_ENV_ENABLED` repo variable (currently unset, so this job never
+    # runs). To activate: provision a qa cluster + its `openshiksha-qa` secret,
+    # fix the branch trigger, then set the repo Actions variable QA_ENV_ENABLED=true.
     deploy-qa:
         name: Deploy to QA Cluster
         timeout-minutes: 15

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -19,12 +19,10 @@ name: CodeQL
 on:
     push:
         branches:
-            - modernization
             - qa
             - prod
     pull_request:
         branches:
-            - modernization
             - qa
             - prod
     schedule:
@@ -33,11 +31,11 @@ on:
         - cron: '17 6 * * 1'
 
 # Cancel superseded runs on feature branches; let the gated long-lived
-# branches (modernization/qa/prod) each run to completion, mirroring
+# branches (qa/prod) each run to completion, mirroring
 # ci-cd.yaml's concurrency policy.
 concurrency:
     group: codeql-${{ github.ref }}
-    cancel-in-progress: ${{ github.ref != 'refs/heads/modernization' && github.ref != 'refs/heads/qa' && github.ref != 'refs/heads/prod' }}
+    cancel-in-progress: ${{ github.ref != 'refs/heads/qa' && github.ref != 'refs/heads/prod' }}
 
 jobs:
     analyze:

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -11,8 +11,8 @@ name: Dependabot auto-merge
 #
 # Why we wait-then-merge instead of `gh pr merge --auto`: GitHub's native
 # auto-merge can only be *enabled* while a PR is blocked by **required status
-# checks** — i.e. the base branch has branch protection. Our integration branch
-# `modernization` is intentionally unprotected (the build routines push to it
+# checks** — i.e. the base branch has branch protection. Our trunk branch
+# `qa` is intentionally unprotected (the build routines push to it
 # directly, which required checks would reject), so `--auto` fails with
 # "Pull request is in unstable status (enablePullRequestAutoMerge)" and nothing
 # ever merges. Instead we watch this commit's "CI/CD Pipeline" run and, when it

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -9,7 +9,6 @@ name: Dependency Review
 on:
     pull_request:
         branches:
-            - modernization
             - qa
             - prod
 


### PR DESCRIPTION
## What

`modernization` was deleted when its content squash-merged into `qa` (now the trunk) in #437. Several CI surfaces still targeted it and were silently broken against the real trunk. This repoints them to `qa`.

## Changes

| File | Fix |
|------|-----|
| `.github/dependabot.yml` | All 5 ecosystems had `target-branch: modernization` (a nonexistent branch) → `qa`. **This is the headline fix: Dependabot couldn't open PRs at all.** |
| `codeql.yaml` | Dropped `modernization` from push/PR triggers (CodeQL SAST wasn't running on trunk). |
| `dependency-review.yaml` | Dropped `modernization` from PR triggers. |
| `ci-cd.yaml` | Removed dead `modernization` clause from the concurrency guard and coverage-comment skip. |
| `dependabot-automerge.yaml` | Comment updated `modernization` → `qa`. |
| `pull_request_template.md` | Checklist now says target `qa`. |

## Deliberately left

The disabled `deploy-qa` job still references `modernization` in its `if`. It's double-gated (`QA_ENV_ENABLED` is unset, so it never runs) and represents future-state wiring. Rather than invent new deploy semantics, its comment now flags the trigger as retired so the branch is fixed before anyone enables the qa env.

## How tested

- All five YAML files parse (`yaml.safe_load`).
- `grep -rn modernization .github/` returns only the intentionally-documented `deploy-qa` lines.
- Pre-commit (check-yaml, trailing-whitespace, eof) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)