### PR TITLE
feat(ops): BAK-3 — prod backup CronJob + CI image publish + S3 secret keys

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -439,6 +439,12 @@ jobs:
                     - service: frontend
                       context: ./frontend_modern
                       dockerfile: ./frontend_modern/Dockerfile.prod
+                    # BAK-3: version-matched Postgres backup image. Build context
+                    # is the repo root so scripts/backup/* is in scope. Ignores
+                    # the GIT_SHA/VITE_* build-args harmlessly (it declares none).
+                    - service: backup
+                      context: .
+                      dockerfile: ./backend/Dockerfile.backup
         steps:
             - name: Check out the repo
               uses: actions/checkout@v7

--- a/docs/changes/2026-06-27-bak-3-backup-cronjob.md
+++ b/docs/changes/2026-06-27-bak-3-backup-cronjob.md
@@ -1,0 +1,63 @@
+# BAK-3 — Prod backup CronJob + CI image publish + S3 secret keys
+
+**Date:** 2026-06-27
+**Classification:** New (Production Observability — Batch 3, Backups & DR drill)
+**Depends on:** [BAK-1](2026-06-27-bak-1-backup-scripts.md) (the published image).
+
+## Summary
+
+Schedules the BAK-1 backup image to run nightly in **prod only**, publishes that
+image from CI, and documents the new S3 secret keys. Additive: qa/dev kustomize
+builds are byte-for-byte unchanged and need no S3 creds.
+
+## What changed
+
+- **`k8s/overlays/prod/backup-cronjob.yaml`** (new) — a `batch/v1 CronJob`
+  (`schedule: "0 2 * * *"`, `concurrencyPolicy: Forbid`,
+  `successful/failedJobsHistoryLimit: 3`, `backoffLimit: 2`,
+  `restartPolicy: OnFailure`, small resource requests/limits) running
+  `ghcr.io/openshiksha/openshiksha-backup:prod`. Env: existing `DATABASE_URL` +
+  new `S3_ENDPOINT/S3_BUCKET/S3_ACCESS_KEY/S3_SECRET_KEY` + `RETENTION_DAYS`,
+  all from the existing `openshiksha-secrets` Secret.
+  - **Placed in the prod overlay, not `base/`** — kustomize's security boundary
+    forbids an overlay referencing a file outside its own dir, and prod-only
+    placement is exactly the intent (qa/dev never run it). Wired into
+    `k8s/overlays/prod/kustomization.yaml` `resources:` + an `images:` retag
+    entry so the bare image name picks up the `:prod` tag like backend/frontend.
+- **`k8s/base/secret.example.yaml`** — documents the four `S3_*` keys (kubectl
+  command + empty `stringData` stubs + comments: DO Spaces is the intended
+  target; server-side only; qa/dev don't need them).
+- **`.github/workflows/ci-cd.yaml`** — adds a `backup` entry to the
+  `build-publish` matrix (context = repo root so `scripts/backup/*` is in scope,
+  `Dockerfile.backup`). Publishes `openshiksha-backup:{branch,sha}` alongside
+  backend/frontend on qa/prod pushes. `fail-fast: false` already isolates it.
+
+## Validation
+
+- `kubectl kustomize k8s/overlays/prod` renders cleanly; the CronJob appears with
+  `namespace: openshiksha-prod` and image `…/openshiksha-backup:prod`.
+- `kubectl kustomize k8s/overlays/qa` is **byte-for-byte unchanged** (sha256
+  compared before/after) — qa carries no backup CronJob.
+- The manifest uses only standard `batch/v1 CronJob` fields, so the CI
+  `kubeconform -strict` gate (#459) passes. (kubeconform's Linux binary isn't
+  runnable on the Windows build host; the clean render + standard schema cover
+  it, and CI is the authoritative gate.)
+
+## What could go wrong (mitigations)
+
+- Schema typo breaking the kubeconform gate → only standard fields used; rendered
+  locally first.
+- CronJob erroring on schedule in qa with no creds → avoided by prod-overlay-only
+  inclusion.
+- No secret baked into the manifest — all values come from `openshiksha-secrets`.
+
+## Migration notes
+
+None — infra/CI only.
+
+## Next steps
+
+- BAK-4 — `BackupRun` model + `openshiksha_backup_age_seconds` freshness gauge,
+  written by the CronJob on success (a follow-up wires `record_backup_run` into
+  the backup script/Job).
+- BAK-5 — `docs/ops/backups.md` runbook + ledger.

--- a/k8s/base/secret.example.yaml
+++ b/k8s/base/secret.example.yaml
@@ -13,7 +13,16 @@
 #     --from-literal=ANTHROPIC_API_KEY='sk-ant-...' \
 #     --from-literal=EMAIL_HOST_USER='...' \
 #     --from-literal=EMAIL_HOST_PASSWORD='...' \
-#     --from-literal=SENTRY_DSN='https://...@oNNN.ingest.sentry.io/NNN'
+#     --from-literal=SENTRY_DSN='https://...@oNNN.ingest.sentry.io/NNN' \
+#     --from-literal=S3_ENDPOINT='https://blr1.digitaloceanspaces.com' \
+#     --from-literal=S3_BUCKET='openshiksha-backups' \
+#     --from-literal=S3_ACCESS_KEY='...' \
+#     --from-literal=S3_SECRET_KEY='...'
+#
+# S3_* (BAK-3) are consumed ONLY by the prod-overlay backup CronJob (nightly
+# pg_dump -> S3-compatible upload). DigitalOcean Spaces is the intended target.
+# Server-side only — never commit real values. qa/dev don't run the CronJob, so
+# they don't need these keys.
 #
 # SENTRY_DSN (OBS-3) is OPTIONAL — leave it empty/unset to keep backend error
 # tracking disabled (init_sentry() no-ops). Prefer a SEPARATE Sentry project from
@@ -42,3 +51,9 @@ stringData:
   # Optional — empty disables backend error tracking (OBS-3). Use a separate
   # Sentry project from the frontend. Server-side only; never commit a real value.
   SENTRY_DSN: ""
+  # S3-compatible backup target (BAK-3) — consumed only by the prod backup
+  # CronJob. Empty here; populate out-of-band in prod. Never commit real values.
+  S3_ENDPOINT: ""
+  S3_BUCKET: ""
+  S3_ACCESS_KEY: ""
+  S3_SECRET_KEY: ""

--- a/k8s/overlays/prod/backup-cronjob.yaml
+++ b/k8s/overlays/prod/backup-cronjob.yaml
@@ -1,0 +1,68 @@
+# Nightly Postgres backup (Production Observability Batch 3, BAK-3).
+#
+# Runs the BAK-1 backup image (pg_dump | gzip -> S3-compatible upload via mc +
+# retention prune). This file lives in the PROD overlay (not base), so qa/dev
+# kustomize builds are byte-for-byte unchanged and no backup runs (or needs S3
+# creds) there.
+#
+# The four S3_* keys are documented in k8s/base/secret.example.yaml and populated
+# out-of-band into the openshiksha-secrets Secret (DigitalOcean Spaces is the
+# intended S3-compatible target). DATABASE_URL is the existing key.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: postgres-backup
+  labels:
+    app: postgres-backup
+spec:
+  schedule: "0 2 * * *" # 02:00 UTC nightly
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app: postgres-backup
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: backup
+              image: ghcr.io/openshiksha/openshiksha-backup:prod
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: openshiksha-secrets
+                      key: DATABASE_URL
+                - name: S3_ENDPOINT
+                  valueFrom:
+                    secretKeyRef:
+                      name: openshiksha-secrets
+                      key: S3_ENDPOINT
+                - name: S3_BUCKET
+                  valueFrom:
+                    secretKeyRef:
+                      name: openshiksha-secrets
+                      key: S3_BUCKET
+                - name: S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: openshiksha-secrets
+                      key: S3_ACCESS_KEY
+                - name: S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: openshiksha-secrets
+                      key: S3_SECRET_KEY
+                - name: RETENTION_DAYS
+                  value: "14"
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 500m
+                  memory: 256Mi

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -5,11 +5,16 @@ namespace: openshiksha-prod
 
 resources:
   - ../../base
+  # Prod-only: nightly Postgres backup (BAK-3). Lives in the overlay (not base) so
+  # qa/dev never run it and never need S3 creds.
+  - backup-cronjob.yaml
 
 images:
   - name: ghcr.io/openshiksha/openshiksha-backend
     newTag: prod
   - name: ghcr.io/openshiksha/openshiksha-frontend
+    newTag: prod
+  - name: ghcr.io/openshiksha/openshiksha-backup
     newTag: prod
 
 patches:


### PR DESCRIPTION
## Classification
**New** — Production Observability **Batch 3**, item **BAK-3**. Independent of BAK-2; uses the BAK-1 image. Targets `qa`.

## What
- **`k8s/overlays/prod/backup-cronjob.yaml`** — nightly (`0 2 * * *`) `batch/v1 CronJob` running `ghcr.io/openshiksha/openshiksha-backup:prod`: `Forbid` concurrency, history limits 3/3, `backoffLimit: 2`, `OnFailure`, small requests/limits. Env from `openshiksha-secrets` (`DATABASE_URL` + new `S3_*` + `RETENTION_DAYS`).
- **Prod-overlay-only** — placed in the overlay (kustomize forbids referencing files outside the overlay dir, and prod-only is the intent). Wired into the prod `kustomization.yaml` `resources:` + an `images:` retag entry.
- **`k8s/base/secret.example.yaml`** — documents the four `S3_*` keys (empty stubs; DO Spaces target; server-side only).
- **`.github/workflows/ci-cd.yaml`** — adds `backup` to the `build-publish` matrix (context = repo root, `Dockerfile.backup`) so the image publishes alongside backend/frontend. `fail-fast: false` isolates it.

## Verify
- `kubectl kustomize k8s/overlays/prod` → CronJob present, `namespace: openshiksha-prod`, image `…/openshiksha-backup:prod`.
- `kubectl kustomize k8s/overlays/qa` **byte-for-byte unchanged** (sha256 before/after).
- Only standard `CronJob` fields → passes the existing `kubeconform -strict` gate (#459). kubeconform's Linux binary isn't runnable on the Windows build host; CI is the authoritative gate.

## Legacy reference
None — greenfield ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)