### PR TITLE
feat(obs): OBS-3 — env-gated backend Sentry + secret scrubber

### DIFF
--- a/backend/openshiksha/apps/core/observability.py
+++ b/backend/openshiksha/apps/core/observability.py
@@ -1,0 +1,97 @@
+"""
+Error tracking / observability wiring (OBS-3).
+
+Sentry is **strictly env-gated**: it initialises only when ``SENTRY_DSN`` is set,
+so dev / test / local runs never send events and behaviour is byte-for-byte
+today's. Factored out of ``settings/production.py`` so the init + scrubber are
+unit-testable without importing the whole settings module.
+"""
+
+import logging
+import os
+import re
+
+logger = logging.getLogger("apps")
+
+# Data keys whose *value* must never leave the process.
+_SENSITIVE_KEY_RE = re.compile(r"password|token|secret|api[_-]?key|anthropic|authorization", re.IGNORECASE)
+
+# Request headers stripped wholesale.
+_SENSITIVE_HEADERS = {"authorization", "cookie", "x-api-key"}
+
+_FILTERED = "[Filtered]"
+
+
+def _scrub_mapping(data):
+    """Recursively replace sensitive values in a dict; non-dicts pass through."""
+    if not isinstance(data, dict):
+        return data
+    cleaned = {}
+    for key, value in data.items():
+        if isinstance(key, str) and _SENSITIVE_KEY_RE.search(key):
+            cleaned[key] = _FILTERED
+        elif isinstance(value, dict):
+            cleaned[key] = _scrub_mapping(value)
+        else:
+            cleaned[key] = value
+    return cleaned
+
+
+def _scrub(event, _hint):
+    """Sentry ``before_send`` hook — strip secrets before an event is transmitted.
+
+    Removes sensitive request headers (Authorization/Cookie/X-API-Key), cookies,
+    and any data/extra key matching ``password|token|secret|api_key|anthropic``.
+    Returns the mutated event (Sentry sends ``None`` events nowhere, but we always
+    keep the event — just sanitised).
+    """
+    request = event.get("request")
+    if isinstance(request, dict):
+        headers = request.get("headers")
+        if isinstance(headers, dict):
+            request["headers"] = {
+                k: (_FILTERED if (k.lower() in _SENSITIVE_HEADERS or _SENSITIVE_KEY_RE.search(k)) else v)
+                for k, v in headers.items()
+            }
+        if "cookies" in request:
+            request["cookies"] = _FILTERED
+        if isinstance(request.get("data"), dict):
+            request["data"] = _scrub_mapping(request["data"])
+
+    if isinstance(event.get("extra"), dict):
+        event["extra"] = _scrub_mapping(event["extra"])
+
+    return event
+
+
+def init_sentry():
+    """Initialise Sentry iff ``SENTRY_DSN`` is set. Returns ``True`` if initialised.
+
+    Lazy-imports the SDK so the dependency is never touched when Sentry is
+    disabled. Django/Celery/Redis integrations are wired; PII is off; the
+    ``before_send`` scrubber strips secrets.
+    """
+    dsn = os.getenv("SENTRY_DSN")
+    if not dsn:
+        return False
+
+    try:
+        import sentry_sdk
+        from sentry_sdk.integrations.celery import CeleryIntegration
+        from sentry_sdk.integrations.django import DjangoIntegration
+        from sentry_sdk.integrations.redis import RedisIntegration
+    except ImportError:
+        logger.warning("SENTRY_DSN is set but sentry-sdk is not installed; error tracking disabled.")
+        return False
+
+    sentry_sdk.init(
+        dsn=dsn,
+        integrations=[DjangoIntegration(), CeleryIntegration(), RedisIntegration()],
+        traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0")),
+        send_default_pii=False,
+        environment=os.getenv("ENVIRONMENT", "production"),
+        release=os.getenv("GIT_SHA") or None,
+        before_send=_scrub,
+    )
+    logger.info("Sentry error tracking initialised (environment=%s).", os.getenv("ENVIRONMENT", "production"))
+    return True

--- a/backend/openshiksha/apps/core/tests/test_observability.py
+++ b/backend/openshiksha/apps/core/tests/test_observability.py
@@ -1,0 +1,59 @@
+"""
+Tests for env-gated Sentry wiring + the secret scrubber (OBS-3).
+
+No real network calls are made — `sentry_sdk.init` is monkeypatched.
+"""
+
+from openshiksha.apps.core import observability
+
+
+class TestInitSentry:
+    def test_noop_without_dsn(self, monkeypatch):
+        monkeypatch.delenv("SENTRY_DSN", raising=False)
+        assert observability.init_sentry() is False
+
+    def test_inits_when_dsn_set(self, monkeypatch):
+        monkeypatch.setenv("SENTRY_DSN", "https://example@o0.ingest.sentry.io/0")
+        captured = {}
+
+        def fake_init(**kwargs):
+            captured.update(kwargs)
+
+        import sentry_sdk
+
+        monkeypatch.setattr(sentry_sdk, "init", fake_init)
+        assert observability.init_sentry() is True
+        # Gated config the prod posture depends on.
+        assert captured["send_default_pii"] is False
+        assert captured["before_send"] is observability._scrub
+        assert len(captured["integrations"]) == 3
+
+
+class TestScrub:
+    def test_strips_authorization_header(self):
+        event = {"request": {"headers": {"Authorization": "Bearer secrettoken", "Accept": "application/json"}}}
+        scrubbed = observability._scrub(event, None)
+        assert scrubbed["request"]["headers"]["Authorization"] == "[Filtered]"
+        # Non-sensitive headers are preserved.
+        assert scrubbed["request"]["headers"]["Accept"] == "application/json"
+
+    def test_strips_cookies(self):
+        event = {"request": {"cookies": "sessionid=abc"}}
+        assert observability._scrub(event, None)["request"]["cookies"] == "[Filtered]"
+
+    def test_strips_password_field_in_request_data(self):
+        event = {"request": {"data": {"username": "alice", "password": "hunter2"}}}
+        scrubbed = observability._scrub(event, None)
+        assert scrubbed["request"]["data"]["password"] == "[Filtered]"
+        assert scrubbed["request"]["data"]["username"] == "alice"
+
+    def test_strips_nested_secret_in_extra(self):
+        event = {"extra": {"config": {"api_key": "sk-123", "anthropic_token": "xyz", "safe": "ok"}}}
+        scrubbed = observability._scrub(event, None)
+        assert scrubbed["extra"]["config"]["api_key"] == "[Filtered]"
+        assert scrubbed["extra"]["config"]["anthropic_token"] == "[Filtered]"
+        assert scrubbed["extra"]["config"]["safe"] == "ok"
+
+    def test_handles_event_without_request_or_extra(self):
+        event = {"message": "boom"}
+        assert observability._scrub(event, None) == {"message": "boom"}

--- a/backend/openshiksha/settings/production.py
+++ b/backend/openshiksha/settings/production.py
@@ -2,6 +2,8 @@
 Production-specific Django settings for OpenShiksha
 """
 
+from openshiksha.apps.core.observability import init_sentry
+
 from .base import *  # noqa: F403
 
 # DEBUG mode OFF for production
@@ -58,5 +60,8 @@ CELERY_TASK_ALWAYS_EAGER = False
 
 # Cache - Use Redis with longer timeouts
 CACHES["default"]["TIMEOUT"] = 600  # 10 minutes  # noqa: F405
+
+# Error tracking (OBS-3) — no-ops unless SENTRY_DSN is set.
+init_sentry()
 
 print("⚠️  Production settings loaded - ensure all environment variables are set!")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -29,6 +29,11 @@ daphne==4.2.2
 # see settings/production.py — required for the prod Docker image build)
 whitenoise==6.12.0
 
+# Error tracking (OBS-3) — only active in production when SENTRY_DSN is set
+# (apps/core/observability.init_sentry). The [django] extra pulls in the Django
+# integration; Celery/Redis integrations ship in the base SDK.
+sentry-sdk[django]==2.63.0
+
 # Validation & Serialization
 pydantic==2.13.4
 pydantic-settings==2.14.2

--- a/docs/changes/2026-06-25-obs-3-sentry.md
+++ b/docs/changes/2026-06-25-obs-3-sentry.md
@@ -1,0 +1,49 @@
+# OBS-3 — Sentry error tracking (backend), env-gated
+
+## Summary
+Wires `sentry-sdk[django]` into production **only when `SENTRY_DSN` is set**, with
+Django/Celery/Redis integrations and a secret-scrubbing `before_send`. With no DSN
+(dev/test/local/today's prod) behaviour is byte-for-byte unchanged.
+
+## Classification
+New.
+
+## Legacy files referenced
+None — the Django 1.11 monolith had no structured error tracking (failures were
+diagnosed by SSH + `grep` over flat logs).
+
+## What changed
+- **`backend/requirements.txt`** — added `sentry-sdk[django]==2.63.0`.
+- **`backend/openshiksha/apps/core/observability.py`** (new):
+  - `init_sentry() -> bool` — returns `False`/no-ops unless `SENTRY_DSN` is set.
+    **Lazy-imports** the SDK so the dependency is never touched when disabled.
+    Wires `DjangoIntegration`, `CeleryIntegration`, `RedisIntegration`;
+    `traces_sample_rate` from `SENTRY_TRACES_SAMPLE_RATE` (default `0`);
+    `send_default_pii=False`; `environment` from `ENVIRONMENT`; `release` from
+    `GIT_SHA`; `before_send=_scrub`.
+  - `_scrub(event, hint)` — strips sensitive request headers
+    (Authorization/Cookie/X-API-Key), cookies, and any data/extra key matching
+    `password|token|secret|api_key|anthropic|authorization` (recursive).
+- **`backend/openshiksha/settings/production.py`** — calls `init_sentry()` (after
+  the cache config, before the warning print). No-op without the DSN.
+
+## Tests written
+`backend/openshiksha/apps/core/tests/test_observability.py` (7 tests, all green,
+**no network calls** — `sentry_sdk.init` is monkeypatched):
+- `init_sentry()` no-ops without `SENTRY_DSN`; inits with it and sets
+  `send_default_pii=False`, the scrubber, and 3 integrations.
+- `_scrub` strips an `Authorization` header (keeps benign headers), cookies, a
+  `password` field, and nested `api_key`/`anthropic_token` in `extra`; passes
+  through an event with no request/extra.
+
+## Migration notes
+None — no model changes.
+
+## How to verify
+- `pytest openshiksha/apps/core/tests/test_observability.py` (7 pass).
+- Import `openshiksha.settings.production` with no `SENTRY_DSN` → loads clean,
+  Sentry inactive. With a DSN set, `init_sentry()` returns `True`.
+
+## Next steps
+OBS-4 (request-id middleware + JSON log option — tags the Sentry scope) → OBS-5
+(frontend error reporting).


### PR DESCRIPTION
## Classification
**New** — Production Observability initiative (Batch 1, OBS-3).

## What & why
A prod incident is currently invisible — there's no error tracking. This wires Sentry into production **only when `SENTRY_DSN` is set**, so with no DSN (dev/test/local/today's prod) behaviour is byte-for-byte unchanged.

- `requirements.txt`: `sentry-sdk[django]==2.63.0`.
- `apps/core/observability.py` (new): `init_sentry()` (lazy-imports the SDK; no-op without DSN) wiring Django/Celery/Redis integrations, `send_default_pii=False`, `traces_sample_rate` from env (default 0), `environment` from `ENVIRONMENT`, `release` from `GIT_SHA`. `_scrub` `before_send` strips Authorization/Cookie/X-API-Key headers, cookies, and any data/extra key matching `password|token|secret|api_key|anthropic` (recursive).
- `settings/production.py`: calls `init_sentry()`.

Factored out of settings so init + scrubber are unit-testable without importing the whole settings module.

## Tests
`apps/core/tests/test_observability.py` — 7 tests, all green, **no network** (`sentry_sdk.init` monkeypatched): no-op without DSN; inits with DSN (PII off, scrubber set, 3 integrations); `_scrub` strips Authorization header / cookies / password field / nested api_key+anthropic in extra; passes through bare events.

## Verify
- `pytest openshiksha/apps/core/tests/test_observability.py` → 7 pass.
- Import `settings.production` with no `SENTRY_DSN` → loads clean, Sentry inactive.

## Legacy reference
None — greenfield (monolith had no structured error tracking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)