### PR TITLE
fix(routing): keep ProtectedRoute deep-links from bouncing during auth bootstrap

### DIFF
--- a/frontend_modern/e2e/a11y.spec.ts
+++ b/frontend_modern/e2e/a11y.spec.ts
@@ -87,6 +87,17 @@ test.describe('public surfaces — accessibility (axe-core)', () => {
       // reporting spec from flaking on a slow paint.
       await page.waitForLoadState('networkidle');
       await page.evaluate(() => document.fonts.ready);
+
+      // Guard against the auth-bootstrap deep-link bounce: a hard nav to a
+      // ProtectedRoute must *stay* on that route, not get redirected through
+      // /login → role home during cache-restore (see useAuth / the deep-link
+      // spec). Without this, a gated route could silently axe-scan the role
+      // dashboard instead of its own surface — e.g. `teacher-question-bank`
+      // scanning the Teacher dashboard at /teacher. Parameterised paths
+      // (`:id`) still resolve to the literal requested pathname here.
+      expect(new URL(page.url()).pathname, `deep-link to ${route.path} was redirected`).toBe(
+        route.path,
+      );
       await expect(page.locator('h1').first()).toBeVisible();
 
       const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();

--- a/frontend_modern/e2e/deep-link.spec.ts
+++ b/frontend_modern/e2e/deep-link.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { AUTH_SETUP } from './support/auth';
+
+// Regression guard for the auth-bootstrap deep-link bounce.
+//
+// Symptom: a hard navigation / deep-link to a ProtectedRoute (e.g.
+// /teacher/questions) rendered the role *dashboard* at /teacher instead of the
+// requested page.
+//
+// Root cause: while `PersistQueryClientProvider` rehydrates the query cache from
+// IndexedDB (MSO-4), queries are held idle — `status: 'pending'` but
+// `fetchStatus: 'idle'`. React Query's `isLoading` (= isPending && isFetching)
+// is therefore *false* during that restore window even though the auth-verify
+// result is still unknown. `useAuth` used to gate on `isLoading`, so the app
+// painted an unauthenticated tree for the first frame; `ProtectedRoute` saw
+// `isAuthenticated === false` and redirected to /login. Moments later verify
+// resolved `true`, and `LoginPage` (now mounted at /login) bounced the verified
+// user to their role home (`/` → defaultPath) — silently dropping the deep
+// link. The fix gates `useAuth` on `isPending` + `useIsRestoring()` instead.
+//
+// This reproduces in both `vite dev` and `vite preview` (it is the restore race,
+// not the service worker). The runner here is `vite preview` (no backend), so we
+// seed a JWT + stub the API exactly as the a11y audit does.
+
+test.describe('protected deep-links survive auth bootstrap', () => {
+  test('hard nav to /teacher/questions renders the Question Bank, not the dashboard', async ({
+    page,
+  }) => {
+    await AUTH_SETUP.teacher(page);
+
+    await page.goto('/teacher/questions');
+    await page.waitForLoadState('networkidle');
+
+    // The URL must not have been rewritten to the teacher dashboard.
+    expect(new URL(page.url()).pathname).toBe('/teacher/questions');
+
+    // …and the rendered page must be the Question Bank heading, not
+    // "Teacher dashboard".
+    const h1 = page.locator('h1').first();
+    await expect(h1).toBeVisible();
+    await expect(h1).toHaveText('Question Bank');
+  });
+});

--- a/frontend_modern/src/features/teacher/OpenResponseGradingPage.tsx
+++ b/frontend_modern/src/features/teacher/OpenResponseGradingPage.tsx
@@ -352,7 +352,7 @@ export const OpenResponseGradingPage = () => {
               onClick={() => setStatusFilter(chip.value)}
               className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
                 statusFilter === chip.value
-                  ? 'bg-brand-600 text-white shadow-soft'
+                  ? 'bg-brand-700 text-white shadow-soft'
                   : 'bg-ink-50 text-ink-700 hover:bg-ink-100'
               }`}
             >

--- a/frontend_modern/src/features/teacher/QuestionBankPage.tsx
+++ b/frontend_modern/src/features/teacher/QuestionBankPage.tsx
@@ -417,6 +417,7 @@ export const QuestionBankPage = () => {
             />
             <div className="grid grid-cols-2 gap-2">
               <Select
+                aria-label={t('qbank.allSubjects')}
                 value={selectedSubject}
                 onChange={(e) => {
                   const next = e.target.value ? Number(e.target.value) : '';
@@ -434,6 +435,7 @@ export const QuestionBankPage = () => {
                 ))}
               </Select>
               <Select
+                aria-label={t('qbank.anyDifficulty')}
                 value={selectedDifficulty}
                 onChange={(e) =>
                   setSelectedDifficulty(e.target.value ? Number(e.target.value) : '')
@@ -448,6 +450,7 @@ export const QuestionBankPage = () => {
               </Select>
             </div>
             <Select
+              aria-label={t('qbank.allChapters')}
               value={selectedChapter}
               onChange={(e) =>
                 setSelectedChapter(e.target.value ? Number(e.target.value) : '')

--- a/frontend_modern/src/shared/hooks/useAuth.ts
+++ b/frontend_modern/src/shared/hooks/useAuth.ts
@@ -1,11 +1,23 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient, useIsRestoring } from '@tanstack/react-query';
 import { authApi } from '@/api/auth';
 import type { User } from '@/types/index';
 
 export const useAuth = () => {
   const queryClient = useQueryClient();
 
-  const { data: isValid, isLoading: isVerifying } = useQuery({
+  // While PersistQueryClientProvider rehydrates the cache from IndexedDB (MSO-4),
+  // queries are held *idle*: `status: 'pending'` but `fetchStatus: 'idle'`. RQ's
+  // `isLoading` (= isPending && isFetching) is therefore FALSE during the restore
+  // window even though `isValid` is still undefined. Gating the app on `isLoading`
+  // would render an unauthenticated tree for the first paint and bounce a hard
+  // deep-link (e.g. /teacher/questions) through ProtectedRoute → /login, from
+  // where LoginPage then redirects the (now-verified) user to their role home —
+  // silently dropping the deep link. We therefore gate on `isPending` (status ===
+  // 'pending', true for the whole restore→fetch window) plus `isRestoring`, so
+  // the bootstrap stays "loading" until verify actually resolves.
+  const isRestoring = useIsRestoring();
+
+  const { data: isValid, isPending: isVerifying } = useQuery({
     queryKey: ['auth', 'verify'],
     queryFn: () => authApi.verifyToken(),
     retry: false,
@@ -14,7 +26,7 @@ export const useAuth = () => {
 
   const isAuthenticated = isValid === true;
 
-  const { data: user, isLoading: isLoadingUser } = useQuery<User>({
+  const { data: user, isPending: isLoadingUser } = useQuery<User>({
     queryKey: ['auth', 'me'],
     queryFn: () => authApi.getCurrentUser(),
     enabled: isAuthenticated,
@@ -30,7 +42,7 @@ export const useAuth = () => {
 
   return {
     isAuthenticated,
-    isLoading: isVerifying || (isAuthenticated && isLoadingUser),
+    isLoading: isRestoring || isVerifying || (isAuthenticated && isLoadingUser),
     user: user ?? null,
     logout,
   };


### PR DESCRIPTION
## Problem

A hard navigation / deep-link to a `ProtectedRoute` — e.g. `/teacher/questions` — rendered the role **dashboard** at `/teacher` instead of the requested page. Reproduction: in an authenticated-teacher context, `page.goto('/teacher/questions')` + `waitForLoadState('networkidle')` resolves to `/teacher` with an `h1` of "Teacher dashboard".

## Root cause

An **auth-bootstrap race**, not the service worker (reproduces in `vite dev` too):

1. `main.tsx` wraps the app in `PersistQueryClientProvider`, which rehydrates the React Query cache from IndexedDB (MSO-4). During that restore window queries are held **idle**: `status: 'pending'` but `fetchStatus: 'idle'`.
2. React Query v5's `isLoading` is `isPending && isFetching` → **`false`** during restore, even though auth-verify is unresolved.
3. `useAuth` gated on `isLoading`, so `App` skipped its spinner and painted an **unauthenticated** tree for the first frame. `ProtectedRoute` saw `isAuthenticated === false` → `<Navigate to="/login" replace />`.
4. Restore finished, verify resolved `true`, and `LoginPage` (now at `/login`) bounced the verified teacher to `/` → `defaultPath` = `/teacher`. The deep link was silently dropped.

## Fix

Gate `useAuth` on `isPending` + `useIsRestoring()` so the bootstrap stays "loading" until verify actually resolves. Single fix point — `ProtectedRoute` consumes the same hook.

## ⚠️ Un-masked two pre-existing a11y violations

The redirect meant the gated `teacher-question-bank` **and** `teacher-grading` routes had **never actually been scanned** — axe was scanning the clean dashboard. With the redirect fixed, the gate turned red on genuine violations. Both fixed so the gate is honestly green:

- **`/teacher/questions`** — `select-name` (critical ×3): the 3 filter `<Select>`s had no accessible name. Added `aria-label` reusing existing i18n keys (no parity-guard churn).
- **`/teacher/grading`** — `color-contrast` (serious): active filter chip `bg-brand-600` (white @ 2.79:1) → `bg-brand-700` (the AA-clean #C05300 shade from A11Y-4).

> Note for the initiative record: A11Y-12's "teacher surfaces came back structurally clean" was based on scans that were actually hitting the dashboard. These two routes are genuinely clean only as of this change.

## Regression coverage

- **`e2e/deep-link.spec.ts`** (new) — hard nav to `/teacher/questions` must render the Question Bank, not the dashboard. Verified it **fails on the pre-fix code** (`Received: "/teacher"`).
- **`e2e/a11y.spec.ts`** — every gated route now asserts the final pathname equals the requested path, so a redirect bounce can't silently scan the wrong surface again.

## Verification

- 16/16 e2e pass (incl. both teacher routes now scanning their real pages)
- 549/549 unit tests pass
- `eslint` + `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)