### PR TITLE
feat(obs): MET-3 — Celery task-health gauges from TaskResult

### DIFF
--- a/backend/openshiksha/apps/core/metrics.py
+++ b/backend/openshiksha/apps/core/metrics.py
@@ -20,6 +20,7 @@ sets ``METRICS_ENABLED=true`` and the endpoint is scraped.
 
 import logging
 import os
+from datetime import timedelta
 
 from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, Gauge, generate_latest
 from prometheus_client.core import GaugeMetricFamily
@@ -125,6 +126,81 @@ class BusinessMetricsCollector:
         )
 
 
+# Non-terminal Celery states — a task in any of these is still in the queue or
+# mid-flight, i.e. it contributes to "oldest pending" staleness.
+_PENDING_TASK_STATES = ("PENDING", "RECEIVED", "STARTED", "RETRY")
+
+# How far back the task-health window looks, so the COUNT stays bounded.
+_TASK_WINDOW = timedelta(hours=24)
+
+
+def _celery_results_in_db() -> bool:
+    """True only when Celery persists results to the DB (``django_celery_results``).
+
+    The default result backend is Redis, where the ``TaskResult`` table stays
+    empty — emitting task gauges then would be a *misleading constant zero*. So
+    MET-3 stays a documented no-op unless ``CELERY_RESULT_BACKEND`` is the
+    database backend; flipping it lights the gauges up automatically.
+    """
+    backend = str(getattr(settings, "CELERY_RESULT_BACKEND", "") or "")
+    return "django-db" in backend or "django_celery_results" in backend
+
+
+class TaskMetricsCollector:
+    """Scrape-time Celery health derived from ``django_celery_results.TaskResult`` (MET-3).
+
+    Celery runs as a **separate worker process**, so in-worker counters can't be
+    scraped from the web process without a pushgateway/second exporter (out of
+    scope per the operability bar). Instead we read task health on-scrape from the
+    already-installed ``TaskResult`` table — but only when results are actually
+    persisted there (see ``_celery_results_in_db``).
+
+    Gauges (windowed to the last 24h by ``date_created``):
+      * ``openshiksha_celery_tasks{status=...}`` — task counts by status,
+      * ``openshiksha_celery_oldest_pending_seconds`` — age of the oldest
+        non-terminal task (``0`` when none) — the async grade-queue-staleness analogue.
+    """
+
+    def collect(self):
+        if not _celery_results_in_db():
+            return
+        try:
+            yield from self._collect()
+        except Exception:  # pragma: no cover - defensive; never break a scrape
+            logger.warning("metrics: TaskMetricsCollector failed; skipping celery gauges", exc_info=True)
+
+    def _collect(self):
+        from django_celery_results.models import TaskResult
+
+        from django.db.models import Count
+        from django.utils import timezone
+
+        now = timezone.now()
+        since = now - _TASK_WINDOW
+
+        by_status = GaugeMetricFamily(
+            "openshiksha_celery_tasks",
+            "Celery task counts by status over the last 24h (requires the django-db result backend).",
+            labels=["status"],
+        )
+        for row in TaskResult.objects.filter(date_created__gte=since).values("status").annotate(n=Count("id")):
+            by_status.add_metric([row["status"] or "UNKNOWN"], row["n"])
+        yield by_status
+
+        oldest = (
+            TaskResult.objects.filter(date_created__gte=since, status__in=_PENDING_TASK_STATES)
+            .order_by("date_created")
+            .values_list("date_created", flat=True)
+            .first()
+        )
+        age = (now - oldest).total_seconds() if oldest else 0.0
+        yield GaugeMetricFamily(
+            "openshiksha_celery_oldest_pending_seconds",
+            "Age in seconds of the oldest non-terminal Celery task in the window (0 when none).",
+            value=age,
+        )
+
+
 # Lazy, idempotent registration of the on-scrape collectors. Guarded so we only
 # touch the registry on a real (enabled) scrape and never double-register.
 _collectors_registered = False
@@ -135,6 +211,7 @@ def _ensure_collectors():
     if _collectors_registered:
         return
     REGISTRY.register(BusinessMetricsCollector())
+    REGISTRY.register(TaskMetricsCollector())
     _collectors_registered = True
 
 

--- a/backend/openshiksha/apps/core/tests/test_metrics_tasks.py
+++ b/backend/openshiksha/apps/core/tests/test_metrics_tasks.py
@@ -1,0 +1,71 @@
+"""
+Tests for the Celery task-health gauges (MET-3).
+
+Derived on-scrape from ``django_celery_results.TaskResult``. Because the table is
+only meaningful when Celery persists results to the DB, the gauges are gated on
+the result backend — verified here both ways.
+"""
+
+from datetime import timedelta
+
+import pytest
+from django_celery_results.models import TaskResult
+
+from django.urls import reverse
+from django.utils import timezone
+
+
+@pytest.fixture
+def db_result_backend(db, settings):
+    settings.METRICS_ENABLED = True
+    settings.CELERY_RESULT_BACKEND = "django-db"
+    return settings
+
+
+def _seed_tasks():
+    now = timezone.now()
+    TaskResult.objects.create(task_id="ok-1", task_name="t.ok", status="SUCCESS", date_created=now, date_done=now)
+    TaskResult.objects.create(task_id="ok-2", task_name="t.ok", status="SUCCESS", date_created=now, date_done=now)
+    TaskResult.objects.create(task_id="bad-1", task_name="t.bad", status="FAILURE", date_created=now, date_done=now)
+    # A non-terminal task ~5 min old → drives oldest_pending_seconds > 0.
+    # date_created is auto_now_add, so backdate it via .update() (bypasses it).
+    pending = TaskResult.objects.create(task_id="pending-1", task_name="t.slow", status="STARTED")
+    TaskResult.objects.filter(pk=pending.pk).update(date_created=now - timedelta(minutes=5))
+
+
+def _scrape(client):
+    response = client.get(reverse("metrics"))
+    assert response.status_code == 200
+    return response.content.decode()
+
+
+class TestTaskGauges:
+    def test_counts_by_status(self, client, db_result_backend):
+        _seed_tasks()
+        body = _scrape(client)
+        assert 'openshiksha_celery_tasks{status="SUCCESS"} 2.0' in body
+        assert 'openshiksha_celery_tasks{status="FAILURE"} 1.0' in body
+
+    def test_oldest_pending_seconds_positive(self, client, db_result_backend):
+        _seed_tasks()
+        body = _scrape(client)
+        line = next(ln for ln in body.splitlines() if ln.startswith("openshiksha_celery_oldest_pending_seconds "))
+        value = float(line.split()[1])
+        # ~5 minutes old; allow generous slack for clock/window.
+        assert value >= 200.0
+
+    def test_oldest_pending_zero_when_none(self, client, db_result_backend):
+        now = timezone.now()
+        TaskResult.objects.create(task_id="ok", task_name="t.ok", status="SUCCESS", date_created=now, date_done=now)
+        body = _scrape(client)
+        assert "openshiksha_celery_oldest_pending_seconds 0.0" in body
+
+    def test_gauges_absent_with_redis_backend(self, client, db, settings):
+        # Default (redis) result backend ⇒ TaskResult is not authoritative ⇒ no
+        # task gauges, even if rows happen to exist (honest no-op, not a false 0).
+        settings.METRICS_ENABLED = True
+        settings.CELERY_RESULT_BACKEND = "redis://localhost:6379/2"
+        _seed_tasks()
+        body = _scrape(client)
+        assert "openshiksha_celery_tasks" not in body
+        assert "openshiksha_celery_oldest_pending_seconds" not in body

--- a/docs/changes/2026-06-27-met3-celery-task-gauges.md
+++ b/docs/changes/2026-06-27-met3-celery-task-gauges.md
@@ -1,0 +1,54 @@
+# MET-3 — Async-task health gauges from `TaskResult` (on-scrape)
+
+**Date:** 2026-06-27
+**Initiative:** [Production Observability & Operational Readiness](../initiatives/2026-production-observability.md) — Batch 2, increment 3 of 5
+**Plan:** [2026-06-27-plan.md](../daily-plans/2026-06-27-plan.md)
+**Classification:** New
+
+## Summary
+
+Adds a `TaskMetricsCollector` that derives Celery health on-scrape from the
+already-installed `django_celery_results.TaskResult` table. Celery runs as a
+**separate worker process**, so in-worker counters can't be scraped from the web
+process without a pushgateway/second exporter (out of scope per the operability
+bar) — reading the DB the workers already write to is the cheap, correct path.
+
+## Gauges (24h window by `date_created`)
+
+| Metric | Meaning |
+|--------|---------|
+| `openshiksha_celery_tasks{status=...}` | Task counts by status (SUCCESS/FAILURE/STARTED/…) |
+| `openshiksha_celery_oldest_pending_seconds` | Age of the oldest non-terminal task (`0` when none) — async grade-queue-staleness analogue |
+
+## Result-backend gate (honest no-op, not a false zero)
+
+The **default** `CELERY_RESULT_BACKEND` is **Redis**, where `TaskResult` stays
+empty — emitting task gauges then would be a *misleading constant zero*. So
+`_celery_results_in_db()` gates the whole collector: the gauges appear **only**
+when `CELERY_RESULT_BACKEND` is the database backend (`django-db`). Flipping the
+backend lights them up automatically; until then MET-3 is a documented no-op.
+(Operators who want these metrics set `CELERY_RESULT_BACKEND=django-db` — noted
+in the MET-5 runbook.)
+
+## Resilience
+
+Like MET-2, `collect()` is wrapped in `try/except` so a DB hiccup degrades to
+"no celery gauges this scrape" rather than 500-ing the endpoint.
+
+## Tests
+
+`backend/openshiksha/apps/core/tests/test_metrics_tasks.py` (4 tests): with the
+django-db backend, counts by status (SUCCESS=2, FAILURE=1) and a positive
+oldest-pending age (a backdated STARTED row, set via `.update()` since
+`date_created` is `auto_now_add`); oldest-pending reads `0` when none pending;
+and with the default Redis backend the gauges are **absent** even if rows exist
+(the honesty guard).
+
+## Migration notes
+
+None — `django_celery_results` is already installed and migrated.
+
+## Next steps
+
+- **MET-4** — gated HTTP request count + latency histogram middleware.
+- **MET-5** — Grafana starter dashboard + scrape runbook + ledger.


### PR DESCRIPTION
## Production Observability — Batch 2 (Metrics & dashboards), increment 3 of 5

Adds async-task health to `/metrics`, derived **on-scrape** from `django_celery_results.TaskResult`.

**Classification:** New · **Plan:** MET-3 · stacked on [#468](https://github.com/openshiksha/openshiksha/pull/468) (MET-2) → [#467](https://github.com/openshiksha/openshiksha/pull/467) (MET-1)

> Stacked PR: review/merge MET-1 → MET-2 → MET-3 in order. The MET-3 diff is the `TaskMetricsCollector` + tests + change doc.

### Why DB, not in-worker
Celery runs as a **separate worker process**; in-worker counters can't be scraped from the web process without a pushgateway/2nd exporter (out of scope). So we read the table the workers already write.

### Gauges (24h window)
| Metric | Meaning |
|--------|---------|
| `openshiksha_celery_tasks{status}` | task counts by status |
| `openshiksha_celery_oldest_pending_seconds` | age of oldest non-terminal task (0 when none) |

### Honest no-op gate
Default `CELERY_RESULT_BACKEND` is **Redis** → `TaskResult` is empty → emitting would be a *misleading constant zero*. `_celery_results_in_db()` gates the collector so the gauges appear **only** under the `django-db` backend; flipping it lights them up automatically. (Runbook note lands in MET-5.)

### Tests
`test_metrics_tasks.py` (4): counts by status; positive oldest-pending age; zero when none pending; **absent** under the Redis backend (honesty guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)