### PR TITLE
feat(obs): OBS-1 — /readyz/ deep readiness probe + repoint k8s readinessProbe

### DIFF
--- a/backend/openshiksha/apps/api/tests/test_health_probes.py
+++ b/backend/openshiksha/apps/api/tests/test_health_probes.py
@@ -1,0 +1,120 @@
+"""
+Tests for the k8s probe endpoints (OBS-1).
+
+Covers:
+- /healthz/ — cheap liveness probe (no DB / cache touched)
+- /readyz/  — deep readiness probe (DB + cache check; 503 on failure)
+"""
+
+import pytest
+
+from django.test import Client
+from django.urls import reverse
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+# ---------------------------------------------------------------------------
+# /healthz/ — cheap liveness
+# ---------------------------------------------------------------------------
+
+
+class TestHealthz:
+    def test_healthz_returns_200(self, client):
+        response = client.get(reverse("healthz"))
+        assert response.status_code == 200
+        assert response.content == b"ok"
+
+    def test_healthz_does_no_db_queries(self, client, db, django_assert_num_queries):
+        """Liveness must stay cheap — it must not hit the database."""
+        with django_assert_num_queries(0):
+            client.get(reverse("healthz"))
+
+    def test_healthz_public(self, client):
+        response = client.get(reverse("healthz"))
+        assert response.status_code not in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# /readyz/ — deep readiness
+# ---------------------------------------------------------------------------
+
+
+class TestReadyz:
+    def test_readyz_returns_200_when_up(self, client, db):
+        response = client.get(reverse("readyz"))
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "healthy"
+        assert body["database"] == "connected"
+        assert body["cache"] == "connected"
+
+    def test_readyz_public(self, client, db):
+        response = client.get(reverse("readyz"))
+        assert response.status_code not in (401, 403)
+
+    def test_readyz_503_when_check_unhealthy(self, client, monkeypatch):
+        """When the deep check reports unhealthy the probe returns 503 (drain)."""
+        from openshiksha.apps.api.views import health
+
+        monkeypatch.setattr(
+            health,
+            "deep_health_status",
+            lambda: ({"status": "unhealthy", "database": "error: db down", "cache": "connected"}, False),
+        )
+        response = client.get(reverse("readyz"))
+        assert response.status_code == 503
+        body = response.json()
+        assert body["status"] == "unhealthy"
+
+
+# ---------------------------------------------------------------------------
+# deep_health_status() — unit (no live DB/cache touched)
+# ---------------------------------------------------------------------------
+
+
+class TestDeepHealthStatus:
+    def test_reports_db_error(self, monkeypatch):
+        from openshiksha.apps.api.views import health
+
+        class FakeConn:
+            def ensure_connection(self):
+                raise RuntimeError("db down")
+
+        class FakeCache:
+            def set(self, *a, **k):
+                return None
+
+            def get(self, *a, **k):
+                return "ok"
+
+        monkeypatch.setattr(health, "connection", FakeConn())
+        monkeypatch.setattr(health, "cache", FakeCache())
+        status_dict, healthy = health.deep_health_status()
+        assert healthy is False
+        assert status_dict["status"] == "unhealthy"
+        assert status_dict["database"].startswith("error:")
+
+    def test_reports_cache_error(self, monkeypatch):
+        from openshiksha.apps.api.views import health
+
+        class FakeConn:
+            def ensure_connection(self):
+                return None
+
+        class FakeCache:
+            def set(self, *a, **k):
+                raise RuntimeError("cache down")
+
+            def get(self, *a, **k):
+                return None
+
+        monkeypatch.setattr(health, "connection", FakeConn())
+        monkeypatch.setattr(health, "cache", FakeCache())
+        status_dict, healthy = health.deep_health_status()
+        assert healthy is False
+        assert status_dict["status"] == "unhealthy"
+        assert status_dict["cache"].startswith("error:")

--- a/backend/openshiksha/apps/api/views/health.py
+++ b/backend/openshiksha/apps/api/views/health.py
@@ -4,25 +4,21 @@ Health check endpoints
 
 from django.core.cache import cache
 from django.db import connection
+from django.http import JsonResponse
 from django.urls import path
+from django.views.decorators.csrf import csrf_exempt
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
 
-@api_view(["GET"])
-@permission_classes([AllowAny])
-def health_check(request):
-    """
-    Health check endpoint to verify service is running
+def deep_health_status():
+    """Run the deep readiness check: DB connection + cache round-trip.
 
-    GET /api/v1/health/
-
-    Returns:
-        - status: healthy/unhealthy
-        - database: connected/disconnected
-        - cache: connected/disconnected
+    Returns a ``(status_dict, healthy)`` tuple. Shared by the DRF
+    ``/api/v1/health/`` endpoint and the top-level ``/readyz/`` k8s readiness
+    probe so the two never drift apart.
     """
     health_status = {
         "status": "healthy",
@@ -45,13 +41,46 @@ def health_check(request):
             health_status["cache"] = "connected"
         else:
             health_status["status"] = "unhealthy"
+            health_status["cache"] = "error: round-trip mismatch"
     except Exception as e:
         health_status["status"] = "unhealthy"
         health_status["cache"] = f"error: {str(e)}"
 
-    status_code = status.HTTP_200_OK if health_status["status"] == "healthy" else status.HTTP_503_SERVICE_UNAVAILABLE
+    return health_status, health_status["status"] == "healthy"
 
+
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def health_check(request):
+    """
+    Health check endpoint to verify service is running
+
+    GET /api/v1/health/
+
+    Returns:
+        - status: healthy/unhealthy
+        - database: connected/disconnected
+        - cache: connected/disconnected
+    """
+    health_status, healthy = deep_health_status()
+    status_code = status.HTTP_200_OK if healthy else status.HTTP_503_SERVICE_UNAVAILABLE
     return Response(health_status, status=status_code)
+
+
+@csrf_exempt
+def readyz(_request):
+    """Deep readiness probe target for the k8s readinessProbe / LB drain signal.
+
+    Unlike the cheap ``/healthz/`` liveness probe, this runs the same DB + cache
+    check as ``/api/v1/health/`` and returns 503 if either is down — so a pod
+    with a dead DB is drained from the load balancer (no traffic) instead of
+    being killed and restart-looped (that's the liveness probe's job).
+
+    Mounted at the top level (``/readyz/``) as a plain, auth-free, DB-aware view.
+    """
+    health_status, healthy = deep_health_status()
+    status_code = 200 if healthy else 503
+    return JsonResponse(health_status, status=status_code)
 
 
 urlpatterns = [

--- a/backend/openshiksha/urls.py
+++ b/backend/openshiksha/urls.py
@@ -12,6 +12,8 @@ from django.contrib import admin
 from django.http import HttpResponse
 from django.urls import include, path
 
+from openshiksha.apps.api.views.health import readyz
+
 
 def healthz(_request):
     """Liveness/readiness probe target for k8s + Docker HEALTHCHECK.
@@ -28,6 +30,8 @@ def healthz(_request):
 urlpatterns = [
     # Cheap liveness probe — no DB / Redis / auth. See healthz() above.
     path("healthz/", healthz, name="healthz"),
+    # Deep readiness probe — DB + cache check; LB drain signal. See readyz().
+    path("readyz/", readyz, name="readyz"),
     # Django admin — mounted at /django-admin/ so it doesn't collide with the
     # React app's /admin route (the in-app school-admin dashboard). Superuser-only
     # gate is applied below.

--- a/docs/changes/2026-06-25-obs-1-readyz.md
+++ b/docs/changes/2026-06-25-obs-1-readyz.md
@@ -1,0 +1,50 @@
+# OBS-1 — `/readyz/` deep readiness endpoint + k8s readinessProbe repoint
+
+## Summary
+Adds the deep, DB+cache-aware readiness probe the `healthz` docstring already
+specified but was never built, and repoints the k8s **readinessProbe** off the
+cheap liveness path (`/healthz/`) onto it (`/readyz/`). A pod with a dead DB or
+cache is now **drained from the load balancer** instead of silently serving 5xx.
+The **livenessProbe stays on `/healthz/`** so a transient DB blip drains the pod
+rather than killing it into a restart loop.
+
+## Classification
+Improve (the readiness/liveness split was documented intent, never implemented).
+
+## Legacy files referenced
+None — observability is greenfield. The Django 1.11 monolith had no
+readiness/liveness split; failures were diagnosed by SSH + `grep` over flat logs.
+
+## What changed
+- **`backend/openshiksha/apps/api/views/health.py`**
+  - Extracted the DB + cache check into a shared `deep_health_status() -> (dict, bool)`
+    so the DRF `/api/v1/health/` endpoint and the new probe never drift.
+  - Added `readyz(request)` — a plain, `@csrf_exempt`, auth-free `JsonResponse`
+    view returning **200** healthy / **503** on any DB/cache failure.
+  - `health_check` now delegates to `deep_health_status()` (behaviour unchanged).
+- **`backend/openshiksha/urls.py`** — mounted `path("readyz/", readyz, name="readyz")`
+  at the top level (alongside `/healthz/`). `/healthz/` left exactly as-is.
+- **`k8s/base/backend.yaml`** — `readinessProbe.httpGet.path: /healthz/ → /readyz/`
+  (kept the `Host: backend` + `X-Forwarded-Proto` headers). **livenessProbe untouched.**
+
+## Tests written
+`backend/openshiksha/apps/api/tests/test_health_probes.py` (8 tests, all green):
+- `/healthz/` returns 200 `"ok"`, is public, and does **0 DB queries**
+  (`django_assert_num_queries(0)`).
+- `/readyz/` returns 200 + `status/database/cache: connected` when up; is public.
+- `/readyz/` returns 503 when the deep check reports unhealthy.
+- `deep_health_status()` unit: reports a DB error / a cache error (fakes, no live
+  resources touched — keeps the `db`-fixture teardown clean).
+
+## Migration notes
+None — no model changes.
+
+## How to verify
+- `pytest openshiksha/apps/api/tests/test_health_probes.py` (8 pass).
+- `kubectl kustomize k8s/overlays/prod` builds clean with the repointed probe.
+- In a live cluster: `curl -H 'Host: backend' http://<pod>:8000/readyz/` → 200 up,
+  503 with DB/Redis stopped; `/healthz/` stays 200 regardless.
+
+## Next steps
+OBS-2 (`/api/v1/version/` build-info) → OBS-3 (backend Sentry) → OBS-4
+(request-id + JSON logs) → OBS-5 (frontend error reporting).

--- a/k8s/base/backend.yaml
+++ b/k8s/base/backend.yaml
@@ -58,9 +58,13 @@ spec:
                 name: openshiksha-config
             - secretRef:
                 name: openshiksha-secrets
+          # Readiness uses the DEEP probe (/readyz/ checks DB + cache) so a pod
+          # with a dead DB is drained from the LB instead of serving 5xx. The
+          # livenessProbe below stays on the cheap /healthz/ so a transient DB
+          # blip drains the pod rather than killing it into a restart loop.
           readinessProbe:
             httpGet:
-              path: /healthz/
+              path: /readyz/
               port: 8000
               httpHeaders:
                 # kubelet probes use the pod IP as Host, which isn't in


### PR DESCRIPTION
## Classification
**Improve** — builds the readiness/liveness split the `healthz` docstring already specified but was never implemented.

## What & why
OpenShiksha is **live in prod** but the k8s **readinessProbe probes `/healthz/`** — a cheap liveness path that never touches the DB/cache. A pod with a dead DB still gets traffic and silently serves 5xx. This adds the deep probe and repoints readiness to it.

- `apps/api/views/health.py`: extract `deep_health_status() -> (dict, bool)` (DB + cache check), shared by `/api/v1/health/` and the new probe so they never drift. Add `readyz()` — plain, `@csrf_exempt`, auth-free view → **200** healthy / **503** on any DB/cache failure.
- `urls.py`: mount `path("readyz/", readyz, name="readyz")` at top level. `/healthz/` untouched.
- `k8s/base/backend.yaml`: `readinessProbe` `/healthz/ → /readyz/` (Host/X-Forwarded-Proto headers kept). **livenessProbe stays `/healthz/`** so a transient DB blip drains the pod instead of restart-looping it.

Part of the **Production Observability** initiative (Batch 1, OBS-1).

## Tests
`apps/api/tests/test_health_probes.py` — 8 tests, all green:
- `/healthz/`: 200 `"ok"`, public, **0 DB queries** (`django_assert_num_queries(0)`).
- `/readyz/`: 200 + connected fields when up; public; 503 when the deep check is unhealthy.
- `deep_health_status()` unit: DB-error + cache-error paths (fakes, no live resources).

## Verify
- `pytest openshiksha/apps/api/tests/test_health_probes.py` → 8 pass.
- `kubectl kustomize k8s/overlays/prod` builds clean.
- Live: `curl -H 'Host: backend' :8000/readyz/` → 200 up, 503 with DB/Redis down; `/healthz/` stays 200.

## Legacy reference
None — observability is greenfield (the 1.11 monolith had no readiness/liveness split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)