### PR TITLE
feat(obs): MET-2 — on-scrape business & queue-depth gauges

### DIFF
--- a/backend/openshiksha/apps/core/metrics.py
+++ b/backend/openshiksha/apps/core/metrics.py
@@ -18,11 +18,15 @@ helper the gated ``/metrics`` view calls. Nothing here runs unless the operator
 sets ``METRICS_ENABLED=true`` and the endpoint is scraped.
 """
 
+import logging
 import os
 
-from prometheus_client import CONTENT_TYPE_LATEST, Gauge, generate_latest
+from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, Gauge, generate_latest
+from prometheus_client.core import GaugeMetricFamily
 
 from django.conf import settings
+
+logger = logging.getLogger("apps")
 
 # build_info: a value-1 gauge whose labels carry the live build identity — the
 # conventional Prometheus pattern for static metadata. Registered on the default
@@ -49,6 +53,91 @@ def _refresh_build_info():
     ).set(1)
 
 
+class BusinessMetricsCollector:
+    """Scrape-time, read-only DB gauges for product / operational signals (MET-2).
+
+    Implements the ``prometheus_client`` custom-collector protocol: ``collect()``
+    runs a handful of single ``COUNT`` queries at scrape time and yields gauges.
+    Computing on-scrape (rather than event counters) keeps these stateless — no
+    cross-process aggregation, no drift — which is the right pattern for
+    "current size of X" business signals.
+
+    Gauges (idiomatically *without* the ``_total`` counter suffix):
+      * ``openshiksha_assignments_active`` — open, not past due,
+      * ``openshiksha_submissions_pending_grading`` — grade-queue depth,
+      * ``openshiksha_users{role=...}`` — accounts grouped by role,
+      * ``openshiksha_classrooms`` / ``openshiksha_subjectrooms`` — totals.
+
+    Registered lazily on the first real scrape (see ``_ensure_collectors``), so no
+    DB work happens — and the collector is never even registered — while the
+    endpoint is disabled (it 404s before ``render_latest`` is called).
+    """
+
+    def collect(self):
+        # Defensive: a DB hiccup mid-scrape degrades to "no business gauges this
+        # scrape" rather than 500-ing the metrics endpoint (build_info + runtime
+        # series still serve).
+        try:
+            yield from self._collect()
+        except Exception:  # pragma: no cover - defensive; never break a scrape
+            logger.warning("metrics: BusinessMetricsCollector failed; skipping business gauges", exc_info=True)
+
+    def _collect(self):
+        from django.db.models import Count
+        from django.utils import timezone
+
+        from openshiksha.apps.core.models import Assignment, ClassRoom, SubjectRoom, Submission, User
+
+        now = timezone.now()
+
+        active = Assignment.objects.filter(closed_at__isnull=True, due_at__gte=now).count()
+        yield GaugeMetricFamily(
+            "openshiksha_assignments_active",
+            "Assignments that are open (not closed) and not past their due date.",
+            value=active,
+        )
+
+        pending = Submission.objects.filter(submitted_at__isnull=False, score__isnull=True).count()
+        yield GaugeMetricFamily(
+            "openshiksha_submissions_pending_grading",
+            "Submitted submissions still awaiting a grade (grade-queue depth).",
+            value=pending,
+        )
+
+        users = GaugeMetricFamily(
+            "openshiksha_users",
+            "User accounts grouped by role.",
+            labels=["role"],
+        )
+        for row in User.objects.values("role").annotate(n=Count("id")):
+            users.add_metric([row["role"] or "unknown"], row["n"])
+        yield users
+
+        yield GaugeMetricFamily(
+            "openshiksha_classrooms",
+            "Total classrooms.",
+            value=ClassRoom.objects.count(),
+        )
+        yield GaugeMetricFamily(
+            "openshiksha_subjectrooms",
+            "Total subject rooms.",
+            value=SubjectRoom.objects.count(),
+        )
+
+
+# Lazy, idempotent registration of the on-scrape collectors. Guarded so we only
+# touch the registry on a real (enabled) scrape and never double-register.
+_collectors_registered = False
+
+
+def _ensure_collectors():
+    global _collectors_registered
+    if _collectors_registered:
+        return
+    REGISTRY.register(BusinessMetricsCollector())
+    _collectors_registered = True
+
+
 def metrics_enabled() -> bool:
     """Whether the ``/metrics`` endpoint should serve (env-gated, default off)."""
     return bool(getattr(settings, "METRICS_ENABLED", False))
@@ -57,4 +146,5 @@ def metrics_enabled() -> bool:
 def render_latest() -> tuple[bytes, str]:
     """Return ``(payload, content_type)`` for the Prometheus text exposition."""
     _refresh_build_info()
+    _ensure_collectors()
     return generate_latest(), CONTENT_TYPE_LATEST

--- a/backend/openshiksha/apps/core/tests/test_metrics_business.py
+++ b/backend/openshiksha/apps/core/tests/test_metrics_business.py
@@ -1,0 +1,100 @@
+"""
+Tests for the on-scrape business / queue-depth gauges (MET-2).
+
+Seeds a small graph via the ORM, scrapes the gated /metrics endpoint, and asserts
+the ``openshiksha_*`` business families reflect the seeded data. The gated-off
+(404, no DB hit) path is covered by ``test_metrics_endpoint.py``.
+"""
+
+from datetime import timedelta
+
+import pytest
+
+from django.urls import reverse
+from django.utils import timezone
+
+from openshiksha.apps.core.models import (
+    Assignment,
+    Board,
+    Chapter,
+    ClassRoom,
+    ProblemSet,
+    School,
+    Standard,
+    Subject,
+    SubjectRoom,
+    Submission,
+    User,
+    UserRole,
+)
+
+
+@pytest.fixture
+def seeded(db, settings):
+    settings.METRICS_ENABLED = True
+    board = Board.objects.create(name="CBSE")
+    school = School.objects.create(name="Test School", board=board)
+    standard = Standard.objects.create(number=9)
+    subject = Subject.objects.create(name="Science")
+    chapter = Chapter.objects.create(name="Motion", subject=subject, standard=standard, order=1)
+    classroom = ClassRoom.objects.create(school=school, standard=standard, division="A", academic_year="2025-26")
+    teacher = User.objects.create_user(username="t1", password="pw", role=UserRole.TEACHER, school=school)
+    s1 = User.objects.create_user(username="s1", password="pw", role=UserRole.STUDENT, school=school)
+    s2 = User.objects.create_user(username="s2", password="pw", role=UserRole.STUDENT, school=school)
+    room = SubjectRoom.objects.create(classroom=classroom, subject=subject, teacher=teacher)
+    ps = ProblemSet.objects.create(
+        school=school, standard=standard, subject=subject, chapter=chapter, title="Set 1", number=1, created_by=teacher
+    )
+
+    now = timezone.now()
+    active = Assignment.objects.create(
+        subject_room=room, problem_set=ps, assigned_by=teacher, due_at=now + timedelta(days=3)
+    )
+    # A closed assignment — must NOT count toward "active".
+    Assignment.objects.create(
+        subject_room=room,
+        problem_set=ps,
+        assigned_by=teacher,
+        due_at=now + timedelta(days=3),
+        number=2,
+        closed_at=now,
+    )
+    # Create both in-progress (no submitted_at ⇒ the on-submit grade signal does
+    # not fire), then force the exact terminal states via .update() — which
+    # bypasses post_save — so the pending row stays ungraded deterministically.
+    sub_pending = Submission.objects.create(assignment=active, student=s1)
+    sub_graded = Submission.objects.create(assignment=active, student=s2)
+    # Pending-grading: submitted, no score → grade-queue depth = 1.
+    Submission.objects.filter(pk=sub_pending.pk).update(submitted_at=now, score=None)
+    # Graded: excluded from the pending count.
+    Submission.objects.filter(pk=sub_graded.pk).update(submitted_at=now, score=0.9)
+    return {"active": active}
+
+
+class TestBusinessGauges:
+    def _scrape(self, client):
+        response = client.get(reverse("metrics"))
+        assert response.status_code == 200
+        return response.content.decode()
+
+    def test_active_assignments_excludes_closed(self, client, seeded):
+        body = self._scrape(client)
+        assert "openshiksha_assignments_active 1.0" in body
+
+    def test_grade_queue_depth_excludes_graded(self, client, seeded):
+        body = self._scrape(client)
+        assert "openshiksha_submissions_pending_grading 1.0" in body
+
+    def test_users_by_role(self, client, seeded):
+        body = self._scrape(client)
+        assert 'openshiksha_users{role="student"} 2.0' in body
+        assert 'openshiksha_users{role="teacher"} 1.0' in body
+
+    def test_classroom_and_subjectroom_totals(self, client, seeded):
+        body = self._scrape(client)
+        assert "openshiksha_classrooms 1.0" in body
+        assert "openshiksha_subjectrooms 1.0" in body
+
+    def test_build_info_still_present(self, client, seeded):
+        # Business gauges ride alongside the MET-1 identity gauge.
+        assert "openshiksha_build_info" in self._scrape(client)

--- a/docs/changes/2026-06-27-met2-business-gauges.md
+++ b/docs/changes/2026-06-27-met2-business-gauges.md
@@ -1,0 +1,63 @@
+# MET-2 — Business & queue-depth gauges (on-scrape collector)
+
+**Date:** 2026-06-27
+**Initiative:** [Production Observability & Operational Readiness](../initiatives/2026-production-observability.md) — Batch 2, increment 2 of 5
+**Plan:** [2026-06-27-plan.md](../daily-plans/2026-06-27-plan.md)
+**Classification:** New
+
+## Summary
+
+Adds a `BusinessMetricsCollector` (the prometheus_client custom-collector
+protocol) that runs read-only `COUNT` queries **at scrape time** and yields the
+product/operational gauges that actually predict an OpenShiksha incident. It
+registers on the default registry **lazily, on the first real (enabled) scrape**,
+so no DB work happens — and the collector isn't even registered — while the
+endpoint is disabled (it 404s before the collector is touched).
+
+## Gauges
+
+| Metric | Meaning |
+|--------|---------|
+| `openshiksha_assignments_active` | Assignments open (not closed) and not past due |
+| `openshiksha_submissions_pending_grading` | Submitted submissions awaiting a grade — **grade-queue depth** |
+| `openshiksha_users{role=...}` | Accounts grouped by role |
+| `openshiksha_classrooms` | Total classrooms |
+| `openshiksha_subjectrooms` | Total subject rooms |
+
+Names follow Prometheus idiom (no `_total` suffix — that suffix is the *counter*
+convention; these are gauges).
+
+## Why on-scrape (not event counters)
+
+Gauges computed lazily on each scrape are stateless: no cross-process
+aggregation, no drift — the right pattern for "current size of X" signals. Each
+is a single indexed `COUNT` (no joins, no N+1) so a scrape stays cheap. The
+predicates reuse the product definitions: active = `closed_at IS NULL AND
+due_at >= now` (mirrors `Assignment.status`); grade-queue = `submitted_at NOT
+NULL AND score IS NULL`.
+
+## Resilience
+
+`collect()` wraps the queries in a `try/except`: a DB hiccup mid-scrape degrades
+to "no business gauges this scrape" (build_info + runtime series still serve)
+rather than 500-ing the endpoint.
+
+## Tests
+
+`backend/openshiksha/apps/core/tests/test_metrics_business.py` (5 tests): seeds a
+small graph, scrapes `/metrics`, asserts active-assignments excludes a closed
+one, grade-queue depth excludes a graded submission, users-by-role counts,
+classroom/subjectroom totals, and build_info still rides alongside. (The grading
+post_save signal auto-grades on submit under eager Celery, so the pending state
+is forced via `.update()` which bypasses the signal.) Gated-off (404) path is
+covered by MET-1's `test_metrics_endpoint.py`.
+
+## Migration notes
+
+None — no model changes.
+
+## Next steps
+
+- **MET-3** — async-task health gauges from `django_celery_results.TaskResult`.
+- **MET-4** — gated HTTP request count + latency histogram middleware.
+- **MET-5** — Grafana starter dashboard + scrape runbook + ledger.


### PR DESCRIPTION
## Production Observability — Batch 2 (Metrics & dashboards), increment 2 of 5

Adds the first product/operational signals to `/metrics`: a `BusinessMetricsCollector` computing read-only `COUNT`s **at scrape time**.

**Classification:** New · **Plan:** MET-2 · stacked on [#467](https://github.com/openshiksha/openshiksha/pull/467) (MET-1)

> Base this on `qa` after #467 merges; the diff here is only the MET-2 commit (`apps/core/metrics.py` collector + tests + change doc).

### Gauges
| Metric | Meaning |
|--------|---------|
| `openshiksha_assignments_active` | open, not past due (mirrors `Assignment.status`) |
| `openshiksha_submissions_pending_grading` | **grade-queue depth** (submitted, ungraded) |
| `openshiksha_users{role}` | accounts by role |
| `openshiksha_classrooms` / `openshiksha_subjectrooms` | totals |

Idiomatic gauge names (no `_total` — that's the counter convention).

### Design
- **On-scrape, not event counters** → stateless, no cross-process aggregation, no drift; each is a single indexed `COUNT`.
- **Lazy registration** on the first enabled scrape ⇒ zero DB work (and the collector isn't even registered) while disabled — endpoint 404s first.
- **Fault-tolerant** `collect()`: a DB hiccup degrades to "no business gauges this scrape", never 500s the endpoint.

### Tests
`test_metrics_business.py` (5): active excludes closed; grade-queue excludes graded; users-by-role; classroom/subjectroom totals; build_info still present. Gated-off path covered by MET-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)