### PR TITLE
test(ci): ratchet frontend coverage thresholds to measured (10→55)

### DIFF
--- a/docs/changes/2026-06-28-frontend-coverage-ratchet.md
+++ b/docs/changes/2026-06-28-frontend-coverage-ratchet.md
@@ -1,0 +1,38 @@
+# 2026-06-28 — Frontend coverage thresholds ratcheted to measured
+
+**Classification:** Test infrastructure (tightens an existing, stale gate — no
+product code touched).
+
+## Summary
+The Vitest coverage thresholds in `frontend_modern/vite.config.ts` were still set
+to the **10 / 10 / 6 / 8** floor baselined on 2026-06-01, when the suite had **38
+tests**. The suite has since grown to **566 tests across 83 files**, and real
+measured coverage is now **56.27 % lines / 55.40 % statements / 51.26 % functions
+/ 55.47 % branches** — roughly 5–6× the gate. The floor no longer protected
+against regression at all: a PR could delete the bulk of the frontend tests, or
+ship a large untested feature, and CI would stay green all the way down to 10 %.
+
+This raises the thresholds to sit ~1 point under the current measured coverage:
+
+| Metric     | Old | New | Measured |
+|------------|----:|----:|---------:|
+| Lines      | 10  | 55  | 56.27    |
+| Statements | 10  | 54  | 55.40    |
+| Functions  | 6   | 50  | 51.26    |
+| Branches   | 8   | 54  | 55.47    |
+
+## Why a ~1-point buffer (not the exact measured value)
+A small gap between the threshold and the measured value absorbs ordinary PR
+churn — e.g. a PR that adds a small untested utility shouldn't turn the coverage
+gate red on its own — while still failing fast on a real regression (deleted
+tests, large untested code). The thresholds remain a **ratchet**: raise them as
+new tests land, never lower without a recorded reason (the existing comment in
+`vite.config.ts` states this).
+
+## Verification
+`npx vitest run --coverage` — 566 tests pass, coverage summary unchanged
+(55.4 / 55.47 / 51.26 / 56.27), exit 0 with the new thresholds enforced.
+
+## Files changed
+- `frontend_modern/vite.config.ts` — `test.coverage.thresholds` raised from
+  10/10/6/8 to 55/54/50/54; comment updated with the new baseline and rationale.

--- a/frontend_modern/vite.config.ts
+++ b/frontend_modern/vite.config.ts
@@ -55,21 +55,28 @@ export default defineConfig(async ({ mode }) => ({
         'src/main.tsx',
         'src/vite-env.d.ts',
       ],
-      // Thresholds match the current measured floor. Ratchet these up as new
-      // tests land — never lower without a recorded reason.
+      // Thresholds sit a point or two below the current measured coverage so a
+      // real regression (deleting tests, shipping large untested code) fails CI
+      // while ordinary PR churn doesn't flake. Ratchet these up as new tests
+      // land — never lower without a recorded reason.
+      //
+      // 2026-06-28: re-baselined to the real measured coverage. The suite has
+      // grown from 38 → 566 tests across 83 files since the last baseline, so
+      // the old 10/10/6/8 floor no longer protected against regression at all
+      // (coverage could halve and still pass). Measured: 56.27% lines / 55.40%
+      // statements / 51.26% funcs / 55.47% branches; thresholds set ~1 pt under.
       //
       // 2026-06-01: re-baselined funcs 18→6 and branches 40→8 after upgrading
       // Vitest 1→4 (security audit fix). Vitest 4's v8 provider uses AST-aware
       // remapping, which counts branches/functions more accurately than v1 did;
-      // the same 38 tests now measure 6.98% funcs / 8.52% branches (was 18.64% /
-      // 45.77%). No tests were lost — only the measurement changed. Lines and
-      // statements are unaffected (10.43%).
+      // the same 38 tests then measured 6.98% funcs / 8.52% branches (was 18.64%
+      // / 45.77%). No tests were lost — only the measurement changed.
       // (2026-05-30 baseline under Vitest 1: 10.24% lines, 18.64% funcs, 45.77% branches.)
       thresholds: {
-        lines: 10,
-        statements: 10,
-        functions: 6,
-        branches: 8,
+        lines: 55,
+        statements: 54,
+        functions: 50,
+        branches: 54,
       },
     },
   },


### PR DESCRIPTION
## What

Raise the Vitest coverage gate in `frontend_modern/vite.config.ts` from the stale **10/10/6/8** floor to **55/54/50/54** — ~1 point under the real measured coverage.

## Why

The thresholds were last baselined on **2026-06-01** when the suite had **38 tests**. It has since grown to **566 tests across 83 files**, and real coverage is now:

| Metric     | Old gate | New gate | Measured |
|------------|---------:|---------:|---------:|
| Lines      | 10       | 55       | 56.27    |
| Statements | 10       | 54       | 55.40    |
| Functions  | 6        | 50       | 51.26    |
| Branches   | 8        | 54       | 55.47    |

At 10% the gate no longer protected against regression at all — a PR could delete the bulk of the frontend tests, or ship a large untested feature, and CI would stay green all the way down to 10%. The `--coverage` step already runs in the `frontend` CI job; this just makes it meaningful.

A ~1-point buffer below measured absorbs ordinary PR churn (a small untested utility won't redden the gate on its own) while still failing fast on a real regression. Thresholds remain a **ratchet** — raise as tests land, never lower without a recorded reason.

## Verification

`npx vitest run --coverage` locally — 566 tests pass, coverage summary unchanged (55.4 / 55.47 / 51.26 / 56.27), exit 0 under the new thresholds.

## Scope

Test-infra only; no product code touched. Details in `docs/changes/2026-06-28-frontend-coverage-ratchet.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)