### PR TITLE
feat(a11y): screen-reader sign-off scaffold + announce post-submit score (A11Y-17)

### DIFF
--- a/docs/changes/2026-06-24-a11y-screenreader-signoff.md
+++ b/docs/changes/2026-06-24-a11y-screenreader-signoff.md
@@ -1,0 +1,60 @@
+# 2026-06-24 — A11Y-17: screen-reader sign-off scaffold + announce-region audit
+
+## Summary
+
+Two-part increment for **Batch 4** (DoD item 5) of the
+[Accessibility — WCAG 2.1 AA](../initiatives/2026-accessibility-wcag-aa.md)
+initiative:
+
+1. **Screen-reader sign-off scaffold** — a structured NVDA (Windows) + VoiceOver
+   (mac/iOS) manual test script, `docs/initiatives/a11y/screen-reader-signoff.md`,
+   with a per-journey table (sign-in, register, browse, **practice + submit**,
+   parent dashboard), expected announcements, and pass/fail columns. This is the
+   manual evidence template a human runs to close DoD item 5.
+2. **Announce-region audit + fix** — audited the app's dynamic regions for correct
+   live-region semantics and fixed the one real gap.
+
+## Classification
+
+**Docs** (sign-off scaffold) + **Improve** (live-region fix).
+
+## Legacy reference
+
+None — legacy Django 1.11 had no live-region / status-message semantics.
+
+## What changed
+
+### Fix: announce the post-submit score (WCAG 4.1.3 Status Messages)
+
+`student/AssignmentDetailPage.tsx` — the post-submit outcome card (score /
+"grading…" / "submitted offline") appears **dynamically** after the student
+submits, but had no live-region semantics, so a screen-reader user heard nothing.
+Added `role="status"` + `aria-live="polite"` to that card so the result is
+announced politely (without stealing focus) once the SR finishes the current
+utterance.
+
+The audit confirmed the other named dynamic regions were already correct:
+- "Saved on this device · will sync" — `SyncStatus.tsx` (`role=status`, MSO-8) ✅
+- offline/reconnect + app-update banners, announcements banner, loading
+  spinners/skeletons — all already live regions ✅
+- the app has **no global toast** (status is inline), so there was nothing to fix
+  there.
+
+The one remaining gap (dialog focus-trap/restore on the QuestionBank side-sheet)
+is documented in the sign-off doc as the Batch-4 follow-up.
+
+## Tests
+
+- `student/AssignmentDetailPage.offline.test.tsx` — extended the score-reconcile
+  case to assert the revealed score sits in a `getByRole('status')` region with
+  `aria-live="polite"` and the score text. **3/3 pass.**
+- `npx tsc --noEmit` + `eslint` — clean.
+
+## Migration notes
+
+None — frontend + docs only.
+
+## Next steps
+
+- Run the NVDA/VoiceOver script and record sign-off → closes DoD item 5.
+- Implement + gate the dialog focus-trap / focus-restore behaviour.

--- a/docs/initiatives/a11y/screen-reader-signoff.md
+++ b/docs/initiatives/a11y/screen-reader-signoff.md
@@ -1,0 +1,96 @@
+# Screen-reader sign-off — manual test script (A11Y-17)
+
+Part of the [Accessibility — WCAG 2.1 AA](../2026-accessibility-wcag-aa.md)
+initiative (**DoD item 5** — keyboard-only + screen-reader sign-off).
+
+This is the **manual evidence template**. The automated specs
+(`e2e/a11y.spec.ts` axe gate, `e2e/keyboard.spec.ts` keyboard gate) cover
+structure, contrast, and keyboard operability; a real screen-reader pass is the
+remaining human check. Run this script per release-significant a11y change, record
+the result in the per-journey tables below, and link the filled copy from the PR.
+
+## How to run
+
+| Platform | Screen reader | Browser | Launch |
+|---|---|---|---|
+| Windows | **NVDA** (free, [nvaccess.org](https://www.nvaccess.org/)) | Firefox or Chrome | `Ctrl+Alt+N` |
+| macOS / iOS | **VoiceOver** (built-in) | Safari | `Cmd+F5` (mac) / triple-click side button (iOS) |
+
+Core commands: NVDA — `Tab`/`Shift+Tab` (focus), `↓`/`↑` (read next/prev),
+`NVDA+Space` (forms mode), `Insert+F7` (elements list). VoiceOver — `VO+→`/`VO+←`
+(navigate), `VO+Space` (activate), `VO+U` (rotor).
+
+**Pass criteria per step:** the expected announcement is spoken, focus order is
+logical, no control is silent or unlabeled, and dynamic changes (status messages)
+are announced without stealing focus.
+
+---
+
+## Journey 1 — Sign in
+
+| # | Action | Expected announcement | NVDA | VO | Notes |
+|---|---|---|---|---|---|
+| 1 | Load `/login` | "OpenShiksha", heading level 1; then "Email, edit" | ☐ | ☐ | |
+| 2 | Tab to password | "Password, edit, protected" | ☐ | ☐ | |
+| 3 | Submit empty | Inline error announced (field `aria-describedby`) | ☐ | ☐ | |
+| 4 | Submit valid | Route change announced; lands on dashboard `h1` | ☐ | ☐ | |
+
+## Journey 2 — Register (open student)
+
+| # | Action | Expected announcement | NVDA | VO | Notes |
+|---|---|---|---|---|---|
+| 1 | Load `/register/open` | Form heading `h1`; first field labelled | ☐ | ☐ | |
+| 2 | Tab through fields | Each control names itself (no placeholder-only) | ☐ | ☐ | |
+| 3 | Validation error | Error text announced, focus stays usable | ☐ | ☐ | |
+
+## Journey 3 — Browse & start practice
+
+| # | Action | Expected announcement | NVDA | VO | Notes |
+|---|---|---|---|---|---|
+| 1 | Load `/student` | "Skip to main content" link reachable first | ☐ | ☐ | |
+| 2 | Activate skip link | Focus moves into `#main-content` | ☐ | ☐ | gated in `keyboard.spec.ts` |
+| 3 | Open an assignment | Assignment title `h1` announced | ☐ | ☐ | |
+
+## Journey 4 — Practice + submit (highest priority)
+
+| # | Action | Expected announcement | NVDA | VO | Notes |
+|---|---|---|---|---|---|
+| 1 | Read a question | Question text + options announced as a group | ☐ | ☐ | |
+| 2 | Select an MCQ option | Selected state announced | ☐ | ☐ | |
+| 3 | Submit | **Score card announced via `role=status`/`aria-live=polite`** | ☐ | ☐ | A11Y-17 fix; asserted in `AssignmentDetailPage.offline.test.tsx` |
+| 4 | Submit while offline | "Saved on this device · will sync" announced (`SyncStatus`, `role=status`) | ☐ | ☐ | MSO-8 |
+
+## Journey 5 — Parent dashboard
+
+| # | Action | Expected announcement | NVDA | VO | Notes |
+|---|---|---|---|---|---|
+| 1 | Load `/parent` | Dashboard `h1`; child cards as a list | ☐ | ☐ | |
+| 2 | Open insights | Insights `h1`; empty/summary state announced | ☐ | ☐ | |
+
+---
+
+## Announce-region inventory (the automatable slice)
+
+Dynamic regions audited for correct live-region semantics. `role=status` /
+`aria-live="polite"` for non-urgent status; `aria-live="assertive"` /
+`role=alert` only for errors. **Scope the live region to the single status node —
+never wrap a whole form**, or every keystroke floods the user.
+
+| Region | Component | Semantics | Status |
+|---|---|---|---|
+| Post-submit score / grading / offline-submit card | `student/AssignmentDetailPage.tsx` | `role=status` `aria-live=polite` | ✅ added A11Y-17 (asserted) |
+| "Saved on this device · will sync" | `student/SyncStatus.tsx` | `role=status` `aria-live=polite` | ✅ MSO-8 |
+| Offline / reconnect banner | `layout/OfflineBanner.tsx` | live region | ✅ (covered by test) |
+| App-update available banner | `pwa/UpdateBanner.tsx` | live region | ✅ (covered by test) |
+| Announcements banner | `student/AnnouncementsBanner.tsx` | live region | ✅ |
+| Loading spinners / skeletons | `shared/ui/LoadingSpinner.tsx`, `Skeleton.tsx` | `role=status` | ✅ |
+
+### Remaining (Batch 4 follow-up)
+
+- **Dialog focus management** — the QuestionBank "Add to set" side-sheet
+  (`teacher/QuestionBankPage.tsx → AddToProblemSetSheet`) moves focus inside on
+  open and closes on Escape, but still needs a true focus **trap** (Tab bounded
+  within the dialog) and focus **restore** (return to the trigger on close) —
+  WCAG 2.4.3 / 2.1.2. Once implemented, gate it in `keyboard.spec.ts`.
+- App has **no global toast component**; status is surfaced inline per the regions
+  above. If a toast is later introduced it must be a polite live region.

--- a/frontend_modern/src/features/student/AssignmentDetailPage.offline.test.tsx
+++ b/frontend_modern/src/features/student/AssignmentDetailPage.offline.test.tsx
@@ -113,6 +113,12 @@ describe('AssignmentDetailPage — offline final-submit (MSO-9)', () => {
     expect(
       screen.queryByText(/will be graded when you're back online/i),
     ).not.toBeInTheDocument();
+
+    // A11Y-17: the revealed score sits in a polite live region so screen-reader
+    // users hear the outcome announced rather than it appearing silently.
+    const statusRegion = screen.getByRole('status');
+    expect(statusRegion).toHaveAttribute('aria-live', 'polite');
+    expect(statusRegion).toHaveTextContent('80%');
   });
 
   it('re-opens the form if the queued submit ultimately fails', async () => {

--- a/frontend_modern/src/features/student/AssignmentDetailPage.tsx
+++ b/frontend_modern/src/features/student/AssignmentDetailPage.tsx
@@ -215,7 +215,16 @@ export const AssignmentDetailPage = () => {
       )}
 
       {isSubmitted && (
-        <div className={`mb-6 rounded-xl p-4 text-center border ${scoreBg}`}>
+        // A11Y-17: announce the post-submit outcome (score / "grading…" /
+        // "submitted offline") to screen-reader users — the card appears
+        // dynamically after submit, so without a polite live region the result
+        // is silent. `aria-live="polite"` waits for the SR to finish the user's
+        // current utterance before reading the score (WCAG 4.1.3 Status Messages).
+        <div
+          role="status"
+          aria-live="polite"
+          className={`mb-6 rounded-xl p-4 text-center border ${scoreBg}`}
+        >
           {submittedOffline ? (
             <>
               <p className="font-display font-semibold text-brand-800">


### PR DESCRIPTION
## Classification
**Docs** (sign-off scaffold) + **Improve** (live-region fix).

Batch 4 (DoD item 5) groundwork for the [Accessibility — WCAG 2.1 AA](../blob/qa/docs/initiatives/2026-accessibility-wcag-aa.md) initiative.

## What this does
**1. Screen-reader sign-off scaffold** — `docs/initiatives/a11y/screen-reader-signoff.md`: a structured NVDA (Windows) + VoiceOver (mac/iOS) manual test script with a per-journey table (sign-in, register, browse, **practice + submit**, parent), expected announcements, and pass/fail columns. The manual evidence template that closes DoD item 5.

**2. Announce-region audit + fix** — the post-submit outcome card (score / "grading…" / "submitted offline") in `AssignmentDetailPage.tsx` appears **dynamically** after submit but had no live-region semantics → silent for screen-reader users. Added `role="status"` + `aria-live="polite"` (WCAG 4.1.3 Status Messages). The audit confirmed the other dynamic regions (SyncStatus MSO-8, offline/update banners, spinners) were already correct; the app has no global toast.

## Tests
- `AssignmentDetailPage.offline.test.tsx` — extended to assert the revealed score sits in a `getByRole('status')` region with `aria-live="polite"`. **3/3 pass.**
- `npx tsc --noEmit` + `eslint` — clean.

## Legacy reference
None — net-new live-region semantics + manual a11y evidence template.

## Next steps
- Run the NVDA/VoiceOver script and record sign-off → closes DoD item 5.
- Implement + gate the QuestionBank dialog focus-trap / focus-restore (documented in the sign-off doc).

Change doc: `docs/changes/2026-06-24-a11y-screenreader-signoff.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)