### PR TITLE
feat(obs): ALT-2 — Alertmanager config + stdlib ntfy bridge

### DIFF
--- a/docs/changes/2026-06-28-alt-2-alertmanager-ntfy-bridge.md
+++ b/docs/changes/2026-06-28-alt-2-alertmanager-ntfy-bridge.md
@@ -1,0 +1,71 @@
+# ALT-2 — Alertmanager config + ntfy bridge
+
+**Date:** 2026-06-28
+**Initiative:** Production Observability & Operational Readiness — Batch 4 (Uptime & alerting)
+**Classification:** New
+
+## Summary
+
+Routes the ALT-1 alerts to a channel the team already uses (**ntfy**, already
+wired for build notifications) with two artifacts:
+
+- `docs/ops/alertmanager/alertmanager.yml` — a minimal Alertmanager config: a
+  `route` grouped by `alertname`/`severity` with conservative
+  `group_wait`/`repeat_interval`, to a single `webhook_configs` receiver pointed
+  at the bridge. A commented `email_configs` block shows the e-mail alternative.
+  No secrets in the file (the ntfy URL is injected via the bridge's env).
+- `scripts/ops/alert_to_ntfy.py` — a ~self-contained **stdlib** bridge
+  (`http.server` + `urllib.request`, **no new pip dependency**) that accepts an
+  Alertmanager webhook POST on `/alert` and POSTs a **single-line** message to
+  `ALERT_NTFY_URL` with `Title`/`Tags`/`Priority` headers derived from `severity`.
+
+## Why a bridge
+
+ntfy is not a native Alertmanager receiver — Alertmanager POSTs its own webhook
+JSON schema, ntfy wants a plain-text body + headers. The ~60-line bridge is the
+standard glue, and because the payload→`(title, body, headers)` mapping is
+factored into the pure `format_alert` / `format_payload` functions, it is
+trivially unit-testable. That is what makes this "tested config," not just YAML.
+
+## Mapping
+
+| severity | priority | tag |
+|---|---|---|
+| critical (firing) | high | rotating_light |
+| warning (firing) | default | warning |
+| info (firing) | low | information_source |
+| **any (resolved)** | min | white_check_mark |
+
+Resolved notifications are forced to `min` priority regardless of original
+severity — the bad thing stopped, so it must not page. Bodies are collapsed to a
+single line (the project notification convention).
+
+## Tests
+
+`scripts/ops/tests/test_alert_to_ntfy.py` (7 tests, **no network** — the HTTP POST
+is the only seam, the formatter is pure):
+
+- critical/firing → high + rotating_light + `[FIRING]` title
+- warning/firing → default + warning
+- resolved critical → min + white_check_mark + `[RESOLVED]` (does not page)
+- multi-line summary collapses to one line
+- summary → description → alertname body fallback chain
+- unknown severity defaults safely (default/bell)
+- multi-alert + empty payloads
+
+Result: **7 passed**. `python -m py_compile scripts/ops/alert_to_ntfy.py` clean.
+
+These run in CI via the ALT-4 `alerting-lint` job (the backend Test job only
+collects `backend/` tests); `amtool check-config` also runs there.
+
+## Security
+
+The ntfy URL is read from `ALERT_NTFY_URL` and **never** echoed to logs (a leaked
+topic URL is a write capability to the channel). The bridge stays a single stdlib
+file, documented as a sidecar/one-off — not a new always-on dependency.
+
+## Next steps
+
+- ALT-3 adds the standalone uptime probe (alerts with zero Prometheus stack).
+- ALT-4 adds `amtool check-config` + this pytest to CI.
+- ALT-5 documents the routing path in `docs/ops/alerting.md`.

--- a/docs/ops/alertmanager/alertmanager.yml
+++ b/docs/ops/alertmanager/alertmanager.yml
@@ -1,0 +1,52 @@
+# OpenShiksha Alertmanager configuration (Production Observability Batch 4, ALT-2).
+#
+# Routes the ALT-1 Prometheus alerts (docs/ops/prometheus/openshiksha-alerts.yml)
+# to a channel the team already uses — ntfy — via the small stdlib bridge
+# scripts/ops/alert_to_ntfy.py (ntfy is not a native Alertmanager receiver, so the
+# bridge translates Alertmanager's webhook JSON into a one-line ntfy push).
+#
+# Like the alert rules and the Grafana starter, this is a DROP-IN ARTIFACT: an
+# operator who stands up Alertmanager points it at this file. No Prometheus or
+# Alertmanager is deployed in k8s/ yet (see docs/ops/alerting.md). Validated in CI
+# by the ALT-4 `alerting-lint` job with `amtool check-config`.
+#
+# No secrets live here: the ntfy topic URL is injected into the bridge via its
+# ALERT_NTFY_URL env var, never written into this committed config.
+
+global:
+  # How long to wait before re-sending a still-firing alert that Alertmanager has
+  # already notified about. Conservative default; tune per the runbook.
+  resolve_timeout: 5m
+
+route:
+  # Group related alerts so a burst (e.g. several 5xx alerts) collapses into one
+  # notification stream rather than one push per series.
+  group_by: ["alertname", "severity"]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  receiver: ntfy-bridge
+
+receivers:
+  - name: ntfy-bridge
+    webhook_configs:
+      # The bridge listens on this in-cluster address (scripts/ops/alert_to_ntfy.py
+      # run as a sidecar / one-off Deployment). It reads the real ntfy topic from
+      # its ALERT_NTFY_URL env — keep the URL out of this file.
+      - url: http://alert-to-ntfy:9098/alert
+        send_resolved: true
+
+  # --- Alternative: e-mail instead of (or in addition to) ntfy --------------
+  # To route to e-mail, configure `global.smtp_*` and swap the receiver above
+  # (or add a second receiver + a `routes:` child match on severity). Example:
+  #
+  # global:
+  #   smtp_smarthost: "smtp.example.com:587"
+  #   smtp_from: "alerts@openshiksha.org"
+  #   smtp_auth_username: "alerts@openshiksha.org"
+  #   smtp_auth_password: "REPLACE-ME"   # inject via env / secret, never commit
+  # receivers:
+  #   - name: ops-email
+  #     email_configs:
+  #       - to: "ops@openshiksha.org"
+  #         send_resolved: true

--- a/scripts/ops/alert_to_ntfy.py
+++ b/scripts/ops/alert_to_ntfy.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Alertmanager → ntfy bridge (Production Observability Batch 4, ALT-2).
+
+ntfy is not a native Alertmanager receiver: Alertmanager POSTs its own webhook
+JSON schema, while ntfy wants a plain-text body plus ``Title``/``Tags``/
+``Priority`` headers. This ~self-contained stdlib script is the standard glue —
+it accepts an Alertmanager webhook POST on ``/alert`` and, for each alert in the
+payload, POSTs a **single-line** message to ``ALERT_NTFY_URL``.
+
+Deliberately dependency-light (``http.server`` + ``urllib.request`` only, **no new
+pip dependency**) so it can run as a tiny sidecar / one-off Deployment next to
+Alertmanager without dragging in a web framework. The Alertmanager config that
+targets it lives at ``docs/ops/alertmanager/alertmanager.yml``.
+
+Run::
+
+    ALERT_NTFY_URL="https://ntfy.sh/openshiksha-shara-alerts" \\
+        python3 scripts/ops/alert_to_ntfy.py            # listens on :9098
+
+The payload→message mapping is factored into the pure ``format_alert`` /
+``format_payload`` functions (no I/O), which is what makes this unit-testable —
+see ``scripts/ops/tests/test_alert_to_ntfy.py``. The HTTP POST is the only seam.
+
+Security: the ntfy URL is read from the environment and is **never** echoed to
+logs (a leaked topic URL is a write capability to the channel).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib import request as urlrequest
+
+logger = logging.getLogger("alert_to_ntfy")
+
+# ntfy priority headers / tag emoji keyed by Alertmanager `severity` label. ntfy
+# priorities: 5=max,4=high,3=default,2=low,1=min.
+_SEVERITY_PRIORITY = {"critical": "high", "warning": "default", "info": "low"}
+_SEVERITY_TAGS = {"critical": "rotating_light", "warning": "warning", "info": "information_source"}
+
+# Listen address; in-cluster the Alertmanager webhook targets http://alert-to-ntfy:9098/alert.
+LISTEN_HOST = os.getenv("ALERT_BRIDGE_HOST", "0.0.0.0")
+LISTEN_PORT = int(os.getenv("ALERT_BRIDGE_PORT", "9098"))
+
+
+def format_alert(alert: dict) -> tuple[str, str, dict[str, str]]:
+    """Map a single Alertmanager alert dict to ``(title, body, headers)``.
+
+    Pure (no I/O). ``headers`` carries the ntfy ``Title``/``Tags``/``Priority``.
+    The body is forced to a **single line** (the project notification convention)
+    by collapsing any embedded newlines.
+    """
+    labels = alert.get("labels") or {}
+    annotations = alert.get("annotations") or {}
+
+    status = (alert.get("status") or "firing").lower()
+    severity = (labels.get("severity") or "info").lower()
+    alertname = labels.get("alertname") or "UnknownAlert"
+
+    resolved = status == "resolved"
+    # Resolved notifications are always informational regardless of the original
+    # severity — the bad thing stopped, so don't page for it.
+    priority = "min" if resolved else _SEVERITY_PRIORITY.get(severity, "default")
+    tag = "white_check_mark" if resolved else _SEVERITY_TAGS.get(severity, "bell")
+
+    state = "RESOLVED" if resolved else "FIRING"
+    title = f"[{state}] {alertname} ({severity})"
+
+    summary = annotations.get("summary") or annotations.get("description") or alertname
+    # Single line: collapse newlines + runs of whitespace so the push is one line.
+    body = " ".join(str(summary).split())
+
+    headers = {"Title": title, "Tags": tag, "Priority": priority}
+    return title, body, headers
+
+
+def format_payload(payload: dict) -> list[tuple[str, str, dict[str, str]]]:
+    """Map a full Alertmanager webhook payload to a list of per-alert messages."""
+    return [format_alert(a) for a in (payload.get("alerts") or [])]
+
+
+def _post_to_ntfy(ntfy_url: str, body: str, headers: dict[str, str]) -> None:
+    """POST one formatted message to ntfy. Never logs the URL (write capability)."""
+    req = urlrequest.Request(ntfy_url, data=body.encode("utf-8"), headers=headers, method="POST")
+    with urlrequest.urlopen(req, timeout=10) as resp:  # noqa: S310 - operator-supplied env URL
+        resp.read()
+
+
+def _handle_payload(payload: dict, ntfy_url: str) -> int:
+    """Format + push every alert in a payload. Returns the count pushed."""
+    messages = format_payload(payload)
+    for _title, body, headers in messages:
+        try:
+            _post_to_ntfy(ntfy_url, body, headers)
+        except Exception:  # pragma: no cover - network failure path
+            # Never include the URL in the log line.
+            logger.warning("alert_to_ntfy: failed to push alert %r", headers.get("Title"), exc_info=True)
+    return len(messages)
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_POST(self):  # noqa: N802 - http.server API
+        if self.path.rstrip("/") not in ("/alert", ""):
+            self.send_error(404, "not found")
+            return
+        ntfy_url = os.getenv("ALERT_NTFY_URL")
+        if not ntfy_url:
+            self.send_error(500, "ALERT_NTFY_URL not configured")
+            return
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+            payload = json.loads(self.rfile.read(length) or b"{}")
+        except (ValueError, json.JSONDecodeError):
+            self.send_error(400, "invalid JSON")
+            return
+        count = _handle_payload(payload, ntfy_url)
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(f"pushed {count} alert(s)\n".encode())
+
+    def log_message(self, *args):  # silence default per-request stderr logging
+        pass
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    if not os.getenv("ALERT_NTFY_URL"):
+        logger.error("ALERT_NTFY_URL is not set; the bridge will reject requests with 500.")
+    server = ThreadingHTTPServer((LISTEN_HOST, LISTEN_PORT), _Handler)
+    logger.info("alert_to_ntfy listening on %s:%s", LISTEN_HOST, LISTEN_PORT)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:  # pragma: no cover
+        server.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ops/alert_to_ntfy.py
+++ b/scripts/ops/alert_to_ntfy.py
@@ -82,6 +82,13 @@ def format_payload(payload: dict) -> list[tuple[str, str, dict[str, str]]]:
     return [format_alert(a) for a in (payload.get("alerts") or [])]
 
 
+def _sanitize_for_log(value: object) -> str:
+    """Return a single-line, control-char-safe representation for logging."""
+    text = str(value)
+    text = text.replace("\r", " ").replace("\n", " ")
+    return "".join(ch if ch.isprintable() else "?" for ch in text)
+
+
 def _post_to_ntfy(ntfy_url: str, body: str, headers: dict[str, str]) -> None:
     """POST one formatted message to ntfy. Never logs the URL (write capability)."""
     req = urlrequest.Request(ntfy_url, data=body.encode("utf-8"), headers=headers, method="POST")
@@ -97,7 +104,11 @@ def _handle_payload(payload: dict, ntfy_url: str) -> int:
             _post_to_ntfy(ntfy_url, body, headers)
         except Exception:  # pragma: no cover - network failure path
             # Never include the URL in the log line.
-            logger.warning("alert_to_ntfy: failed to push alert %r", headers.get("Title"), exc_info=True)
+            logger.warning(
+                "alert_to_ntfy: failed to push alert %r",
+                _sanitize_for_log(headers.get("Title", "")),
+                exc_info=True,
+            )
     return len(messages)
 
 

--- a/scripts/ops/tests/test_alert_to_ntfy.py
+++ b/scripts/ops/tests/test_alert_to_ntfy.py
@@ -1,0 +1,104 @@
+"""Unit tests for the Alertmanager → ntfy bridge formatter (ALT-2).
+
+The bridge's payload→(title, body, headers) mapping is a pure function, so these
+tests need no network and no running server — they exercise ``format_alert`` /
+``format_payload`` directly. The script lives outside the Django package
+(``scripts/ops/``), so it is imported by path.
+
+Run::
+
+    python -m pytest scripts/ops/tests/test_alert_to_ntfy.py
+"""
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "alert_to_ntfy.py"
+_spec = importlib.util.spec_from_file_location("alert_to_ntfy", _SCRIPT)
+bridge = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bridge)
+
+
+def _alert(name, severity, status="firing", summary="Something happened", description=None):
+    annotations = {"summary": summary}
+    if description is not None:
+        annotations["description"] = description
+    return {
+        "status": status,
+        "labels": {"alertname": name, "severity": severity},
+        "annotations": annotations,
+    }
+
+
+def test_critical_firing_maps_to_high_priority_rotating_light():
+    title, body, headers = bridge.format_alert(
+        _alert("OpenShikshaBackupStale", "critical", summary="Backup is stale (>36h)")
+    )
+    assert headers["Priority"] == "high"
+    assert headers["Tags"] == "rotating_light"
+    assert title == "[FIRING] OpenShikshaBackupStale (critical)"
+    assert body == "Backup is stale (>36h)"
+    assert headers["Title"] == title
+
+
+def test_warning_firing_maps_to_default_priority_warning_tag():
+    _title, _body, headers = bridge.format_alert(_alert("OpenShikshaGradeQueueBacklog", "warning"))
+    assert headers["Priority"] == "default"
+    assert headers["Tags"] == "warning"
+
+
+def test_resolved_is_always_low_priority_with_check_mark():
+    title, _body, headers = bridge.format_alert(
+        _alert("OpenShikshaBackupStale", "critical", status="resolved")
+    )
+    # Resolution must NOT page even for a critical alert.
+    assert headers["Priority"] == "min"
+    assert headers["Tags"] == "white_check_mark"
+    assert title.startswith("[RESOLVED]")
+
+
+def test_body_is_collapsed_to_a_single_line():
+    multiline = "Line one.\n  Line two.\n\nLine three."
+    _title, body, _headers = bridge.format_alert(
+        _alert("X", "warning", summary=multiline)
+    )
+    assert "\n" not in body
+    assert body == "Line one. Line two. Line three."
+
+
+def test_falls_back_to_description_then_alertname_for_body():
+    # No summary -> description
+    _t, body, _h = bridge.format_alert(
+        {"status": "firing", "labels": {"alertname": "X", "severity": "warning"},
+         "annotations": {"description": "from description"}}
+    )
+    assert body == "from description"
+    # No annotations at all -> alertname
+    _t2, body2, _h2 = bridge.format_alert(
+        {"status": "firing", "labels": {"alertname": "OnlyName", "severity": "info"}}
+    )
+    assert body2 == "OnlyName"
+
+
+def test_unknown_severity_defaults_safely():
+    _t, _b, headers = bridge.format_alert(
+        {"status": "firing", "labels": {"alertname": "X", "severity": "bogus"}, "annotations": {}}
+    )
+    assert headers["Priority"] == "default"
+    assert headers["Tags"] == "bell"
+
+
+def test_format_payload_handles_multiple_and_empty():
+    payload = {
+        "status": "firing",
+        "alerts": [
+            _alert("A", "critical"),
+            _alert("B", "warning", status="resolved"),
+        ],
+    }
+    msgs = bridge.format_payload(payload)
+    assert len(msgs) == 2
+    assert msgs[0][2]["Priority"] == "high"  # critical firing
+    assert msgs[1][2]["Priority"] == "min"  # resolved
+    assert bridge.format_payload({}) == []
+    assert bridge.format_payload({"alerts": []}) == []


### PR DESCRIPTION
## Production Observability — Batch 4 (Uptime & alerting), ALT-2

**Classification:** New · depends on nothing at build time (references ALT-1 only by receiver name)

Routes the ALT-1 alerts to **ntfy** (the channel the team already uses for build
notifications) with two artifacts:

- **`docs/ops/alertmanager/alertmanager.yml`** — minimal `route` (grouped by
  `alertname`/`severity`) → single `webhook_configs` receiver pointed at the
  bridge; commented `email_configs` alternative. No secrets (ntfy URL injected via
  the bridge env).
- **`scripts/ops/alert_to_ntfy.py`** — dependency-light **stdlib** bridge
  (`http.server` + `urllib`, **no new pip dep**) translating Alertmanager webhook
  JSON into **one-line** ntfy pushes with `Title`/`Tags`/`Priority` by severity.
  Pure `format_alert`/`format_payload`; ntfy URL read from env, **never logged**.

### severity → ntfy mapping
| severity | priority | tag |
|---|---|---|
| critical (firing) | high | rotating_light |
| warning (firing) | default | warning |
| **any (resolved)** | min | white_check_mark (never pages) |

### Tests
`scripts/ops/tests/test_alert_to_ntfy.py` — **7 formatter unit tests, no network**
(the HTTP POST is the only seam, the formatter is pure): severity mapping, resolved
never-pages, single-line collapse, summary/description/alertname fallback, unknown
severity default, multi/empty payloads. **7 passed.** `py_compile` clean.

> The backend Test job only collects `backend/` tests, so these run in CI via the
> **ALT-4** `alerting-lint` job alongside `amtool check-config`.

### How to verify
`python -m pytest scripts/ops/tests/test_alert_to_ntfy.py` · `amtool check-config docs/ops/alertmanager/alertmanager.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)