### PR TITLE
ci(obs): wire Sentry DSNs into build/deploy (OBS-3/OBS-5 activation)

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -465,11 +465,16 @@ jobs:
                     ghcr.io/${{ github.repository_owner }}/openshiksha-${{ matrix.service }}:${{ steps.extract_branch.outputs.branch }}
                     ghcr.io/${{ github.repository_owner }}/openshiksha-${{ matrix.service }}:${{ github.sha }}
                 # Bake build identity into the image for /api/v1/version/ (OBS-2).
-                # The backend Dockerfile consumes these; the frontend ignores the
-                # extra ARGs harmlessly.
+                # The backend Dockerfile consumes GIT_SHA/BUILD_TIME; the frontend
+                # consumes VITE_SENTRY_DSN (OBS-5). Each image ignores the ARGs it
+                # doesn't declare, harmlessly. VITE_SENTRY_DSN comes from the repo
+                # Actions secret (masked in logs); empty ⇒ frontend reporting stays
+                # disabled. A frontend DSN is inlined into the public bundle by
+                # design — it is not a confidential value.
                 build-args: |
                     GIT_SHA=${{ github.sha }}
                     BUILD_TIME=${{ steps.extract_branch.outputs.build_time }}
+                    VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}
                 cache-from: type=gha,scope=${{ matrix.service }}
                 cache-to: type=gha,scope=${{ matrix.service }},mode=max
 

--- a/docs/changes/2026-06-26-sentry-dsn-build-wiring.md
+++ b/docs/changes/2026-06-26-sentry-dsn-build-wiring.md
@@ -1,0 +1,50 @@
+# Wire Sentry DSNs into the build/deploy (OBS-3 / OBS-5 activation)
+
+## Summary
+Completes the OBS-3/OBS-5 follow-up: makes the env-gated Sentry wiring actually
+reachable in deployed builds. The **frontend** DSN is injected into the prod image
+at build time from a GitHub Actions secret; the **backend** DSN key is documented
+in the cluster Secret template (set out-of-band on the cluster).
+
+## Classification
+Improve / ops wiring (no app code change).
+
+## What changed
+- **`frontend_modern/Dockerfile.prod`** — added `ARG VITE_SENTRY_DSN=` + `ENV`
+  before `npm run build` so Vite inlines it. Empty default ⇒ reporting disabled
+  and Rollup drops the SDK (entry chunk unchanged), so local/uncfg builds are
+  byte-for-byte today's.
+- **`.github/workflows/ci-cd.yaml`** — the image build-push step passes
+  `VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}` as a build-arg (alongside the
+  existing GIT_SHA/BUILD_TIME). The backend image ignores the undeclared ARG
+  harmlessly. The secret is masked in CI logs.
+- **`k8s/base/secret.example.yaml`** — documented the optional backend
+  `SENTRY_DSN` key (server-side only; recommend a *separate* Sentry project from
+  the frontend so Python/Django events don't mix with browser events).
+
+## Secret handling
+- **Frontend DSN** → GitHub Actions secret `VITE_SENTRY_DSN`. Not in the source
+  tree, masked in CI logs, not readable by collaborators in settings. Note: a
+  frontend DSN is inlined into the public JS bundle by design (true for any
+  browser SDK) — it is not a confidential value; Sentry-side rate limits / allowed
+  domains are the real protection.
+- **Backend DSN** → the cluster Secret `openshiksha-secrets` (created out-of-band,
+  never committed). Set with, e.g.:
+  ```
+  kubectl -n openshiksha-prod patch secret openshiksha-secrets --type merge \
+    -p '{"stringData":{"SENTRY_DSN":"https://...@oNNN.ingest.sentry.io/NNN"}}'
+  kubectl -n openshiksha-prod rollout restart deploy/backend deploy/celery-worker
+  ```
+
+## How to verify
+- Frontend: after a CI build with the secret set, the shipped bundle initialises
+  Sentry; with the secret empty, no Sentry code ships (`check:budget` still green).
+- Backend: with `SENTRY_DSN` present in the pod env, `init_sentry()` returns True;
+  empty/unset ⇒ no-op.
+
+## Notes / follow-ups
+- The given DSN is a **frontend (React) project** DSN. Backend error tracking
+  should use a **separate Sentry project**; reusing the frontend DSN mixes
+  platforms in one project (works, but not recommended).
+- Backend DSN must be set on the cluster Secret (manual step above) — it is not
+  driven by CI, since `openshiksha-secrets` is bootstrapped out-of-band.

--- a/frontend_modern/Dockerfile.prod
+++ b/frontend_modern/Dockerfile.prod
@@ -27,6 +27,12 @@ COPY . .
 ARG VITE_API_BASE_URL=/api/v1
 ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 
+# Frontend Sentry DSN (OBS-5). Vite inlines VITE_* at build time, and the runtime
+# reporter is gated on this value: empty ⇒ reporting disabled and Rollup drops the
+# SDK entirely (entry chunk unchanged). Passed from the VITE_SENTRY_DSN CI secret.
+ARG VITE_SENTRY_DSN=
+ENV VITE_SENTRY_DSN=$VITE_SENTRY_DSN
+
 RUN npm run build
 # Defend the entry-chunk ceiling — fails the image build if it's blown.
 RUN npm run check:budget

--- a/k8s/base/secret.example.yaml
+++ b/k8s/base/secret.example.yaml
@@ -12,7 +12,14 @@
 #     --from-literal=CELERY_RESULT_BACKEND='redis://redis:6379/2' \
 #     --from-literal=ANTHROPIC_API_KEY='sk-ant-...' \
 #     --from-literal=EMAIL_HOST_USER='...' \
-#     --from-literal=EMAIL_HOST_PASSWORD='...'
+#     --from-literal=EMAIL_HOST_PASSWORD='...' \
+#     --from-literal=SENTRY_DSN='https://...@oNNN.ingest.sentry.io/NNN'
+#
+# SENTRY_DSN (OBS-3) is OPTIONAL — leave it empty/unset to keep backend error
+# tracking disabled (init_sentry() no-ops). Prefer a SEPARATE Sentry project from
+# the frontend so Python (Django/Celery) events don't mix with browser events.
+# Unlike the frontend DSN (which ships in the public bundle), the backend DSN is
+# server-side only — keep it in this Secret, never in committed config.
 #
 # Sealed-secrets / external-secrets are the right long-term solution; this
 # bootstraps the cluster.
@@ -32,3 +39,6 @@ stringData:
   ANTHROPIC_API_KEY: ""
   EMAIL_HOST_USER: ""
   EMAIL_HOST_PASSWORD: ""
+  # Optional — empty disables backend error tracking (OBS-3). Use a separate
+  # Sentry project from the frontend. Server-side only; never commit a real value.
+  SENTRY_DSN: ""


### PR DESCRIPTION
Makes the env-gated Sentry wiring (OBS-3 backend / OBS-5 frontend) actually reachable in deployed builds.

## Frontend (`VITE_SENTRY_DSN`)
- `frontend_modern/Dockerfile.prod`: `ARG VITE_SENTRY_DSN=` + `ENV` before `npm run build` (Vite inlines it). Empty default ⇒ reporting off, SDK dropped from the bundle (entry chunk unchanged).
- `ci-cd.yaml`: build-push step passes `VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}` (masked in logs; backend image ignores the undeclared ARG).

## Backend (`SENTRY_DSN`)
- `k8s/base/secret.example.yaml`: documents the optional `SENTRY_DSN` key in the out-of-band cluster Secret. Server-side only, never committed. Set on the cluster:
  ```
  kubectl -n openshiksha-prod patch secret openshiksha-secrets --type merge \
    -p '{"stringData":{"SENTRY_DSN":"https://...@oNNN.ingest.sentry.io/NNN"}}'
  kubectl -n openshiksha-prod rollout restart deploy/backend deploy/celery-worker
  ```

## Secret handling
- Frontend DSN lives in a **GitHub Actions secret** (not source, masked, not collaborator-readable). Caveat: a frontend DSN is inlined into the public bundle by design — not a confidential value; Sentry-side rate limits / allowed domains are the real protection.
- Backend DSN lives only in the cluster Secret.

## ⚠️ Recommendation
The provisioned DSN is a **frontend (React) project** DSN. Backend should use a **separate Sentry project** so Python/Django events don't mix with browser events. Reusing the frontend DSN works mechanically but isn't recommended.

## Verify
- `kubectl kustomize k8s/overlays/prod` builds clean; CI YAML valid.
- Empty secret ⇒ behaviour byte-for-byte today's; `check:budget` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)