### PR TITLE
feat(ops): BAK-1 — Postgres backup/restore scripts + version-matched dump image

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts and Dockerfiles must keep LF endings — a CRLF in a `#!/usr/bin/env
+# bash` shebang breaks execution inside Linux containers (BAK-1 backup image).
+*.sh           text eol=lf
+Dockerfile*    text eol=lf

--- a/backend/Dockerfile.backup
+++ b/backend/Dockerfile.backup
@@ -1,0 +1,35 @@
+# OpenShiksha Postgres backup image (Production Observability Batch 3, BAK-1).
+#
+# Based on postgres:15-alpine so `pg_dump`/`pg_restore`/`psql` match the EXACT
+# major version of the prod server (a pg_dump OLDER than the server refuses to
+# run — a generic awscli image would not give us a version-matched dump tool).
+#
+# Adds the static `mc` (MinIO client) binary for S3-compatible upload — one
+# static binary, far lighter than installing aws-cli into alpine.
+#
+# Build context is the REPO ROOT (so scripts/backup/* is in scope):
+#   docker build -f backend/Dockerfile.backup -t openshiksha-backup .
+#
+# Default entrypoint runs a backup; the restore script is also present and is
+# invoked explicitly (e.g. by a one-off restore Job — see docs/ops/backups.md).
+FROM postgres:15-alpine
+
+# bash for the scripts (alpine ships ash by default); ca-certificates for TLS to
+# the S3 endpoint; curl to fetch mc at build time.
+RUN apk add --no-cache bash ca-certificates curl
+
+# Pinned mc release for reproducible builds (a moving "latest" would make the
+# image non-deterministic). Verify the binary runs before baking it in.
+ARG MC_VERSION=RELEASE.2025-04-08T15-39-49Z
+RUN curl -fsSL "https://dl.min.io/client/mc/release/linux-amd64/archive/mc.${MC_VERSION}" \
+        -o /usr/local/bin/mc \
+    && chmod +x /usr/local/bin/mc \
+    && mc --version
+
+COPY scripts/backup/pg_backup.sh scripts/backup/pg_restore.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/pg_backup.sh /usr/local/bin/pg_restore.sh
+
+# Run as the unprivileged postgres user the base image already provides.
+USER postgres
+
+ENTRYPOINT ["/usr/local/bin/pg_backup.sh"]

--- a/docs/changes/2026-06-27-bak-1-backup-scripts.md
+++ b/docs/changes/2026-06-27-bak-1-backup-scripts.md
@@ -1,0 +1,80 @@
+# BAK-1 — Postgres backup/restore scripts + version-matched dump image
+
+**Date:** 2026-06-27
+**Classification:** New (Production Observability — Batch 3, Backups & DR drill)
+**Initiative:** [Production Observability & Operational Readiness](../initiatives/2026-production-observability.md)
+
+## Summary
+
+OpenShiksha runs live in production on a single `postgres:15-alpine` StatefulSet
+with **zero backups** — one bad migration or volume loss wipes every teacher's
+questions and every student's submission/proficiency history, unrecoverably. This
+PR lays the **foundation** for Batch 3: the dump/restore tooling and a
+version-matched container image. It touches nothing live (pure files); the
+nightly CronJob (BAK-3), local restore drill (BAK-2), and freshness metric
+(BAK-4) build on top of it.
+
+## What changed
+
+- **`scripts/backup/pg_backup.sh`** — `set -euo pipefail`. Custom-format
+  `pg_dump --no-owner --no-privileges` → `gzip -9` → timestamped
+  `openshiksha-YYYYmmddTHHMMSSZ.dump.gz`. Uploads via the MinIO client (`mc`) to
+  an S3-compatible bucket, then prunes objects older than `RETENTION_DAYS`
+  (default 14). **Local mode:** when `S3_ENDPOINT` is empty it keeps the dump on
+  disk and skips upload — this is the branch the BAK-2 drill exercises so the
+  *same* script is tested end-to-end without cloud creds. Secrets are never
+  echoed (pg_dump reads the connection URI / PG* env directly; `mc alias set`
+  reads creds from args into a private `MC_CONFIG_DIR`).
+- **`scripts/backup/pg_restore.sh`** — inverse path. Downloads a named or
+  `latest` object (or reads `LOCAL_FILE`), gunzips, and
+  `pg_restore --clean --if-exists --no-owner`. **Refuses to run without
+  `CONFIRM=1`** to guard against a fat-fingered prod restore.
+- **`backend/Dockerfile.backup`** — `FROM postgres:15-alpine` so `pg_dump`
+  matches the prod server's major version exactly (an older pg_dump refuses to
+  run against a newer server). Adds a **pinned** static `mc` binary (not aws-cli
+  — one static binary vs. a heavy install), copies both scripts, runs as the
+  unprivileged `postgres` user, default `ENTRYPOINT` = `pg_backup.sh`.
+- **`.gitattributes`** (new) — forces `*.sh` / `Dockerfile*` to LF so a CRLF
+  shebang from a Windows checkout can never break execution inside the container.
+
+## What changed from legacy and why
+
+Nothing to port — the Django 1.11 monolith (now under `legacy/`) had **no**
+backup story; data integrity relied on the host disk. This is greenfield ops. The
+improvement is an off-site, retained, **version-matched** dump on a schedule,
+plus (in BAK-2) a restore that has actually been run rather than a backup nobody
+has restored from.
+
+## Technical details
+
+- Custom format (`-Fc`) is selectively restorable and already compressed; the
+  extra `gzip -9` shrinks the transferred artefact and yields a single file.
+  `pipefail` ensures a `pg_dump` failure fails the pipe even though `gzip` is
+  last.
+- `latest` resolution sorts object names lexicographically — the
+  `openshiksha-YYYYmmddT…` timestamp sorts chronologically by construction.
+- `mc` version is pinned (`ARG MC_VERSION`) for reproducible image builds; the
+  build verifies `mc --version` before baking it in.
+
+## Tests / validation
+
+- `bash -n` syntax check clean on both scripts (shellcheck not installed in the
+  build env; the CI `k8s`/lint lanes are unaffected — these are new infra files).
+- `pg_backup.sh --help` prints usage; `pg_restore.sh` without `CONFIRM=1` fails
+  closed with a clear error and non-zero exit.
+- Image build (`docker build -f backend/Dockerfile.backup .`) is exercised by CI
+  once the publish matrix entry lands in BAK-3.
+
+## Migration notes
+
+None — no Django models or migrations in this PR.
+
+## Next steps
+
+- **BAK-2** — `scripts/backup/drill.sh`: local seed → backup (local mode) → drop
+  → restore → assert row-count parity (the "tested restore runbook" DoD clause).
+- **BAK-3** — prod-overlay-only `CronJob` + CI publish of this image + `S3_*`
+  secret keys documented.
+- **BAK-4** — `BackupRun` model + `openshiksha_backup_age_seconds` freshness
+  gauge on the MET-2 collector.
+- **BAK-5** — `docs/ops/backups.md` runbook + ledger.

--- a/scripts/backup/pg_backup.sh
+++ b/scripts/backup/pg_backup.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# pg_backup.sh — version-matched Postgres backup for OpenShiksha.
+#
+# Dumps the database with a custom-format `pg_dump`, gzips it to a timestamped
+# file, and (unless running in local mode) uploads it to an S3-compatible bucket
+# via the MinIO client (`mc`), then prunes objects older than RETENTION_DAYS.
+#
+# This is part of Production Observability Batch 3 (BAK-1). It is invoked by the
+# nightly prod CronJob (BAK-3) and exercised end-to-end by the local restore
+# drill (BAK-2, scripts/backup/drill.sh).
+#
+# Configuration (all via environment — secrets are NEVER echoed):
+#   DATABASE_URL    postgres://user:pwd@host:port/db   (preferred), OR the
+#                   discrete PG* vars below.
+#   PGHOST PGPORT PGUSER PGPASSWORD PGDATABASE          (used if DATABASE_URL unset)
+#   S3_ENDPOINT     S3-compatible endpoint, e.g. https://blr1.digitaloceanspaces.com
+#                   *** Empty/unset ⇒ LOCAL MODE: keep the dump on disk, skip
+#                       upload + prune. Used by the drill. ***
+#   S3_BUCKET       target bucket name
+#   S3_PREFIX       key prefix (default: postgres/)
+#   S3_ACCESS_KEY   S3 access key id
+#   S3_SECRET_KEY   S3 secret access key
+#   RETENTION_DAYS  prune objects older than this many days (default: 14)
+#   BACKUP_DIR      where to write the local dump (default: a mktemp dir)
+#
+# Output: prints the dump filename and (in S3 mode) the uploaded object key.
+# Exits non-zero on any failure so the CronJob surfaces it.
+#
+# Legacy reference: none — the Django 1.11 monolith had no backup story.
+
+set -euo pipefail
+
+log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"; }
+die() { log "ERROR: $*" >&2; exit 1; }
+
+usage() {
+    sed -n '2,40p' "$0" | sed 's/^#//; s/^ //'
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+S3_PREFIX="${S3_PREFIX:-postgres/}"
+RETENTION_DAYS="${RETENTION_DAYS:-14}"
+S3_ENDPOINT="${S3_ENDPOINT:-}"
+
+# --- Resolve DB connection -------------------------------------------------
+# pg_dump reads PG* env vars natively; if DATABASE_URL is given, pg_dump accepts
+# a connection URI as a positional argument, so we never have to parse it
+# ourselves (and never echo it).
+PG_TARGET=()
+if [[ -n "${DATABASE_URL:-}" ]]; then
+    PG_TARGET=(--dbname "$DATABASE_URL")
+else
+    [[ -n "${PGDATABASE:-}" ]] || die "Set DATABASE_URL or PGDATABASE (and PGHOST/PGUSER/PGPASSWORD)."
+fi
+
+# --- Produce the dump ------------------------------------------------------
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+BACKUP_DIR="${BACKUP_DIR:-$(mktemp -d)}"
+mkdir -p "$BACKUP_DIR"
+DUMP_FILE="$BACKUP_DIR/openshiksha-${TS}.dump.gz"
+
+log "Dumping database → ${DUMP_FILE}"
+# custom format is compressed + selectively restorable; --no-owner/--no-privileges
+# keep the dump portable across roles. Pipe through gzip for an extra ~size win
+# and a single transferable artefact. set -o pipefail catches a pg_dump failure
+# even though gzip is last in the pipe.
+pg_dump --format=custom --no-owner --no-privileges "${PG_TARGET[@]}" | gzip -9 > "$DUMP_FILE"
+
+SIZE_BYTES="$(wc -c < "$DUMP_FILE" | tr -d ' ')"
+[[ "$SIZE_BYTES" -gt 0 ]] || die "Dump is empty — refusing to upload."
+log "Dump complete: ${SIZE_BYTES} bytes"
+
+# --- Local mode: stop here -------------------------------------------------
+if [[ -z "$S3_ENDPOINT" ]]; then
+    log "S3_ENDPOINT unset → LOCAL MODE: dump kept at ${DUMP_FILE} (no upload)."
+    echo "$DUMP_FILE"
+    exit 0
+fi
+
+# --- S3 upload + prune -----------------------------------------------------
+: "${S3_BUCKET:?Set S3_BUCKET for upload}"
+: "${S3_ACCESS_KEY:?Set S3_ACCESS_KEY for upload}"
+: "${S3_SECRET_KEY:?Set S3_SECRET_KEY for upload}"
+command -v mc >/dev/null 2>&1 || die "mc (MinIO client) not found on PATH."
+
+# mc alias set reads the creds from arguments; we pass them once and never echo.
+# Use a private config dir so we don't clobber a developer's ~/.mc.
+export MC_CONFIG_DIR="${MC_CONFIG_DIR:-$(mktemp -d)}"
+mc alias set osbackup "$S3_ENDPOINT" "$S3_ACCESS_KEY" "$S3_SECRET_KEY" >/dev/null
+
+OBJECT_KEY="${S3_PREFIX}$(basename "$DUMP_FILE")"
+log "Uploading → s3://${S3_BUCKET}/${OBJECT_KEY}"
+mc cp "$DUMP_FILE" "osbackup/${S3_BUCKET}/${OBJECT_KEY}"
+
+log "Pruning objects older than ${RETENTION_DAYS} days under ${S3_PREFIX}"
+# --force is required by mc rm to actually delete; --older-than takes a duration.
+mc rm --recursive --force --older-than "${RETENTION_DAYS}d" \
+    "osbackup/${S3_BUCKET}/${S3_PREFIX}" 2>/dev/null || \
+    log "WARN: prune step reported a non-fatal error (continuing)."
+
+log "Backup OK: ${OBJECT_KEY} (${SIZE_BYTES} bytes)"
+echo "$OBJECT_KEY"

--- a/scripts/backup/pg_restore.sh
+++ b/scripts/backup/pg_restore.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# pg_restore.sh — restore an OpenShiksha Postgres backup produced by pg_backup.sh.
+#
+# Downloads a named (or `latest`) dump from the S3-compatible bucket — or reads a
+# local file in LOCAL MODE — gunzips it, and restores into the target database
+# with `pg_restore --clean --if-exists`.
+#
+# *** DESTRUCTIVE: this DROPS and recreates the target schema. It refuses to run
+#     without CONFIRM=1 to guard against a fat-fingered prod restore. ***
+#
+# Part of Production Observability Batch 3 (BAK-1). The local restore drill
+# (BAK-2) calls this in LOCAL MODE; the prod runbook (BAK-5) calls it via a
+# one-off kubectl Job.
+#
+# Configuration (environment):
+#   CONFIRM=1       REQUIRED — acknowledges the destructive restore.
+#   TARGET_DB       postgres URI or dbname to restore INTO (preferred), OR PG* vars.
+#   PGHOST PGPORT PGUSER PGPASSWORD PGDATABASE   (used if TARGET_DB unset)
+#   LOCAL_FILE      path to a local *.dump.gz — sets LOCAL MODE, skips S3.
+#   S3_ENDPOINT S3_BUCKET S3_PREFIX S3_ACCESS_KEY S3_SECRET_KEY   (S3 mode)
+#   OBJECT         object key under S3_PREFIX, or "latest" (default: latest).
+#
+# Legacy reference: none — greenfield ops.
+
+set -euo pipefail
+
+log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"; }
+die() { log "ERROR: $*" >&2; exit 1; }
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    sed -n '2,30p' "$0" | sed 's/^#//; s/^ //'
+    exit 0
+fi
+
+[[ "${CONFIRM:-}" == "1" ]] || die "Refusing to restore without CONFIRM=1 (this DROPS data)."
+
+S3_PREFIX="${S3_PREFIX:-postgres/}"
+OBJECT="${OBJECT:-latest}"
+
+# --- Resolve restore target ------------------------------------------------
+PG_TARGET=()
+if [[ -n "${TARGET_DB:-}" ]]; then
+    PG_TARGET=(--dbname "$TARGET_DB")
+else
+    [[ -n "${PGDATABASE:-}" ]] || die "Set TARGET_DB or PGDATABASE (and PGHOST/PGUSER/PGPASSWORD)."
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# --- Obtain the dump -------------------------------------------------------
+if [[ -n "${LOCAL_FILE:-}" ]]; then
+    [[ -f "$LOCAL_FILE" ]] || die "LOCAL_FILE not found: ${LOCAL_FILE}"
+    GZ="$LOCAL_FILE"
+    log "LOCAL MODE: restoring from ${GZ}"
+else
+    : "${S3_ENDPOINT:?Set S3_ENDPOINT (or LOCAL_FILE for local restore)}"
+    : "${S3_BUCKET:?Set S3_BUCKET}"
+    : "${S3_ACCESS_KEY:?Set S3_ACCESS_KEY}"
+    : "${S3_SECRET_KEY:?Set S3_SECRET_KEY}"
+    command -v mc >/dev/null 2>&1 || die "mc (MinIO client) not found on PATH."
+
+    export MC_CONFIG_DIR="${MC_CONFIG_DIR:-$(mktemp -d)}"
+    mc alias set osbackup "$S3_ENDPOINT" "$S3_ACCESS_KEY" "$S3_SECRET_KEY" >/dev/null
+
+    if [[ "$OBJECT" == "latest" ]]; then
+        # Newest object under the prefix by lexicographic name (timestamps sort
+        # chronologically by construction: openshiksha-YYYYmmddT...).
+        OBJECT="$(mc ls "osbackup/${S3_BUCKET}/${S3_PREFIX}" | awk '{print $NF}' | sort | tail -1)"
+        [[ -n "$OBJECT" ]] || die "No backups found under ${S3_PREFIX}"
+        log "Resolved latest backup: ${OBJECT}"
+    fi
+    GZ="${WORK_DIR}/$(basename "$OBJECT")"
+    log "Downloading s3://${S3_BUCKET}/${S3_PREFIX}${OBJECT}"
+    mc cp "osbackup/${S3_BUCKET}/${S3_PREFIX}${OBJECT}" "$GZ"
+fi
+
+# --- Restore ---------------------------------------------------------------
+DUMP="${WORK_DIR}/restore.dump"
+log "Decompressing dump"
+gunzip -c "$GZ" > "$DUMP"
+
+log "Restoring (pg_restore --clean --if-exists)"
+# --clean --if-exists drops existing objects first so a restore over a populated
+# DB is idempotent; --no-owner matches the dump flags. A non-zero pg_restore exit
+# on benign "does not exist" notices is suppressed by --if-exists.
+pg_restore --clean --if-exists --no-owner "${PG_TARGET[@]}" "$DUMP"
+
+log "Restore complete."


### PR DESCRIPTION
## Classification
**New** — Production Observability **Batch 3 (Backups & DR drill)**, item **BAK-1** (foundation). Per [docs/daily-plans/2026-06-27-plan-2.md](docs/daily-plans/2026-06-27-plan-2.md).

## Why
OpenShiksha is live in prod on a single `postgres:15-alpine` StatefulSet with **zero backups** — one bad migration / volume loss = every question, submission and proficiency record gone, unrecoverably. This PR is the foundation: dump/restore tooling + a version-matched image. **Touches nothing live** (pure files).

## What
- `scripts/backup/pg_backup.sh` — custom-format `pg_dump | gzip` → S3-compatible upload via `mc` + retention prune (`RETENTION_DAYS`, default 14). **Local mode** (`S3_ENDPOINT` empty) keeps the dump on disk so the BAK-2 drill exercises the *same* script without cloud creds. Secrets never echoed.
- `scripts/backup/pg_restore.sh` — download latest/named (or `LOCAL_FILE`) → `pg_restore --clean --if-exists`; **refuses without `CONFIRM=1`**.
- `backend/Dockerfile.backup` — `FROM postgres:15-alpine` (version-matched `pg_dump`) + pinned static `mc`; runs as unprivileged `postgres`.
- `.gitattributes` — force `*.sh`/`Dockerfile*` to LF (CRLF shebang would break the container).

## Legacy reference
None — the Django 1.11 monolith had no backup story. Greenfield ops.

## Tests / verify
- `bash -n` syntax clean on both scripts.
- `pg_backup.sh --help` prints usage; `pg_restore.sh` without `CONFIRM=1` fails closed (non-zero exit, clear error).
- Image build is exercised by CI once the publish matrix entry lands (BAK-3).

## Notes
Additive only — no live infra, no Django models. BAK-2 (drill), BAK-3 (CronJob + CI publish), BAK-4 (freshness gauge), BAK-5 (runbook) build on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)