### PR TITLE
ci: validate k8s manifests with kustomize + kubeconform (strict)

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -50,6 +50,45 @@ jobs:
               # trips style warnings that aren't worth gating CI on.
               run: ${{ steps.install-actionlint.outputs.actionlint }} -color -shellcheck=
 
+    k8s-manifests:
+        name: K8s Manifests (kustomize + kubeconform)
+        timeout-minutes: 10
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out the repo
+              uses: actions/checkout@v7
+            - name: Set up kubectl (provides `kubectl kustomize`)
+              # Same action + version the deploy jobs use, so the renderer here
+              # matches what actually applies the manifests to the cluster.
+              uses: azure/setup-kubectl@v5
+              with:
+                version: 'v1.31.0'
+            - name: Install kubeconform
+              run: |
+                curl --silent --show-error --fail --location \
+                  -o kubeconform.tar.gz \
+                  https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz
+                tar -xzf kubeconform.tar.gz kubeconform
+                sudo install -m 0755 kubeconform /usr/local/bin/kubeconform
+            - name: Render & schema-validate every overlay
+              # Renders each kustomize overlay (base is pulled in transitively)
+              # and validates the output against the upstream Kubernetes JSON
+              # schemas with kubeconform. `-strict` rejects unknown fields, so a
+              # typo'd manifest key (e.g. a mis-spelled probe field) fails here
+              # at PR time instead of silently passing CI and only blowing up at
+              # `kubectl apply` / rollout on the live cluster. The two deploy
+              # jobs render the same overlays, but only on qa/prod *after* the
+              # image build — far too late and never on a PR. `-kubernetes-version`
+              # is pinned to the version the deploy jobs install.
+              run: |
+                for overlay in qa prod; do
+                  echo "::group::overlay: $overlay"
+                  kubectl kustomize "k8s/overlays/$overlay" \
+                    | kubeconform -strict -summary -ignore-missing-schemas \
+                        -kubernetes-version 1.31.0 -
+                  echo "::endgroup::"
+                done
+
     lint:
         name: Lint
         timeout-minutes: 10
@@ -384,7 +423,7 @@ jobs:
     build-publish:
         name: Build & Publish (${{ matrix.service }})
         timeout-minutes: 30
-        needs: [lint, typecheck, security, test, frontend, frontend-e2e, visual-regression]
+        needs: [lint, typecheck, security, test, frontend, frontend-e2e, visual-regression, k8s-manifests]
         if: github.ref == 'refs/heads/qa' || github.ref == 'refs/heads/prod'
         runs-on: ubuntu-latest
         permissions:

--- a/docs/changes/2026-06-25-k8s-manifest-validation.md
+++ b/docs/changes/2026-06-25-k8s-manifest-validation.md
@@ -1,0 +1,45 @@
+# 2026-06-25 — K8s manifest validation gate (kustomize + kubeconform)
+
+**Classification:** CI / infrastructure (new static gate; no runtime behaviour
+change).
+
+## Summary
+Added a `k8s-manifests` job to [`ci-cd.yaml`](../../.github/workflows/ci-cd.yaml)
+that renders every kustomize overlay (`k8s/overlays/qa`, `k8s/overlays/prod` —
+base is pulled in transitively) and validates the rendered output against the
+upstream Kubernetes JSON schemas with [`kubeconform`](https://github.com/yannh/kubeconform)
+in `-strict` mode. The job is wired into `build-publish`'s `needs:`, so invalid
+manifests now block the image build and the deploy that follows.
+
+## Why
+Until now nothing validated the k8s manifests on a PR. The only `kustomize build`
+calls live **inside** the `deploy-qa` / `deploy-prod` jobs — they run on the
+cluster, *after* the image build, and only on the `qa` / `prod` branches. So a
+typo in a manifest (a mis-spelled field, a malformed probe block, a bad type)
+sailed through CI green and only surfaced at `kubectl apply` / rollout against the
+**live** environment.
+
+This is timely: the in-flight **Production Observability** initiative
+([`OBS-1`](../initiatives/2026-production-observability.md)) repoints the backend
+`readinessProbe` in [`k8s/base/backend.yaml`](../../k8s/base/backend.yaml) — a
+hand-edited probe block is exactly the kind of change a schema gate catches before
+it can break a rollout.
+
+## Why `-strict`
+Plain kubeconform validation allows unknown/additional properties, so a typo'd key
+(e.g. `htpGet:` instead of `httpGet:` in a probe) passes silently. `-strict`
+rejects unknown fields, catching that whole class of bug. Verified locally:
+
+- Both overlays render (13 resources each) and pass `kubeconform -strict`.
+- A negative test injecting `htpGet` into the probe fails the gate under
+  `-strict` (`additionalProperties 'htpGet' not allowed`) while passing under
+  non-strict — confirming the gate has teeth.
+
+## Pinning notes
+- `kubectl` is installed via `azure/setup-kubectl@v5` at `v1.31.0` — the same
+  action and version the deploy jobs use, so the PR-time renderer matches the
+  one that applies manifests to the cluster.
+- `-kubernetes-version 1.31.0` targets the same API surface.
+- `kubeconform` is pinned to `v0.6.7`.
+- `-ignore-missing-schemas` keeps the gate from failing on any future CRD-backed
+  resource whose schema isn't in the default store (none today).


### PR DESCRIPTION
## What

Adds a `k8s-manifests` CI job that renders every kustomize overlay (`k8s/overlays/qa`, `k8s/overlays/prod` — base pulled in transitively) and schema-validates the rendered output against the upstream Kubernetes JSON schemas with [`kubeconform`](https://github.com/yannh/kubeconform) in `-strict` mode. Wired into `build-publish`'s `needs:`, so invalid manifests block the image build and the deploy that follows.

## Why

Nothing validated the k8s manifests on a PR. The only `kustomize build` calls live **inside** the `deploy-qa` / `deploy-prod` jobs — they run on the cluster, *after* the image build, and only on `qa` / `prod`. So a manifest typo (mis-spelled field, malformed probe block, bad type) sailed through CI green and only surfaced at `kubectl apply` / rollout against the **live** environment.

This is timely for the in-flight **Production Observability** initiative: `OBS-1` repoints the backend `readinessProbe` in `k8s/base/backend.yaml` — a hand-edited probe block is exactly what a schema gate catches before it can break a rollout.

## Why `-strict`

Plain kubeconform allows unknown/additional properties, so a typo'd key (e.g. `htpGet:` instead of `httpGet:`) passes silently. `-strict` rejects unknown fields, catching that whole class of bug.

## Verification (local)

- Both overlays render (13 resources each) and pass `kubeconform -strict`.
- Negative test: injecting `htpGet` into a probe **fails** the gate under `-strict` (`additionalProperties 'htpGet' not allowed`) while passing non-strict — confirms the gate has teeth.
- `actionlint` clean on the modified workflow; YAML parses; `build-publish.needs` updated.

## Pinning

- `kubectl` via `azure/setup-kubectl@v5` at `v1.31.0` (same action/version the deploy jobs use, so the PR-time renderer matches the cluster applier).
- `-kubernetes-version 1.31.0`; `kubeconform` pinned `v0.6.7`.
- `-ignore-missing-schemas` so a future CRD-backed resource won't hard-fail the gate (none today).

See [`docs/changes/2026-06-25-k8s-manifest-validation.md`](docs/changes/2026-06-25-k8s-manifest-validation.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)