### PR TITLE
feat(obs): OBS-2 — /api/v1/version/ build-info endpoint

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -403,8 +403,10 @@ jobs:
         steps:
             - name: Check out the repo
               uses: actions/checkout@v7
-            - name: Extract Branch name for Tagging
-              run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+            - name: Extract Branch name + build time for Tagging
+              run: |
+                echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+                echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
               id: extract_branch
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v4
@@ -423,6 +425,12 @@ jobs:
                 tags: |
                     ghcr.io/${{ github.repository_owner }}/openshiksha-${{ matrix.service }}:${{ steps.extract_branch.outputs.branch }}
                     ghcr.io/${{ github.repository_owner }}/openshiksha-${{ matrix.service }}:${{ github.sha }}
+                # Bake build identity into the image for /api/v1/version/ (OBS-2).
+                # The backend Dockerfile consumes these; the frontend ignores the
+                # extra ARGs harmlessly.
+                build-args: |
+                    GIT_SHA=${{ github.sha }}
+                    BUILD_TIME=${{ steps.extract_branch.outputs.build_time }}
                 cache-from: type=gha,scope=${{ matrix.service }}
                 cache-to: type=gha,scope=${{ matrix.service }},mode=max
 

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -41,6 +41,13 @@ RUN apt-get purge -y --auto-remove build-essential libpq-dev \
 
 COPY . /app/
 
+# Build identity — baked at image build time and surfaced by /api/v1/version/
+# (OBS-2). Passed via --build-arg from CI; default to "unknown" for local builds.
+ARG GIT_SHA=unknown
+ARG BUILD_TIME=unknown
+ENV GIT_SHA=${GIT_SHA} \
+    BUILD_TIME=${BUILD_TIME}
+
 # Build-time static collection — uses ManifestStaticFilesStorage so the
 # resulting filenames are content-hashed and long-cacheable. SECRET_KEY isn't
 # needed at collectstatic time but Django will complain if it's unset, so a

--- a/backend/openshiksha/apps/api/tests/test_version_api.py
+++ b/backend/openshiksha/apps/api/tests/test_version_api.py
@@ -1,0 +1,46 @@
+"""
+Tests for the build-info endpoint (OBS-2): /api/v1/version/.
+"""
+
+import pytest
+
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+class TestVersionEndpoint:
+    def test_returns_all_four_keys(self, api_client):
+        response = api_client.get(reverse("version_info"))
+        assert response.status_code == status.HTTP_200_OK
+        assert set(response.data.keys()) == {"version", "git_sha", "built_at", "environment"}
+
+    @override_settings(APP_VERSION="9.9.9", ENVIRONMENT="prod")
+    def test_reflects_settings(self, api_client):
+        response = api_client.get(reverse("version_info"))
+        assert response.data["version"] == "9.9.9"
+        assert response.data["environment"] == "prod"
+
+    def test_git_sha_and_built_at_default_to_unknown(self, api_client, monkeypatch):
+        monkeypatch.delenv("GIT_SHA", raising=False)
+        monkeypatch.delenv("BUILD_TIME", raising=False)
+        response = api_client.get(reverse("version_info"))
+        assert response.data["git_sha"] == "unknown"
+        assert response.data["built_at"] == "unknown"
+
+    def test_reads_build_env_vars(self, api_client, monkeypatch):
+        monkeypatch.setenv("GIT_SHA", "abc123")
+        monkeypatch.setenv("BUILD_TIME", "2026-06-25T00:00:00Z")
+        response = api_client.get(reverse("version_info"))
+        assert response.data["git_sha"] == "abc123"
+        assert response.data["built_at"] == "2026-06-25T00:00:00Z"
+
+    def test_accessible_without_authentication(self, api_client):
+        response = api_client.get(reverse("version_info"))
+        assert response.status_code not in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)

--- a/backend/openshiksha/apps/api/urls.py
+++ b/backend/openshiksha/apps/api/urls.py
@@ -22,11 +22,8 @@ from openshiksha.apps.api.views.core import (
     SubmissionViewSet,
     UserViewSet,
 )
-from openshiksha.apps.api.views.push import (
-    PushSubscribeView,
-    PushUnsubscribeView,
-    VapidPublicKeyView,
-)
+from openshiksha.apps.api.views.push import PushSubscribeView, PushUnsubscribeView, VapidPublicKeyView
+from openshiksha.apps.api.views.version import version_info
 
 # Create router for ViewSets
 router = DefaultRouter()
@@ -56,6 +53,8 @@ urlpatterns = [
     path("push/unsubscribe/", PushUnsubscribeView.as_view(), name="push_unsubscribe"),
     # Health check endpoint
     path("health/", include("openshiksha.apps.api.views.health")),
+    # Build / version info endpoint (OBS-2)
+    path("version/", version_info, name="version_info"),
     # Router URLs (all ViewSets)
     path("", include(router.urls)),
     # AI Analytics endpoints

--- a/backend/openshiksha/apps/api/views/version.py
+++ b/backend/openshiksha/apps/api/views/version.py
@@ -1,0 +1,38 @@
+"""
+Build-info endpoint (OBS-2).
+
+Surfaces which build is live so an operator can correlate a prod incident with a
+specific image. Deliberately trivial and DB-free; **never** returns secrets —
+only the release version, git sha, build time, and environment name.
+"""
+
+import os
+
+from django.conf import settings
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def version_info(_request):
+    """
+    Build / version info.
+
+    GET /api/v1/version/
+
+    Returns:
+        - version:     human-facing release (settings.APP_VERSION)
+        - git_sha:     commit baked into the image at build time ("unknown" if unset)
+        - built_at:    image build timestamp ("unknown" if unset)
+        - environment: running environment name (dev/qa/prod)
+    """
+    return Response(
+        {
+            "version": getattr(settings, "APP_VERSION", "unknown"),
+            "git_sha": os.getenv("GIT_SHA", "unknown"),
+            "built_at": os.getenv("BUILD_TIME", "unknown"),
+            "environment": getattr(settings, "ENVIRONMENT", "unknown"),
+        }
+    )

--- a/backend/openshiksha/settings/base.py
+++ b/backend/openshiksha/settings/base.py
@@ -20,6 +20,12 @@ DEBUG = os.getenv("DEBUG", "False") == "True"
 
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1").split(",")
 
+# Build / deploy identity — surfaced by the /api/v1/version/ build-info endpoint
+# (OBS-2). APP_VERSION is the human-facing release; GIT_SHA / BUILD_TIME are baked
+# into the prod image at build time; ENVIRONMENT names the running env (dev/qa/prod).
+APP_VERSION = os.getenv("APP_VERSION", "2.0.0")
+ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
 # Custom User Model
 AUTH_USER_MODEL = "core.User"
 

--- a/docs/changes/2026-06-25-obs-2-version.md
+++ b/docs/changes/2026-06-25-obs-2-version.md
@@ -1,0 +1,48 @@
+# OBS-2 — `/api/v1/version/` build-info endpoint
+
+## Summary
+Adds a trivial, DB-free, public `/api/v1/version/` endpoint that reports which
+build is live (version, git sha, build time, environment) so an operator can
+correlate a prod incident with a specific image. The git sha + build time are
+baked into the prod image at build time via Docker `ARG`s passed from CI.
+
+## Classification
+New.
+
+## Legacy files referenced
+None — observability is greenfield.
+
+## What changed
+- **`backend/openshiksha/settings/base.py`** — added `APP_VERSION`
+  (`env APP_VERSION`, default `"2.0.0"`) and `ENVIRONMENT`
+  (`env ENVIRONMENT`, default `"development"`).
+- **`backend/openshiksha/apps/api/views/version.py`** (new) — `version_info`,
+  an `AllowAny` DRF view returning `{version, git_sha, built_at, environment}`.
+  `git_sha`/`built_at` come from env (`GIT_SHA`/`BUILD_TIME`), defaulting to
+  `"unknown"`. **No secrets, ever.**
+- **`backend/openshiksha/apps/api/urls.py`** — mounted
+  `path("version/", version_info, name="version_info")`.
+- **`backend/Dockerfile.prod`** — `ARG GIT_SHA`/`ARG BUILD_TIME` → `ENV` (default
+  `unknown` for local builds).
+- **`.github/workflows/ci-cd.yaml`** — the image build-push step now passes
+  `--build-arg GIT_SHA=${{ github.sha }}` and a `date -u` build time (new
+  `build_time` output on the extract-branch step). The frontend image ignores the
+  extra ARGs harmlessly.
+
+## Tests written
+`backend/openshiksha/apps/api/tests/test_version_api.py` (5 tests, all green):
+- returns exactly the four keys; reflects `APP_VERSION`/`ENVIRONMENT` settings;
+  `git_sha`/`built_at` default to `"unknown"` when env unset; reads `GIT_SHA`/
+  `BUILD_TIME` env when set; accessible unauthenticated.
+
+## Migration notes
+None — no model changes.
+
+## How to verify
+- `pytest openshiksha/apps/api/tests/test_version_api.py` (5 pass).
+- `curl :8000/api/v1/version/` → JSON with the four keys; `git_sha`/`built_at`
+  show the baked image values in a CI-built image, `"unknown"` locally.
+
+## Next steps
+OBS-3 (backend Sentry, env-gated) → OBS-4 (request-id + JSON logs) → OBS-5
+(frontend error reporting).


### PR DESCRIPTION
## Classification
**New** — part of the **Production Observability** initiative (Batch 1, OBS-2).

## What & why
An operator currently has no way to tell *which build* is running in prod. This adds a trivial, DB-free, public endpoint so a prod incident can be correlated to a specific image.

- `settings/base.py`: `APP_VERSION` (default `2.0.0`) + `ENVIRONMENT` (default `development`), both env-overridable.
- `apps/api/views/version.py`: `version_info` (`AllowAny`) → `{version, git_sha, built_at, environment}`. `git_sha`/`built_at` from env, default `"unknown"`. **No secrets, ever.**
- `apps/api/urls.py`: mount `version/`.
- `Dockerfile.prod`: `ARG GIT_SHA`/`ARG BUILD_TIME` → `ENV` (default `unknown` locally).
- `ci-cd.yaml`: build-push step passes `--build-arg GIT_SHA=${{ github.sha }}` + a `date -u` build time. Frontend image ignores the extra ARGs harmlessly.

## Tests
`apps/api/tests/test_version_api.py` — 5 tests, all green: four keys present; reflects `APP_VERSION`/`ENVIRONMENT`; `unknown` defaults; reads `GIT_SHA`/`BUILD_TIME`; public.

## Verify
- `pytest openshiksha/apps/api/tests/test_version_api.py` → 5 pass.
- `curl :8000/api/v1/version/` → JSON; baked sha/time in CI images, `"unknown"` locally.

## Legacy reference
None — greenfield observability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)