### PR TITLE
feat(obs): OBS-4 — request-correlation id middleware + JSON log option

### DIFF
--- a/backend/openshiksha/apps/core/logging_utils.py
+++ b/backend/openshiksha/apps/core/logging_utils.py
@@ -1,0 +1,36 @@
+"""
+Logging helpers (OBS-4): a request-id filter + an opt-in JSON formatter.
+
+The filter injects the current correlation id onto every record so any formatter
+can reference ``%(request_id)s``. The JSON formatter is selected only when
+``LOG_FORMAT=json``; the default text formatters are left untouched.
+"""
+
+import json
+import logging
+
+from openshiksha.apps.core.request_context import get_request_id
+
+
+class RequestIDFilter(logging.Filter):
+    """Attach the current request's correlation id to every log record."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = get_request_id()
+        return True
+
+
+class JSONFormatter(logging.Formatter):
+    """Emit one JSON object per log line — friendly to log aggregators."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            "level": record.levelname,
+            "time": self.formatTime(record),
+            "logger": record.name,
+            "message": record.getMessage(),
+            "request_id": getattr(record, "request_id", "-"),
+        }
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(payload, default=str)

--- a/backend/openshiksha/apps/core/middleware.py
+++ b/backend/openshiksha/apps/core/middleware.py
@@ -1,0 +1,51 @@
+"""
+Request-scoped middleware (OBS-4).
+
+``RequestIDMiddleware`` stamps every request with a correlation id (from an
+incoming ``X-Request-ID`` header, or a fresh uuid4) that is threaded through the
+logs (via the ContextVar in ``request_context``) and echoed back on the response.
+When Sentry is active it also tags the current scope so an error and its log lines
+share the same id.
+"""
+
+import uuid
+
+from openshiksha.apps.core.request_context import reset_request_id, set_request_id
+
+REQUEST_ID_HEADER = "X-Request-ID"
+
+
+class RequestIDMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        incoming = request.headers.get(REQUEST_ID_HEADER)
+        request_id = incoming or uuid.uuid4().hex
+        request.request_id = request_id
+        token = set_request_id(request_id)
+        self._tag_sentry(request_id)
+        try:
+            response = self.get_response(request)
+        finally:
+            # Always restore the previous context value, even on exceptions, so
+            # the id never leaks into the next request on a reused worker.
+            reset_request_id(token)
+        response[REQUEST_ID_HEADER] = request_id
+        return response
+
+    @staticmethod
+    def _tag_sentry(request_id: str) -> None:
+        """Tag the Sentry scope with the request id — a no-op when Sentry is off.
+
+        Soft-depends on OBS-3: guarded so it does nothing when sentry-sdk is not
+        installed or no DSN was configured.
+        """
+        try:
+            import sentry_sdk
+
+            client = sentry_sdk.get_client()
+            if client is not None and client.is_active():
+                sentry_sdk.set_tag("request_id", request_id)
+        except Exception:  # pragma: no cover - defensive; never break a request
+            pass

--- a/backend/openshiksha/apps/core/request_context.py
+++ b/backend/openshiksha/apps/core/request_context.py
@@ -1,0 +1,27 @@
+"""
+Per-request correlation id, stored in a ContextVar (OBS-4).
+
+A ``ContextVar`` is the right primitive here: it is isolated per thread *and* per
+asyncio task (the app runs under Daphne/ASGI), so the id set by
+``RequestIDMiddleware`` is visible to every log record emitted while handling that
+request, without leaking across concurrent requests.
+"""
+
+import contextvars
+
+_request_id_var: "contextvars.ContextVar[str]" = contextvars.ContextVar("request_id", default="-")
+
+
+def get_request_id() -> str:
+    """Return the current request's correlation id, or ``"-"`` outside a request."""
+    return _request_id_var.get()
+
+
+def set_request_id(value: str):
+    """Set the correlation id for the current context; returns a reset token."""
+    return _request_id_var.set(value)
+
+
+def reset_request_id(token) -> None:
+    """Restore the previous correlation id (call in a ``finally``)."""
+    _request_id_var.reset(token)

--- a/backend/openshiksha/apps/core/tests/test_request_id.py
+++ b/backend/openshiksha/apps/core/tests/test_request_id.py
@@ -1,0 +1,80 @@
+"""
+Tests for request-correlation id middleware + JSON log formatter (OBS-4).
+"""
+
+import json
+import logging
+
+import pytest
+
+from django.test import Client
+from django.urls import reverse
+
+from openshiksha.apps.core.logging_utils import JSONFormatter, RequestIDFilter
+from openshiksha.apps.core.middleware import REQUEST_ID_HEADER
+from openshiksha.apps.core.request_context import get_request_id, reset_request_id, set_request_id
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+class TestRequestIDMiddleware:
+    def test_round_trips_supplied_id(self, client):
+        resp = client.get(reverse("healthz"), headers={"x-request-id": "abc-123"})
+        assert resp[REQUEST_ID_HEADER] == "abc-123"
+
+    def test_generates_id_when_absent(self, client):
+        resp = client.get(reverse("healthz"))
+        rid = resp[REQUEST_ID_HEADER]
+        assert rid and rid != "-"
+        # uuid4().hex → 32 hex chars
+        assert len(rid) == 32
+
+    def test_response_always_carries_header(self, client):
+        resp = client.get(reverse("healthz"))
+        assert REQUEST_ID_HEADER in resp
+
+    def test_context_resets_between_requests(self, client):
+        # Outside any request the contextvar is the default sentinel.
+        assert get_request_id() == "-"
+        client.get(reverse("healthz"), headers={"x-request-id": "first"})
+        assert get_request_id() == "-"
+
+
+class TestRequestContext:
+    def test_set_get_reset(self):
+        assert get_request_id() == "-"
+        token = set_request_id("xyz")
+        try:
+            assert get_request_id() == "xyz"
+        finally:
+            reset_request_id(token)
+        assert get_request_id() == "-"
+
+
+class TestLoggingHelpers:
+    def test_filter_injects_request_id(self):
+        record = logging.LogRecord("t", logging.INFO, __file__, 1, "msg", None, None)
+        token = set_request_id("req-7")
+        try:
+            assert RequestIDFilter().filter(record) is True
+            assert record.request_id == "req-7"
+        finally:
+            reset_request_id(token)
+
+    def test_json_formatter_emits_parseable_json_with_request_id(self):
+        record = logging.LogRecord("apps", logging.WARNING, __file__, 1, "boom %s", ("x",), None)
+        RequestIDFilter().filter(record)  # populate request_id
+        line = JSONFormatter().format(record)
+        parsed = json.loads(line)
+        assert parsed["level"] == "WARNING"
+        assert parsed["logger"] == "apps"
+        assert parsed["message"] == "boom x"
+        assert "request_id" in parsed
+
+    def test_json_formatter_defaults_request_id_dash(self):
+        record = logging.LogRecord("apps", logging.INFO, __file__, 1, "hi", None, None)
+        parsed = json.loads(JSONFormatter().format(record))
+        assert parsed["request_id"] == "-"

--- a/backend/openshiksha/settings/base.py
+++ b/backend/openshiksha/settings/base.py
@@ -54,6 +54,9 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    # Request-correlation id (OBS-4) — early so the id is available to every
+    # downstream middleware/view/log record for the whole request lifecycle.
+    "openshiksha.apps.core.middleware.RequestIDMiddleware",
     "corsheaders.middleware.CorsMiddleware",  # CORS - must be before CommonMiddleware
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -289,9 +292,19 @@ MANAGERS = ADMINS
 # Ensure the logs directory exists (CI environments and fresh checkouts won't have it)
 (BASE_DIR / "logs").mkdir(exist_ok=True)
 
+# Log format: "text" (default — today's human-readable formatters, byte-for-byte
+# unchanged) or "json" (one JSON object per line, for log aggregators). OBS-4.
+LOG_FORMAT = os.getenv("LOG_FORMAT", "text")
+_CONSOLE_FORMATTER = "json" if LOG_FORMAT == "json" else "simple"
+_FILE_FORMATTER = "json" if LOG_FORMAT == "json" else "verbose"
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
+    "filters": {
+        # Injects the per-request correlation id onto every record (OBS-4).
+        "request_id": {"()": "openshiksha.apps.core.logging_utils.RequestIDFilter"},
+    },
     "formatters": {
         "verbose": {
             "format": "[{levelname}] {asctime} {module} {process:d} {thread:d} {message}",
@@ -301,18 +314,23 @@ LOGGING = {
             "format": "[{levelname}] {message}",
             "style": "{",
         },
+        "json": {
+            "()": "openshiksha.apps.core.logging_utils.JSONFormatter",
+        },
     },
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
-            "formatter": "simple",
+            "formatter": _CONSOLE_FORMATTER,
+            "filters": ["request_id"],
         },
         "file": {
             "class": "logging.handlers.RotatingFileHandler",
             "filename": BASE_DIR / "logs" / "openshiksha.log",
             "maxBytes": 1024 * 1024 * 10,  # 10 MB
             "backupCount": 5,
-            "formatter": "verbose",
+            "formatter": _FILE_FORMATTER,
+            "filters": ["request_id"],
         },
     },
     "root": {

--- a/docs/changes/2026-06-25-obs-4-request-id.md
+++ b/docs/changes/2026-06-25-obs-4-request-id.md
@@ -1,0 +1,59 @@
+# OBS-4 — Request-correlation id + JSON log option
+
+## Summary
+Adds a `RequestIDMiddleware` that stamps every request with a correlation id
+(from an incoming `X-Request-ID` header, or a fresh uuid4), threads it through all
+log records via a `ContextVar`, echoes it back on the response, and tags the
+Sentry scope when Sentry is active. Adds an opt-in JSON log formatter selected by
+`LOG_FORMAT=json`. The default text logging is untouched (no behaviour change).
+
+## Classification
+Improve.
+
+## Legacy files referenced
+None — the monolith had no request correlation (failures were diagnosed by SSH +
+`grep` over flat, uncorrelated logs). Correlation is the improvement over both
+legacy and today's modern stack.
+
+## What changed
+- **`backend/openshiksha/apps/core/request_context.py`** (new) — a `ContextVar`
+  (thread- *and* asyncio-task-isolated, correct under Daphne/ASGI) with
+  `get/set/reset_request_id` helpers.
+- **`backend/openshiksha/apps/core/middleware.py`** (new) — `RequestIDMiddleware`:
+  reads/generates the id, sets `request.request_id`, stores it in the contextvar
+  (reset in a `finally` so it never leaks across requests on a reused worker),
+  echoes `X-Request-ID` on the response, and tags the Sentry scope **iff Sentry is
+  active** (guarded soft-dep on OBS-3 — no-op when sentry-sdk is absent).
+- **`backend/openshiksha/apps/core/logging_utils.py`** (new) — `RequestIDFilter`
+  (injects `record.request_id`, default `"-"`) + `JSONFormatter` (one JSON object
+  per line: `level/time/logger/message/request_id`, plus `exc_info` when present).
+- **`backend/openshiksha/settings/base.py`** —
+  - `RequestIDMiddleware` added right after `SecurityMiddleware`.
+  - `LOGGING`: registered the `request_id` filter on both handlers, added the
+    `json` formatter, and select it via `LOG_FORMAT=json` (default `text` →
+    today's `simple`/`verbose` formatters, byte-for-byte unchanged).
+
+## Tests written
+`backend/openshiksha/apps/core/tests/test_request_id.py` (8 tests, all green):
+- middleware round-trips a supplied `X-Request-ID`; generates a 32-char uuid4 hex
+  when absent; the response always carries the header; the contextvar resets to
+  `"-"` between requests.
+- `request_context` set/get/reset round-trip.
+- `RequestIDFilter` injects the id; `JSONFormatter` emits parseable JSON
+  containing `request_id` (and defaults it to `"-"`).
+
+Full backend suite re-run green (**1096 passed**) — the global middleware causes
+no regressions.
+
+## Migration notes
+None — no model changes.
+
+## How to verify
+- `pytest openshiksha/apps/core/tests/test_request_id.py` (8 pass).
+- `curl -i :8000/healthz/` → response has an `X-Request-ID` header; supplying one
+  echoes it back.
+- Run with `LOG_FORMAT=json` → console/file logs become one JSON object per line
+  with a `request_id` field.
+
+## Next steps
+OBS-5 (frontend error reporting via the shared `ErrorBoundary`, env-gated).


### PR DESCRIPTION
## Classification
**Improve** — Production Observability initiative (Batch 1, OBS-4).

## What & why
Logs today are unstructured and uncorrelated — you can't follow one request across log lines, or tie a log line to a Sentry error. This threads a correlation id through the request.

- `apps/core/request_context.py` (new): a `ContextVar` (thread- & asyncio-task-isolated, correct under Daphne/ASGI) with get/set/reset helpers.
- `apps/core/middleware.py` (new): `RequestIDMiddleware` — reads/generates `X-Request-ID`, sets `request.request_id`, stores in the contextvar (reset in `finally` → no cross-request leak), echoes the header on the response, and tags the Sentry scope **iff Sentry active** (guarded soft-dep on OBS-3, no-op otherwise).
- `apps/core/logging_utils.py` (new): `RequestIDFilter` (injects `record.request_id`, default `-`) + `JSONFormatter` (one JSON object/line).
- `settings/base.py`: middleware added right after `SecurityMiddleware`; `request_id` filter on both handlers; `json` formatter selected via `LOG_FORMAT=json`. **Default `text` → today's formatters byte-for-byte unchanged.**

## Tests
`apps/core/tests/test_request_id.py` — 8 tests, all green: round-trips supplied id; generates 32-char uuid4 when absent; response always carries header; contextvar resets between requests; set/get/reset; filter injects id; JSON formatter parseable with `request_id` (defaults to `-`).
**Full backend suite re-run green (1096 passed)** — global middleware, no regressions.

## Verify
- `curl -i :8000/healthz/` → `X-Request-ID` header present; supplying one echoes it back.
- `LOG_FORMAT=json` → logs become one JSON object per line with `request_id`.

## Legacy reference
None — correlation is the improvement over both legacy (SSH+grep flat logs) and today's stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)