### PR TITLE
test(a11y): gate authoring forms + parent insights (A11Y-13/15) — Batch 3 close-out

### DIFF
--- a/docs/changes/2026-06-24-a11y-batch3-closeout.md
+++ b/docs/changes/2026-06-24-a11y-batch3-closeout.md
@@ -1,0 +1,102 @@
+# 2026-06-24 — A11Y-13/15: authoring forms + parent insights gated (Batch 3 close-out)
+
+## Summary
+
+Extended the gated WCAG 2.1 AA axe contract onto the **last unmeasured
+authenticated surfaces** — the dense teacher authoring forms and the parent
+insights pages — fully satisfying **DoD item 6** of the
+[Accessibility — WCAG 2.1 AA](../initiatives/2026-accessibility-wcag-aa.md)
+initiative. Five routes were added to the per-route axe harness and, because the
+baseline came back clean, gated directly:
+
+- `/teacher/questions/new` (`CreateQuestionPage`)
+- `/teacher/assignments/new` (`CreateAssignmentPage`)
+- `/teacher/problem-sets/new` (`CreateProblemSetPage`)
+- `/parent/insights` (`ParentInsightsLandingPage`)
+- `/parent/insights/:childId` (`ParentInsightsPage`)
+
+All five compute `blocking === []` (zero serious/critical axe violations). The
+only residual is `color-contrast` in axe's **`incomplete`** bucket (a background
+axe can't compute) — recorded but non-gating, the same contract as every other
+gated route.
+
+## Classification
+
+**New** (gate the last authenticated surfaces) + **Improve** (latent crash fix) +
+**Docs** (Batch 3 close-out).
+
+## Legacy reference
+
+None to port — legacy Django 1.11 templates (`sphinx/`) had no labels-for, no
+fieldset grouping, no automated a11y checking. This is net-new platform capability
+(an enforced AA gate over the modern authoring/insights surfaces).
+
+## What changed
+
+### Harness (`frontend_modern/e2e/`)
+
+- **`a11y.spec.ts`** — added the five routes above to the `ROUTES` table with
+  `gate: true`.
+- **`support/auth.ts`** — added the object/list reads these pages need so they
+  render past their loading states to a visible `h1`:
+  - `/subject-rooms/` → one `TEACHER_SUBJECT_ROOM` (the authoring forms swap their
+    class `<Select>` for a "no rooms" message when the list is empty, hiding the
+    very controls axe must scan; one row renders the labelled selects).
+  - `/chapters/` → one `CHAPTER`.
+  - `/ai/parent-summaries/latest/` → `404`, so `ParentInsightsPage` renders its
+    "No summary yet" empty state (which carries the `h1`) via the hook's existing
+    404→null contract — a paginated-empty body would be the wrong shape.
+
+### Latent crash fix (`support/auth.ts`)
+
+Seeding a subject room makes the **teacher dashboard** render
+`ClassroomCodeWidget` (previously never exercised by the gated `/teacher` route,
+because the empty-rooms dashboard skips it). That widget reads the **bare-array**
+endpoint `/users/me/classroom-code/`, but the harness catch-all returns a
+*paginated object*, so `codes?.find(...)` threw `TypeError: codes?.find is not a
+function` and tripped the ErrorBoundary. Added an explicit `[]` stub for that
+endpoint. Net effect: the teacher-dashboard gate now actually covers
+`ClassroomCodeWidget`, closing a blind spot.
+
+## Why A11Y-14 (remediation) was a no-op
+
+The day's plan staged this as baseline (A11Y-13) → remediate (A11Y-14) → gate
+(A11Y-15), anticipating unlabelled inputs / heading-order / contrast findings on
+the dense forms. The baseline disproved that premise: every form control is built
+from the shared `Input` / `Select` / `Textarea` primitives
+(`src/shared/ui/Input.tsx`), which already wire `<label htmlFor>` +
+`aria-describedby`, and each page leads with a single `h1` (`SectionHeading
+as="h1"` or a literal `<h1>`). With `blocking === []` on all five routes there was
+nothing to remediate, so the empty A11Y-14 step was collapsed and the rows gate
+directly — mirroring the A11Y-3 / A11Y-9 precedent where the public and
+teacher-core baselines also came back structurally clean.
+
+## Tests
+
+- `npx playwright test e2e/a11y.spec.ts` — **20/20 routes pass**, including the
+  five newly-gated routes asserting `blocking === []` and the teacher-dashboard
+  route now rendering `ClassroomCodeWidget`.
+- `npx tsc --noEmit` — clean.
+- `npm run lint` — clean (`--max-warnings 0`).
+
+## How to verify
+
+```bash
+cd frontend_modern
+npx playwright test e2e/a11y.spec.ts
+# inspect the baselines:
+cat axe-report/teacher-create-question.json | jq .summary.blocking      # []
+cat axe-report/parent-insights-child.json   | jq .summary.blocking      # []
+```
+
+## Migration notes
+
+None — frontend + docs only, no backend or schema changes.
+
+## Next steps
+
+- **Batch 4 (DoD item 5)** — automated keyboard-traversal spec
+  (`e2e/keyboard.spec.ts`: skip-link, no-trap, dialog focus-trap + Escape) and a
+  screen-reader (NVDA/VoiceOver) sign-off scaffold + announce-region audit.
+- Once Batch 4 lands, consider an axe CI job over authenticated routes against the
+  full Docker stack (real data instead of stubs).

--- a/docs/initiatives/2026-accessibility-wcag-aa.md
+++ b/docs/initiatives/2026-accessibility-wcag-aa.md
@@ -57,12 +57,14 @@ platform capability**.
    proficiency) remediated + gated. ✅ *(Batch 2 — A11Y-6/7/8, 2026-06-20..23)*
 5. *(future)* **Keyboard-only walkthrough + screen-reader spot-check** (NVDA /
    VoiceOver) sign-off.
-6. **Teacher / parent surfaces** remediated + gated. 🟡 *(Batch 3 — A11Y-9/11/12,
-   2026-06-23: the teacher dashboard/question-bank/grading + parent dashboard are
-   gated. Remaining: the dense authoring forms — `CreateQuestionPage`,
-   `CreateAssignmentPage`, `CreateProblemSetPage` — and parent insights pages, a
-   future increment.)* Consider an axe CI job over authenticated routes against the
-   Docker stack.
+6. **Teacher / parent surfaces** remediated + gated. ✅ *(Batch 3 — A11Y-9/11/12
+   + A11Y-13/15, 2026-06-23..24: the teacher dashboard/question-bank/grading +
+   parent dashboard, **plus** the dense authoring forms — `CreateQuestionPage`,
+   `CreateAssignmentPage`, `CreateProblemSetPage` — and the parent insights pages
+   are all gated (`blocking === []`). The authoring-form baseline came back clean:
+   the forms compose from the shared labelled `Input`/`Select`/`Textarea`
+   primitives, so the anticipated labelling/heading remediation surface was empty.)*
+   Consider an axe CI job over authenticated routes against the Docker stack.
 
 ## Phase / batch plan
 
@@ -106,4 +108,5 @@ it in = flip that row's `gate` once it's clean.
 | [#441](https://github.com/openshiksha/openshiksha/pull/441) | A11Y-8 — gate the student core-loop routes + Batch 2 close-out | New + Docs | Flipped `/student`, `/student/assignments/:id`, `/student/proficiency`, `/student/srs-drill/:entryId` to `gate: true` (all `blocking === []`); change doc + student-loop manual checklist; **DoD item 4 done**. |
 | [#442](https://github.com/openshiksha/openshiksha/pull/442) | A11Y-9 — authenticated axe harness for teacher + parent surfaces (Batch 3 baseline) | New | Role-parametrized the harness (`TEACHER_USER`/`PARENT_USER`/`CHILD_USER` + `makeRouteHandler`); added `/teacher`, `/teacher/questions`, `/teacher/grading`, `/parent` (reporting). Teacher surfaces clean; `/parent` flagged one contrast node. |
 | [#450](https://github.com/openshiksha/openshiksha/pull/450) | A11Y-11 — brand-text-on-tint contrast remediation | Improve | Small `brand-700` text on the `brand-50` tint is 4.45 : 1 (under AA); moved the `/parent` "View insights" link + the `AssignmentList` brand badge to `brand-800`; documented the rule. `/parent` → `blocking: []`. |
-| A11Y-12 (this batch) | Gate the teacher + parent routes + Batch 3 close-out | New + Docs | Flipped `/teacher`, `/teacher/questions`, `/teacher/grading`, `/parent` to `gate: true` (all `blocking === []`); change doc + teacher/parent manual checklist; **DoD item 6 (partial) — teacher/parent core surfaces gated**. |
+| [#451](https://github.com/openshiksha/openshiksha/pull/451) | A11Y-12 — gate the teacher + parent routes + Batch 3 close-out | New + Docs | Flipped `/teacher`, `/teacher/questions`, `/teacher/grading`, `/parent` to `gate: true` (all `blocking === []`); change doc + teacher/parent manual checklist; **DoD item 6 (partial) — teacher/parent core surfaces gated**. |
+| A11Y-13/15 (this batch) | Baseline + gate the authoring forms + parent insights + ClassroomCodeWidget crash fix | New + Improve + Docs | Added `/teacher/questions/new`, `/teacher/assignments/new`, `/teacher/problem-sets/new`, `/parent/insights`, `/parent/insights/:childId` to the harness; baseline came back `blocking === []` (forms use the shared labelled primitives), so the planned A11Y-14 remediation was a no-op and the rows gate directly. Also stubbed the bare-array `/users/me/classroom-code/` read so the dashboard's `ClassroomCodeWidget` renders (a previously-uncovered crash under the catch-all). **DoD item 6 fully met.** |

--- a/docs/initiatives/STATUS.md
+++ b/docs/initiatives/STATUS.md
@@ -11,7 +11,22 @@
 > it is the only thing with open work. It is intentionally **omitted from the
 > priority table below** so it is never picked as the "top active initiative."
 
-**Last updated:** 2026-06-23 (latest) — **Accessibility Batch 3 CLOSED — teacher +
+**Last updated:** 2026-06-24 (latest) — **Accessibility Batch 3 FULLY CLOSED —
+authoring forms + parent insights measured & gated (DoD item 6 ✅).** A11Y-13/15
+added the last unmeasured authenticated surfaces to the harness —
+`/teacher/questions/new`, `/teacher/assignments/new`, `/teacher/problem-sets/new`,
+`/parent/insights`, `/parent/insights/:childId`. The baseline came back
+`blocking === []` on all five: the dense authoring forms compose from the shared
+labelled `Input`/`Select`/`Textarea` primitives, so the anticipated A11Y-14
+labelling/heading remediation was a no-op and the rows gate directly. The same PR
+fixes a previously-uncovered crash — the dashboard's `ClassroomCodeWidget` reads
+the bare-array `/users/me/classroom-code/` endpoint, which the harness catch-all
+mishandled; now stubbed (and the widget is exercised by the gated teacher-dashboard
+route). **DoD item 6 fully met.** **Next: Batch 4 — automated keyboard-traversal
+spec + screen-reader (NVDA/VoiceOver) sign-off** (DoD item 5). The
+`ai-features` routine fence is respected. *(Prior update below.)*
+
+**2026-06-23** — **Accessibility Batch 3 (core) CLOSED — teacher +
 parent core surfaces measured, remediated & gated.** Building on the same-day
 Batch 2 close-out, Batch 3 generalized the authenticated axe harness to the
 teacher and parent roles and extended the gated AA contract to those surfaces:
@@ -20,14 +35,10 @@ A11Y-9 ([#442](https://github.com/openshiksha/openshiksha/pull/442) — role-par
 `/parent` baselined; teacher surfaces clean) → A11Y-11
 ([#450](https://github.com/openshiksha/openshiksha/pull/450) — the one finding:
 small `brand-700` text on the `brand-50` tint = 4.45 : 1 → `brand-800`, the
-`/parent` link + `AssignmentList` badge, rule documented) → **A11Y-12 (this PR)**
-flips all four teacher/parent routes to `gate: true` (all `blocking === []`) +
-Batch 3 close-out (change doc, teacher/parent manual checklist, ledger). **DoD
-item 6 is now partially met** — the teacher/parent *core* surfaces are gated; the
-dense authoring forms (`CreateQuestionPage`/`CreateAssignmentPage`/`CreateProblemSetPage`)
-and parent insights pages are deferred to a future increment (never gate a dirty
-route). **Next: Batch 4 — full keyboard-only + screen-reader (NVDA/VoiceOver)
-sign-off** (DoD item 5), plus the deferred authoring-form baseline. The
+`/parent` link + `AssignmentList` badge, rule documented) → **A11Y-12**
+([#451](https://github.com/openshiksha/openshiksha/pull/451)) flips all four
+teacher/parent routes to `gate: true` (all `blocking === []`) +
+Batch 3 close-out (change doc, teacher/parent manual checklist, ledger). The
 `ai-features` routine fence is respected. *(Prior update below.)*
 
 **2026-06-23** — **Accessibility Batch 2 CLOSED — student

--- a/frontend_modern/e2e/a11y.spec.ts
+++ b/frontend_modern/e2e/a11y.spec.ts
@@ -73,6 +73,21 @@ const ROUTES: AuditRoute[] = [
   { name: 'teacher-question-bank', path: '/teacher/questions', gate: true, auth: 'teacher' },
   { name: 'teacher-grading', path: '/teacher/grading', gate: true, auth: 'teacher' },
   { name: 'parent-dashboard', path: '/parent', gate: true, auth: 'parent' },
+  // A11Y-13/15 (Batch 3 close-out): the dense teacher authoring forms + parent
+  // insights — the last authenticated surfaces that were still UNMEASURED — now
+  // GATED. The A11Y-13 baseline came back structurally clean (`blocking === []`
+  // on all five): the forms are composed from the shared labelled `Input` /
+  // `Select` / `Textarea` primitives, so the labelling/heading findings A11Y-14
+  // anticipated never materialised (the planned remediation surface was empty,
+  // mirroring how A11Y-9 found the teacher *core* surfaces clean). Residual
+  // colour-contrast lands in axe's `incomplete` bucket (background axe can't
+  // compute) — recorded but non-gating, the same contract as every other route.
+  // This fully satisfies the initiative's DoD item 6.
+  { name: 'teacher-create-question', path: '/teacher/questions/new', gate: true, auth: 'teacher' },
+  { name: 'teacher-create-assignment', path: '/teacher/assignments/new', gate: true, auth: 'teacher' },
+  { name: 'teacher-create-problemset', path: '/teacher/problem-sets/new', gate: true, auth: 'teacher' },
+  { name: 'parent-insights', path: '/parent/insights', gate: true, auth: 'parent' },
+  { name: 'parent-insights-child', path: '/parent/insights/10', gate: true, auth: 'parent' },
 ];
 
 const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];

--- a/frontend_modern/e2e/support/auth.ts
+++ b/frontend_modern/e2e/support/auth.ts
@@ -177,6 +177,32 @@ const STREAK = {
   milestone_tier: 'week',
 };
 
+// ── Authoring-form fixtures (A11Y-13) ────────────────────────────────────────
+// The teacher authoring forms render their inner controls whenever the teacher
+// has at least one subject room (`CreateAssignmentPage` swaps its class <Select>
+// for a "no rooms" message when the list is empty, hiding the very controls axe
+// must scan). One row is enough to render the labelled selects without requiring
+// any in-test interaction.
+const TEACHER_SUBJECT_ROOM = {
+  id: 1,
+  classroom: 1,
+  classroom_display: 'Class 8A',
+  subject: 1,
+  subject_name: 'Mathematics',
+  teacher: TEACHER_USER.id,
+  teacher_name: 'Meera Teacher',
+  is_active: true,
+  student_count: 20,
+};
+
+const CHAPTER = {
+  id: 1,
+  name: 'Whole Numbers',
+  standard: 8,
+  standard_number: 8,
+  subject: 1,
+};
+
 // ── Dispatch ─────────────────────────────────────────────────────────────────
 
 /** The signed-in user shape the dispatch resolves `/users/me/` to. */
@@ -197,12 +223,28 @@ function makeRouteHandler(user: SessionUser) {
     if (p.endsWith('/users/me/children/')) return json(route, [CHILD_USER]);
     if (p.endsWith('/users/me/')) return json(route, user);
     if (p.endsWith('/users/me/streak/')) return json(route, STREAK);
+    // Bare-array (non-paginated) reads: the catch-all returns a paginated
+    // *object*, which breaks consumers that call array methods on the body
+    // directly (`codes?.find`). The teacher dashboard's ClassroomCodeWidget now
+    // renders once a subject room exists (A11Y-13 fixtures), so stub its read.
+    if (p.endsWith('/users/me/classroom-code/')) return json(route, []);
 
     // Object (non-list) endpoints that signal "nothing yet" with a 404 — their
     // hooks map 404 → null/disabled and render an empty state, whereas a
     // paginated-empty body would be the wrong shape and throw in a consumer.
     if (p.endsWith('/ai/practice-plans/today/')) return json(route, { detail: 'No plan' }, 404);
     if (p.endsWith('/push/vapid-public-key/')) return json(route, { detail: 'Disabled' }, 404);
+    // Parent insights: no summary generated yet → the page renders its
+    // "No summary yet" empty state (which carries the `h1`), the same 404→null
+    // contract the page's hook already handles. A paginated-empty body would be
+    // the wrong shape and render a malformed summary card.
+    if (p.endsWith('/ai/parent-summaries/latest/')) return json(route, { detail: 'No summary' }, 404);
+
+    // Teacher authoring-form reads (A11Y-13). One row each so the forms render
+    // their labelled selects; the inner question/chapter selects stay at their
+    // empty default, which still renders a labelled control for axe to scan.
+    if (p.endsWith('/subject-rooms/')) return json(route, paginated([TEACHER_SUBJECT_ROOM]));
+    if (p.endsWith('/chapters/')) return json(route, paginated([CHAPTER]));
 
     // Core-loop reads (shared across roles).
     if (/\/assignments\/\d+\/$/.test(p)) return json(route, ASSIGNMENT_DETAIL);


### PR DESCRIPTION
## Classification
**New** (gate the last unmeasured authenticated surfaces) + **Improve** (latent crash fix) + **Docs** (Batch 3 close-out).

Part of the [Accessibility — WCAG 2.1 AA](../blob/qa/docs/initiatives/2026-accessibility-wcag-aa.md) initiative. **Closes DoD item 6.**

## What this does
Adds the last unmeasured authenticated surfaces to the per-route axe harness (`e2e/a11y.spec.ts`) and gates them directly:

- `/teacher/questions/new` (`CreateQuestionPage`)
- `/teacher/assignments/new` (`CreateAssignmentPage`)
- `/teacher/problem-sets/new` (`CreateProblemSetPage`)
- `/parent/insights` (`ParentInsightsLandingPage`)
- `/parent/insights/:childId` (`ParentInsightsPage`)

All five compute `blocking === []` (zero serious/critical axe violations). Residual `color-contrast` stays in axe's non-gating `incomplete` bucket — the same contract as every other gated route.

### Why no remediation PR (A11Y-14)
The day's plan staged baseline → remediate → gate, expecting unlabelled-input / heading-order findings on the dense forms. The baseline disproved that: every control is built from the shared labelled `Input`/`Select`/`Textarea` primitives (`src/shared/ui/Input.tsx`) and each page leads with a single `h1`. With `blocking === []` everywhere, A11Y-14 was a no-op and the rows gate directly — mirroring the A11Y-3/A11Y-9 clean-baseline precedent.

### Latent crash fix
Seeding a subject room makes the teacher dashboard render `ClassroomCodeWidget`, which reads the **bare-array** `/users/me/classroom-code/` endpoint. The harness catch-all returns a paginated *object*, so `codes?.find(...)` threw and tripped the ErrorBoundary. Added an explicit `[]` stub — the teacher-dashboard gate now actually covers `ClassroomCodeWidget` (previously a blind spot).

## Legacy reference
None to port — legacy `sphinx/` templates had no labels-for / fieldset grouping / a11y checking. Net-new enforced AA gate.

## Tests
- `npx playwright test e2e/a11y.spec.ts` — **20/20 routes pass** (5 newly gated + teacher-dashboard now rendering ClassroomCodeWidget).
- `npx tsc --noEmit` — clean.
- `npm run lint` — clean (`--max-warnings 0`).

## How to verify
```bash
cd frontend_modern && npx playwright test e2e/a11y.spec.ts
cat axe-report/teacher-create-question.json | jq .summary.blocking   # []
```

Change doc: `docs/changes/2026-06-24-a11y-batch3-closeout.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)