### PR TITLE
feat(obs): MET-4 — gated HTTP request-metrics middleware

### DIFF
--- a/backend/openshiksha/apps/core/metrics.py
+++ b/backend/openshiksha/apps/core/metrics.py
@@ -22,12 +22,29 @@ import logging
 import os
 from datetime import timedelta
 
-from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, Gauge, generate_latest
+from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, Counter, Gauge, Histogram, generate_latest
 from prometheus_client.core import GaugeMetricFamily
 
 from django.conf import settings
 
 logger = logging.getLogger("apps")
+
+# HTTP request metrics (MET-4), recorded by ``MetricsMiddleware``. Module-level
+# singletons (defined once at import) so they're never recreated per request,
+# which would raise a "Duplicated timeseries" registry error. Labelled by method
+# and status class (2xx/3xx/4xx/5xx) only — never raw path — to avoid unbounded
+# cardinality from per-id URLs. The middleware only records when metrics are
+# enabled, so these stay sample-less (zero overhead) by default.
+http_requests_total = Counter(
+    "openshiksha_http_requests",
+    "HTTP requests handled, by method and status class.",
+    ["method", "status_class"],
+)
+http_request_duration_seconds = Histogram(
+    "openshiksha_http_request_duration_seconds",
+    "HTTP request latency in seconds, by method.",
+    ["method"],
+)
 
 # build_info: a value-1 gauge whose labels carry the live build identity — the
 # conventional Prometheus pattern for static metadata. Registered on the default

--- a/backend/openshiksha/apps/core/metrics.py
+++ b/backend/openshiksha/apps/core/metrics.py
@@ -20,6 +20,7 @@ sets ``METRICS_ENABLED=true`` and the endpoint is scraped.
 
 import logging
 import os
+from datetime import timedelta
 
 from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, Gauge, generate_latest
 from prometheus_client.core import GaugeMetricFamily
@@ -125,6 +126,81 @@ class BusinessMetricsCollector:
         )
 
 
+# Non-terminal Celery states — a task in any of these is still in the queue or
+# mid-flight, i.e. it contributes to "oldest pending" staleness.
+_PENDING_TASK_STATES = ("PENDING", "RECEIVED", "STARTED", "RETRY")
+
+# How far back the task-health window looks, so the COUNT stays bounded.
+_TASK_WINDOW = timedelta(hours=24)
+
+
+def _celery_results_in_db() -> bool:
+    """True only when Celery persists results to the DB (``django_celery_results``).
+
+    The default result backend is Redis, where the ``TaskResult`` table stays
+    empty — emitting task gauges then would be a *misleading constant zero*. So
+    MET-3 stays a documented no-op unless ``CELERY_RESULT_BACKEND`` is the
+    database backend; flipping it lights the gauges up automatically.
+    """
+    backend = str(getattr(settings, "CELERY_RESULT_BACKEND", "") or "")
+    return "django-db" in backend or "django_celery_results" in backend
+
+
+class TaskMetricsCollector:
+    """Scrape-time Celery health derived from ``django_celery_results.TaskResult`` (MET-3).
+
+    Celery runs as a **separate worker process**, so in-worker counters can't be
+    scraped from the web process without a pushgateway/second exporter (out of
+    scope per the operability bar). Instead we read task health on-scrape from the
+    already-installed ``TaskResult`` table — but only when results are actually
+    persisted there (see ``_celery_results_in_db``).
+
+    Gauges (windowed to the last 24h by ``date_created``):
+      * ``openshiksha_celery_tasks{status=...}`` — task counts by status,
+      * ``openshiksha_celery_oldest_pending_seconds`` — age of the oldest
+        non-terminal task (``0`` when none) — the async grade-queue-staleness analogue.
+    """
+
+    def collect(self):
+        if not _celery_results_in_db():
+            return
+        try:
+            yield from self._collect()
+        except Exception:  # pragma: no cover - defensive; never break a scrape
+            logger.warning("metrics: TaskMetricsCollector failed; skipping celery gauges", exc_info=True)
+
+    def _collect(self):
+        from django_celery_results.models import TaskResult
+
+        from django.db.models import Count
+        from django.utils import timezone
+
+        now = timezone.now()
+        since = now - _TASK_WINDOW
+
+        by_status = GaugeMetricFamily(
+            "openshiksha_celery_tasks",
+            "Celery task counts by status over the last 24h (requires the django-db result backend).",
+            labels=["status"],
+        )
+        for row in TaskResult.objects.filter(date_created__gte=since).values("status").annotate(n=Count("id")):
+            by_status.add_metric([row["status"] or "UNKNOWN"], row["n"])
+        yield by_status
+
+        oldest = (
+            TaskResult.objects.filter(date_created__gte=since, status__in=_PENDING_TASK_STATES)
+            .order_by("date_created")
+            .values_list("date_created", flat=True)
+            .first()
+        )
+        age = (now - oldest).total_seconds() if oldest else 0.0
+        yield GaugeMetricFamily(
+            "openshiksha_celery_oldest_pending_seconds",
+            "Age in seconds of the oldest non-terminal Celery task in the window (0 when none).",
+            value=age,
+        )
+
+
 # Lazy, idempotent registration of the on-scrape collectors. Guarded so we only
 # touch the registry on a real (enabled) scrape and never double-register.
 _collectors_registered = False
@@ -135,6 +211,7 @@ def _ensure_collectors():
     if _collectors_registered:
         return
     REGISTRY.register(BusinessMetricsCollector())
+    REGISTRY.register(TaskMetricsCollector())
     _collectors_registered = True
 
 

--- a/backend/openshiksha/apps/core/middleware.py
+++ b/backend/openshiksha/apps/core/middleware.py
@@ -8,6 +8,7 @@ When Sentry is active it also tags the current scope so an error and its log lin
 share the same id.
 """
 
+import time
 import uuid
 
 from openshiksha.apps.core.request_context import reset_request_id, set_request_id
@@ -49,3 +50,31 @@ class RequestIDMiddleware:
                 sentry_sdk.set_tag("request_id", request_id)
         except Exception:  # pragma: no cover - defensive; never break a request
             pass
+
+
+class MetricsMiddleware:
+    """Record HTTP request count + latency into Prometheus (MET-4), env-gated.
+
+    When ``METRICS_ENABLED`` is falsy this is a **pure pass-through** — no metric
+    object is touched, no measurable overhead — so default behaviour is unchanged.
+    Placed after ``RequestIDMiddleware`` so request-id context is already set.
+    Labels are method + status class only (no raw path) to bound cardinality.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        from openshiksha.apps.core import metrics
+
+        if not metrics.metrics_enabled():
+            return self.get_response(request)
+
+        start = time.perf_counter()
+        response = self.get_response(request)
+        elapsed = time.perf_counter() - start
+
+        status_class = f"{response.status_code // 100}xx"
+        metrics.http_requests_total.labels(request.method, status_class).inc()
+        metrics.http_request_duration_seconds.labels(request.method).observe(elapsed)
+        return response

--- a/backend/openshiksha/apps/core/tests/test_metrics_http.py
+++ b/backend/openshiksha/apps/core/tests/test_metrics_http.py
@@ -1,0 +1,70 @@
+"""
+Tests for the gated HTTP request-metrics middleware (MET-4).
+
+Verifies the gated-ON path (a request through the stack increments the counter and
+observes a latency sample) and the gated-OFF path (the middleware is a pure
+pass-through that touches no metric object).
+"""
+
+from prometheus_client import REGISTRY
+
+from django.urls import reverse
+
+from openshiksha.apps.core.middleware import MetricsMiddleware
+
+
+def _requests_total(method="GET", status_class="2xx"):
+    """Current counter value (or 0.0 if the series has no samples yet)."""
+    value = REGISTRY.get_sample_value(
+        "openshiksha_http_requests_total", {"method": method, "status_class": status_class}
+    )
+    return value or 0.0
+
+
+class TestMetricsMiddlewareEnabled:
+    def test_request_increments_counter_and_observes_latency(self, client, settings):
+        settings.METRICS_ENABLED = True
+        before = _requests_total()
+        # Drive one request through the full middleware stack.
+        assert client.get(reverse("healthz")).status_code == 200
+        after = _requests_total()
+        assert after == before + 1.0
+
+        # A latency sample was recorded for GET.
+        count = REGISTRY.get_sample_value("openshiksha_http_request_duration_seconds_count", {"method": "GET"})
+        assert count is not None and count >= 1.0
+
+    def test_metrics_endpoint_exposes_http_family(self, client, settings):
+        settings.METRICS_ENABLED = True
+        client.get(reverse("healthz"))
+        body = client.get(reverse("metrics")).content.decode()
+        assert "openshiksha_http_requests_total" in body
+        assert "openshiksha_http_request_duration_seconds_bucket" in body
+
+
+class TestMetricsMiddlewareDisabled:
+    def test_pure_passthrough_records_nothing(self, settings):
+        settings.METRICS_ENABLED = False
+        before = _requests_total(status_class="2xx")
+
+        calls = {"n": 0}
+
+        def get_response(request):
+            calls["n"] += 1
+            return _FakeResponse(200)
+
+        mw = MetricsMiddleware(get_response)
+
+        class _Req:
+            method = "GET"
+
+        result = mw(_Req())
+        assert calls["n"] == 1  # downstream was called (pass-through)
+        assert isinstance(result, _FakeResponse)
+        # No counter movement while disabled.
+        assert _requests_total(status_class="2xx") == before
+
+
+class _FakeResponse:
+    def __init__(self, status_code):
+        self.status_code = status_code

--- a/backend/openshiksha/apps/core/tests/test_metrics_tasks.py
+++ b/backend/openshiksha/apps/core/tests/test_metrics_tasks.py
@@ -1,0 +1,71 @@
+"""
+Tests for the Celery task-health gauges (MET-3).
+
+Derived on-scrape from ``django_celery_results.TaskResult``. Because the table is
+only meaningful when Celery persists results to the DB, the gauges are gated on
+the result backend — verified here both ways.
+"""
+
+from datetime import timedelta
+
+import pytest
+from django_celery_results.models import TaskResult
+
+from django.urls import reverse
+from django.utils import timezone
+
+
+@pytest.fixture
+def db_result_backend(db, settings):
+    settings.METRICS_ENABLED = True
+    settings.CELERY_RESULT_BACKEND = "django-db"
+    return settings
+
+
+def _seed_tasks():
+    now = timezone.now()
+    TaskResult.objects.create(task_id="ok-1", task_name="t.ok", status="SUCCESS", date_created=now, date_done=now)
+    TaskResult.objects.create(task_id="ok-2", task_name="t.ok", status="SUCCESS", date_created=now, date_done=now)
+    TaskResult.objects.create(task_id="bad-1", task_name="t.bad", status="FAILURE", date_created=now, date_done=now)
+    # A non-terminal task ~5 min old → drives oldest_pending_seconds > 0.
+    # date_created is auto_now_add, so backdate it via .update() (bypasses it).
+    pending = TaskResult.objects.create(task_id="pending-1", task_name="t.slow", status="STARTED")
+    TaskResult.objects.filter(pk=pending.pk).update(date_created=now - timedelta(minutes=5))
+
+
+def _scrape(client):
+    response = client.get(reverse("metrics"))
+    assert response.status_code == 200
+    return response.content.decode()
+
+
+class TestTaskGauges:
+    def test_counts_by_status(self, client, db_result_backend):
+        _seed_tasks()
+        body = _scrape(client)
+        assert 'openshiksha_celery_tasks{status="SUCCESS"} 2.0' in body
+        assert 'openshiksha_celery_tasks{status="FAILURE"} 1.0' in body
+
+    def test_oldest_pending_seconds_positive(self, client, db_result_backend):
+        _seed_tasks()
+        body = _scrape(client)
+        line = next(ln for ln in body.splitlines() if ln.startswith("openshiksha_celery_oldest_pending_seconds "))
+        value = float(line.split()[1])
+        # ~5 minutes old; allow generous slack for clock/window.
+        assert value >= 200.0
+
+    def test_oldest_pending_zero_when_none(self, client, db_result_backend):
+        now = timezone.now()
+        TaskResult.objects.create(task_id="ok", task_name="t.ok", status="SUCCESS", date_created=now, date_done=now)
+        body = _scrape(client)
+        assert "openshiksha_celery_oldest_pending_seconds 0.0" in body
+
+    def test_gauges_absent_with_redis_backend(self, client, db, settings):
+        # Default (redis) result backend ⇒ TaskResult is not authoritative ⇒ no
+        # task gauges, even if rows happen to exist (honest no-op, not a false 0).
+        settings.METRICS_ENABLED = True
+        settings.CELERY_RESULT_BACKEND = "redis://localhost:6379/2"
+        _seed_tasks()
+        body = _scrape(client)
+        assert "openshiksha_celery_tasks" not in body
+        assert "openshiksha_celery_oldest_pending_seconds" not in body

--- a/backend/openshiksha/settings/base.py
+++ b/backend/openshiksha/settings/base.py
@@ -70,6 +70,9 @@ MIDDLEWARE = [
     # Request-correlation id (OBS-4) — early so the id is available to every
     # downstream middleware/view/log record for the whole request lifecycle.
     "openshiksha.apps.core.middleware.RequestIDMiddleware",
+    # HTTP request count + latency metrics (MET-4) — pure pass-through unless
+    # METRICS_ENABLED; after RequestIDMiddleware so the request id is already set.
+    "openshiksha.apps.core.middleware.MetricsMiddleware",
     "corsheaders.middleware.CorsMiddleware",  # CORS - must be before CommonMiddleware
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",

--- a/docs/changes/2026-06-27-met3-celery-task-gauges.md
+++ b/docs/changes/2026-06-27-met3-celery-task-gauges.md
@@ -1,0 +1,54 @@
+# MET-3 — Async-task health gauges from `TaskResult` (on-scrape)
+
+**Date:** 2026-06-27
+**Initiative:** [Production Observability & Operational Readiness](../initiatives/2026-production-observability.md) — Batch 2, increment 3 of 5
+**Plan:** [2026-06-27-plan.md](../daily-plans/2026-06-27-plan.md)
+**Classification:** New
+
+## Summary
+
+Adds a `TaskMetricsCollector` that derives Celery health on-scrape from the
+already-installed `django_celery_results.TaskResult` table. Celery runs as a
+**separate worker process**, so in-worker counters can't be scraped from the web
+process without a pushgateway/second exporter (out of scope per the operability
+bar) — reading the DB the workers already write to is the cheap, correct path.
+
+## Gauges (24h window by `date_created`)
+
+| Metric | Meaning |
+|--------|---------|
+| `openshiksha_celery_tasks{status=...}` | Task counts by status (SUCCESS/FAILURE/STARTED/…) |
+| `openshiksha_celery_oldest_pending_seconds` | Age of the oldest non-terminal task (`0` when none) — async grade-queue-staleness analogue |
+
+## Result-backend gate (honest no-op, not a false zero)
+
+The **default** `CELERY_RESULT_BACKEND` is **Redis**, where `TaskResult` stays
+empty — emitting task gauges then would be a *misleading constant zero*. So
+`_celery_results_in_db()` gates the whole collector: the gauges appear **only**
+when `CELERY_RESULT_BACKEND` is the database backend (`django-db`). Flipping the
+backend lights them up automatically; until then MET-3 is a documented no-op.
+(Operators who want these metrics set `CELERY_RESULT_BACKEND=django-db` — noted
+in the MET-5 runbook.)
+
+## Resilience
+
+Like MET-2, `collect()` is wrapped in `try/except` so a DB hiccup degrades to
+"no celery gauges this scrape" rather than 500-ing the endpoint.
+
+## Tests
+
+`backend/openshiksha/apps/core/tests/test_metrics_tasks.py` (4 tests): with the
+django-db backend, counts by status (SUCCESS=2, FAILURE=1) and a positive
+oldest-pending age (a backdated STARTED row, set via `.update()` since
+`date_created` is `auto_now_add`); oldest-pending reads `0` when none pending;
+and with the default Redis backend the gauges are **absent** even if rows exist
+(the honesty guard).
+
+## Migration notes
+
+None — `django_celery_results` is already installed and migrated.
+
+## Next steps
+
+- **MET-4** — gated HTTP request count + latency histogram middleware.
+- **MET-5** — Grafana starter dashboard + scrape runbook + ledger.

--- a/docs/changes/2026-06-27-met4-http-metrics.md
+++ b/docs/changes/2026-06-27-met4-http-metrics.md
@@ -1,0 +1,54 @@
+# MET-4 — Gated HTTP request-metrics middleware
+
+**Date:** 2026-06-27
+**Initiative:** [Production Observability & Operational Readiness](../initiatives/2026-production-observability.md) — Batch 2, increment 4 of 5
+**Plan:** [2026-06-27-plan.md](../daily-plans/2026-06-27-plan.md)
+**Classification:** New
+
+## Summary
+
+Adds `MetricsMiddleware`, which records HTTP request count + latency into
+Prometheus **only when `METRICS_ENABLED`**. When disabled it is a pure
+pass-through — no metric object is touched, no measurable overhead — so default
+behaviour is byte-for-byte today's. Placed in `MIDDLEWARE` immediately after
+`RequestIDMiddleware` so the request-id context is already set.
+
+## Metrics
+
+| Metric | Type | Labels | Meaning |
+|--------|------|--------|---------|
+| `openshiksha_http_requests_total` | Counter | `method`, `status_class` | Requests handled |
+| `openshiksha_http_request_duration_seconds` | Histogram | `method` | Request latency |
+
+`status_class` is `2xx/3xx/4xx/5xx` — **not** raw path — to avoid unbounded
+cardinality from per-id URLs. The Counter/Histogram are **module-level singletons**
+defined once at import (in `apps/core/metrics.py`) so they're never recreated per
+request (which would raise a "Duplicated timeseries" registry error).
+
+## Operability bar
+
+1. **Additive & env-gated** — pure pass-through when `METRICS_ENABLED` is off
+   (`test_pure_passthrough_records_nothing`).
+2. **Probe-safe** — no probe paths touched.
+3. **No secrets** — only method + status class + timing, never path/body/PII.
+4. **No perf/offline regression** — backend-only; disabled path does one boolean
+   check per request.
+5. **Tested both ways** — enabled (counter increments + latency observed +
+   exposed on `/metrics`) and disabled (no counter movement).
+
+## Tests
+
+`backend/openshiksha/apps/core/tests/test_metrics_http.py` (3 tests): a request
+through the stack increments `openshiksha_http_requests_total` and observes a
+duration sample; the families appear in the `/metrics` exposition; and with
+metrics disabled the middleware calls downstream but records nothing.
+
+## Migration notes
+
+None — no model changes. `MetricsMiddleware` is added to `MIDDLEWARE` but is inert
+unless `METRICS_ENABLED=true`.
+
+## Next steps
+
+- **MET-5** — Grafana starter dashboard + scrape runbook + STATUS/ledger update
+  (marks Batch 2 shipped).


### PR DESCRIPTION
## Production Observability — Batch 2 (Metrics & dashboards), increment 4 of 5

Adds `MetricsMiddleware` recording HTTP request count + latency into Prometheus, **env-gated**.

**Classification:** New · **Plan:** MET-4 · stacked on [#470](https://github.com/openshiksha/openshiksha/pull/470) (MET-3)

> Stacked PR — merge MET-3 (#470) first; then this rebases onto qa to a single commit.

### Metrics
| Metric | Type | Labels |
|--------|------|--------|
| `openshiksha_http_requests_total` | Counter | `method`, `status_class` |
| `openshiksha_http_request_duration_seconds` | Histogram | `method` |

`status_class` = `2xx/3xx/4xx/5xx` (never raw path) to bound cardinality. Counter/Histogram are module-level singletons (no per-request recreation → no duplicate-timeseries errors).

### Gating
Records **only when `METRICS_ENABLED`**; otherwise a pure pass-through (one boolean check, no metric object touched). Placed after `RequestIDMiddleware`.

### Tests
`test_metrics_http.py` (3): request increments the counter + observes latency; families exposed on `/metrics`; disabled → downstream called but nothing recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)