### PR TITLE
feat(obs): MET-1 — env-gated Prometheus /metrics endpoint

### DIFF
--- a/backend/openshiksha/apps/api/tests/test_metrics_endpoint.py
+++ b/backend/openshiksha/apps/api/tests/test_metrics_endpoint.py
@@ -1,0 +1,59 @@
+"""
+Tests for the env-gated Prometheus /metrics endpoint (MET-1).
+
+Covers both the gated-OFF default (404, behaviour byte-for-byte today's) and the
+gated-ON path (exposition + optional bearer-token gate).
+"""
+
+from django.test import override_settings
+from django.urls import reverse
+
+
+class TestMetricsGating:
+    def test_disabled_by_default_returns_404(self, client):
+        # No override → settings.METRICS_ENABLED is the default (False in test settings).
+        response = client.get(reverse("metrics"))
+        assert response.status_code == 404
+
+    @override_settings(METRICS_ENABLED=True)
+    def test_enabled_returns_prometheus_exposition(self, client):
+        response = client.get(reverse("metrics"))
+        assert response.status_code == 200
+        assert response["Content-Type"].startswith("text/plain")
+        body = response.content.decode()
+        # Valid Prometheus text exposition (HELP/TYPE banners present).
+        assert "# HELP" in body
+        assert "# TYPE" in body
+        # build_info series is always present and carries the live identity.
+        assert "openshiksha_build_info" in body
+
+    @override_settings(METRICS_ENABLED=True, APP_VERSION="9.9.9", ENVIRONMENT="prod")
+    def test_build_info_reflects_settings(self, client):
+        body = client.get(reverse("metrics")).content.decode()
+        assert 'version="9.9.9"' in body
+        assert 'environment="prod"' in body
+
+    def test_endpoint_is_public_no_auth_redirect(self, client):
+        # Even disabled, it must not 302 to login — it's a probe-style path.
+        response = client.get(reverse("metrics"))
+        assert response.status_code == 404
+
+
+class TestMetricsTokenGate:
+    @override_settings(METRICS_ENABLED=True, METRICS_TOKEN="s3cret")
+    def test_missing_token_forbidden(self, client):
+        assert client.get(reverse("metrics")).status_code == 403
+
+    @override_settings(METRICS_ENABLED=True, METRICS_TOKEN="s3cret")
+    def test_wrong_token_forbidden(self, client):
+        response = client.get(reverse("metrics"), HTTP_AUTHORIZATION="Bearer nope")
+        assert response.status_code == 403
+
+    @override_settings(METRICS_ENABLED=True, METRICS_TOKEN="s3cret")
+    def test_correct_token_allowed(self, client):
+        response = client.get(reverse("metrics"), HTTP_AUTHORIZATION="Bearer s3cret")
+        assert response.status_code == 200
+
+    @override_settings(METRICS_ENABLED=True, METRICS_TOKEN="")
+    def test_no_token_configured_allows_anonymous(self, client):
+        assert client.get(reverse("metrics")).status_code == 200

--- a/backend/openshiksha/apps/api/views/metrics.py
+++ b/backend/openshiksha/apps/api/views/metrics.py
@@ -1,0 +1,42 @@
+"""
+Prometheus ``/metrics`` exposition view (MET-1, Observability Batch 2).
+
+Strictly env-gated: returns **404** unless ``settings.METRICS_ENABLED`` is true, so
+the endpoint is invisible (byte-for-byte today's behaviour) in dev / test / CI.
+When enabled it is meant to live on an internal network and be scraped by
+Prometheus; an optional ``METRICS_TOKEN`` adds a bearer-token gate for defence in
+depth. No auth framework, no DB — kept cheap like the health probes.
+"""
+
+import hmac
+
+from django.conf import settings
+from django.http import HttpResponse, HttpResponseForbidden, HttpResponseNotFound
+from django.views.decorators.csrf import csrf_exempt
+
+from openshiksha.apps.core import metrics
+
+
+def _token_ok(request) -> bool:
+    """True if no token is configured, or the request carries the matching bearer."""
+    expected = getattr(settings, "METRICS_TOKEN", "") or ""
+    if not expected:
+        return True
+    auth = request.headers.get("Authorization", "")
+    presented = auth[7:] if auth.startswith("Bearer ") else ""
+    # Constant-time compare so the gate can't be probed by timing.
+    return hmac.compare_digest(presented, expected)
+
+
+@csrf_exempt
+def metrics_view(request):
+    """Serve the Prometheus text exposition when metrics are enabled.
+
+    GET /metrics/  →  404 (disabled), 403 (bad token), or 200 text exposition.
+    """
+    if not metrics.metrics_enabled():
+        return HttpResponseNotFound("metrics disabled")
+    if not _token_ok(request):
+        return HttpResponseForbidden("forbidden")
+    payload, content_type = metrics.render_latest()
+    return HttpResponse(payload, content_type=content_type)

--- a/backend/openshiksha/apps/core/metrics.py
+++ b/backend/openshiksha/apps/core/metrics.py
@@ -1,0 +1,60 @@
+"""
+Prometheus metrics exposition (MET-1, Observability Batch 2).
+
+Uses the **process-global default registry** (``prometheus_client.REGISTRY``) so
+the runtime collectors prometheus_client auto-registers — process CPU/RSS, open
+fds, Python GC — are exposed for free, and later increments' module-level
+collectors (business gauges, request histogram) land on the same registry without
+extra plumbing.
+
+Process-model assumption (verified 2026-06-27): prod runs a **single daphne ASGI
+process** (`CMD ["daphne", ...]` in Dockerfile.prod), so the default in-process
+registry is correct — no ``PROMETHEUS_MULTIPROC_DIR`` is needed. A future move to
+a multi-worker server (e.g. gunicorn with >1 worker) would require multiprocess
+mode; this comment is the flag for that.
+
+This module owns the ``openshiksha_build_info`` identity gauge and the rendering
+helper the gated ``/metrics`` view calls. Nothing here runs unless the operator
+sets ``METRICS_ENABLED=true`` and the endpoint is scraped.
+"""
+
+import os
+
+from prometheus_client import CONTENT_TYPE_LATEST, Gauge, generate_latest
+
+from django.conf import settings
+
+# build_info: a value-1 gauge whose labels carry the live build identity — the
+# conventional Prometheus pattern for static metadata. Registered on the default
+# registry at import (harmless when metrics are disabled: it's just a series that
+# is never scraped). The same identity the /api/v1/version/ endpoint surfaces.
+_build_info = Gauge(
+    "openshiksha_build_info",
+    "Live build identity (always 1); version / git sha / environment ride on the labels.",
+    ["version", "git_sha", "environment"],
+)
+
+
+def _refresh_build_info():
+    """(Re)set the build_info series from current settings/env.
+
+    Called at scrape time so test ``override_settings`` is reflected and the gauge
+    never holds a stale label set (``.clear()`` drops prior label combinations).
+    """
+    _build_info.clear()
+    _build_info.labels(
+        version=getattr(settings, "APP_VERSION", "unknown"),
+        git_sha=os.getenv("GIT_SHA", "unknown"),
+        environment=getattr(settings, "ENVIRONMENT", "unknown"),
+    ).set(1)
+
+
+def metrics_enabled() -> bool:
+    """Whether the ``/metrics`` endpoint should serve (env-gated, default off)."""
+    return bool(getattr(settings, "METRICS_ENABLED", False))
+
+
+def render_latest() -> tuple[bytes, str]:
+    """Return ``(payload, content_type)`` for the Prometheus text exposition."""
+    _refresh_build_info()
+    return generate_latest(), CONTENT_TYPE_LATEST

--- a/backend/openshiksha/settings/base.py
+++ b/backend/openshiksha/settings/base.py
@@ -26,6 +26,13 @@ ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1").split(",")
 APP_VERSION = os.getenv("APP_VERSION", "2.0.0")
 ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 
+# Prometheus metrics exposition (MET-1). Strictly env-gated: the /metrics endpoint
+# 404s unless METRICS_ENABLED is true, so default dev/test/CI behaviour is
+# unchanged. When enabled behind an internal network, an optional METRICS_TOKEN
+# adds a bearer-token gate (Prometheus passes it via the Authorization header).
+METRICS_ENABLED = os.getenv("METRICS_ENABLED", "false").lower() == "true"
+METRICS_TOKEN = os.getenv("METRICS_TOKEN", "")
+
 # Custom User Model
 AUTH_USER_MODEL = "core.User"
 

--- a/backend/openshiksha/urls.py
+++ b/backend/openshiksha/urls.py
@@ -13,6 +13,7 @@ from django.http import HttpResponse
 from django.urls import include, path
 
 from openshiksha.apps.api.views.health import readyz
+from openshiksha.apps.api.views.metrics import metrics_view
 
 
 def healthz(_request):
@@ -32,6 +33,8 @@ urlpatterns = [
     path("healthz/", healthz, name="healthz"),
     # Deep readiness probe — DB + cache check; LB drain signal. See readyz().
     path("readyz/", readyz, name="readyz"),
+    # Prometheus metrics — env-gated (404 unless METRICS_ENABLED). See metrics_view().
+    path("metrics/", metrics_view, name="metrics"),
     # Django admin — mounted at /django-admin/ so it doesn't collide with the
     # React app's /admin route (the in-app school-admin dashboard). Superuser-only
     # gate is applied below.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -34,6 +34,11 @@ whitenoise==6.12.0
 # integration; Celery/Redis integrations ship in the base SDK.
 sentry-sdk[django]==2.63.0
 
+# Metrics exposition (OBS-6) — Prometheus client. The /metrics endpoint is
+# strictly env-gated (METRICS_ENABLED); the SDK is only imported when scraped, so
+# nothing runs by default in dev / test / CI.
+prometheus-client==0.21.1
+
 # Validation & Serialization
 pydantic==2.13.4
 pydantic-settings==2.14.2

--- a/docs/changes/2026-06-27-met1-metrics-endpoint.md
+++ b/docs/changes/2026-06-27-met1-metrics-endpoint.md
@@ -1,0 +1,71 @@
+# MET-1 — `prometheus-client` dep + env-gated `/metrics` endpoint
+
+**Date:** 2026-06-27
+**Initiative:** [Production Observability & Operational Readiness](../initiatives/2026-production-observability.md) — Batch 2 (Metrics & dashboards), increment 1 of 5
+**Plan:** [2026-06-27-plan.md](../daily-plans/2026-06-27-plan.md)
+**Classification:** New
+
+## Summary
+
+Adds the foundation of Observability Batch 2: a Prometheus text-exposition
+endpoint at `/metrics/`, **strictly env-gated**. It returns `404` unless
+`METRICS_ENABLED=true`, so default dev / test / CI behaviour is byte-for-byte
+today's. When enabled it serves the process-global default registry — so the
+runtime collectors prometheus_client auto-registers (process CPU/RSS, open fds,
+Python GC) are exposed for free — plus an `openshiksha_build_info` gauge whose
+labels (version / git sha / environment) pin a metrics series to a specific live
+build (the same identity `/api/v1/version/` surfaces).
+
+## What changed
+
+- `backend/requirements.txt` — pin `prometheus-client==0.21.1` (the thin
+  exposition lib, **not** `django-prometheus` which auto-patches and is always-on,
+  violating the operability bar).
+- `backend/openshiksha/settings/base.py` — `METRICS_ENABLED` (default `false`)
+  and `METRICS_TOKEN` (optional bearer-token gate) settings.
+- `backend/openshiksha/apps/core/metrics.py` — uses the default registry;
+  `openshiksha_build_info` gauge refreshed at scrape time; `render_latest()` /
+  `metrics_enabled()` helpers. A comment records the verified single-daphne-process
+  assumption (no `PROMETHEUS_MULTIPROC_DIR` needed until multi-worker).
+- `backend/openshiksha/apps/api/views/metrics.py` — cheap plain-Django
+  (`csrf_exempt`, no DRF, no DB) `metrics_view`: `404` when disabled, `403` on a
+  bad token (constant-time `hmac.compare_digest`), `200` exposition otherwise.
+- `backend/openshiksha/urls.py` — mount `path("metrics/", ...)` next to the
+  `/healthz/` + `/readyz/` probes.
+
+## Exposure (verified)
+
+The ingress routes only `/api`, `/django-admin`, `/static`, `/` — so top-level
+`/metrics` is **not publicly routable**; it is reachable only in-cluster via the
+`backend:8000` Service. The token gate is defence in depth. (No ingress path is
+added for `/metrics`.)
+
+## Operability bar
+
+1. **Additive & env-gated** — `404` and invisible unless `METRICS_ENABLED=true`
+   (`test_disabled_by_default_returns_404`).
+2. **Probe-safe** — separate cheap path; liveness/readiness untouched.
+3. **No secrets** — exposition is build identity + (later) aggregate counts only;
+   optional token gate.
+4. **No perf/offline regression** — backend/infra-only; no frontend change.
+5. **Tested both ways** — gated-off (404) and gated-on (exposition + token gate).
+
+## Tests
+
+`backend/openshiksha/apps/api/tests/test_metrics_endpoint.py` (8 tests):
+default 404; enabled returns valid Prometheus exposition (`# HELP`/`# TYPE`) with
+`openshiksha_build_info`; build-info labels reflect `override_settings`; token
+gate (missing / wrong / correct / unset).
+
+## Migration notes
+
+None — no model changes. To enable: set `METRICS_ENABLED=true` (and optionally
+`METRICS_TOKEN=<random>`) in the prod secret; leave unset everywhere else.
+
+## Next steps
+
+- **MET-2** — business + queue-depth gauges (active assignments, grade-queue
+  depth, users by role, classroom counts) via a scrape-time collector.
+- **MET-3** — async-task health gauges from `django_celery_results.TaskResult`.
+- **MET-4** — gated HTTP request count + latency histogram middleware.
+- **MET-5** — Grafana starter dashboard + scrape runbook + ledger.


### PR DESCRIPTION
## Production Observability — Batch 2 (Metrics & dashboards), increment 1 of 5

Foundation for time-series telemetry. Adds a Prometheus text-exposition endpoint at `/metrics/`, **strictly env-gated**.

**Classification:** New
**Plan:** `docs/daily-plans/2026-06-27-plan.md` (MET-1)
**Initiative:** `docs/initiatives/2026-production-observability.md`

### What
- `prometheus-client==0.21.1` (thin exposition lib, *not* `django-prometheus` — no always-on patching).
- Top-level `metrics_view`: **404** unless `METRICS_ENABLED=true` (byte-for-byte today's behaviour when off); **403** on bad `METRICS_TOKEN` bearer (constant-time compare); **200** Prometheus text otherwise. Plain Django, `csrf_exempt`, no DB.
- Uses the **default registry** so process CPU/RSS, open-fds and Python-GC runtime metrics come for free; plus an `openshiksha_build_info` identity gauge (version / git_sha / environment — same identity as `/api/v1/version/`).
- `METRICS_ENABLED` / `METRICS_TOKEN` settings (both default off/empty).

### Exposure
Ingress routes only `/api`, `/django-admin`, `/static`, `/` → `/metrics` is **not publicly routable**; in-cluster only via `backend:8000`. Token gate is defence in depth. No ingress path added.

### Operability bar
Additive & env-gated (404 default) · probe-safe (separate cheap path) · no secrets · backend-only (no perf/offline impact) · tested gated-off **and** gated-on.

### Tests
`test_metrics_endpoint.py` (8): default 404; enabled → valid exposition (`# HELP`/`# TYPE`) incl. `openshiksha_build_info`; build-info labels reflect settings; token gate missing/wrong/correct/unset. All green.

### Verify
```
cd backend && METRICS_ENABLED=true ./venv/Scripts/python.exe -m pytest openshiksha/apps/api/tests/test_metrics_endpoint.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)