### PR TITLE
feat(ops): ALT-3 — standalone in-cluster uptime probe CronJob

### DIFF
--- a/backend/Dockerfile.backup
+++ b/backend/Dockerfile.backup
@@ -29,6 +29,13 @@ RUN curl -fsSL "https://dl.min.io/client/mc/release/linux-amd64/archive/mc.${MC_
 COPY scripts/backup/pg_backup.sh scripts/backup/pg_restore.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/pg_backup.sh /usr/local/bin/pg_restore.sh
 
+# ALT-3 (Batch 4): the standalone uptime probe rides in this image too — it only
+# needs curl + bash, which this image already has. Run via an explicit
+# `command:` override from k8s/overlays/prod/uptime-probe-cronjob.yaml (the
+# default ENTRYPOINT below still runs a backup).
+COPY scripts/ops/uptime_probe.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/uptime_probe.sh
+
 # Run as the unprivileged postgres user the base image already provides.
 USER postgres
 

--- a/docs/changes/2026-06-28-alt-3-uptime-probe-cronjob.md
+++ b/docs/changes/2026-06-28-alt-3-uptime-probe-cronjob.md
@@ -1,0 +1,64 @@
+# ALT-3 — Standalone in-cluster uptime probe CronJob
+
+**Date:** 2026-06-28
+**Initiative:** Production Observability & Operational Readiness — Batch 4 (Uptime & alerting)
+**Classification:** New
+
+## Summary
+
+A floor-level "is the site up?" alarm that works with **zero Prometheus /
+Alertmanager deployed** — the complement to the rule-based ALT-1/ALT-2 path:
+
+- `scripts/ops/uptime_probe.sh` (`set -euo pipefail`) — curls the backend
+  `/healthz/` + `/readyz/`; on **any** non-200 (or a connection failure → `000`)
+  pushes a **single-line** DOWN alert to ntfy (`Title: OpenShiksha DOWN`, high
+  priority, `rotating_light`) naming the failing endpoint + status code, and exits
+  non-zero so the Job is marked failed. Success path is **silent** (no per-run
+  spam). The ntfy URL is read from env and **never echoed**.
+- `k8s/overlays/prod/uptime-probe-cronjob.yaml` — `batch/v1 CronJob`,
+  `schedule: "*/5 * * * *"`, `concurrencyPolicy: Forbid`,
+  `successful/failedJobsHistoryLimit: 3`, `backoffLimit: 1`,
+  `restartPolicy: OnFailure`. **Prod-overlay-only** (referenced only from
+  `k8s/overlays/prod/kustomization.yaml`, same pattern as `backup-cronjob.yaml`).
+
+## Image decision
+
+Reuses the **already-published BAK-1 backup image**
+(`ghcr.io/openshiksha/openshiksha-backup:prod`, `postgres:15-alpine` base) which
+already has `curl` + `bash` + `ca-certificates` — **no new CI publish target**.
+The probe script is added to that image (`backend/Dockerfile.backup` COPY) and the
+CronJob overrides the backup ENTRYPOINT with
+`command: ["/usr/local/bin/uptime_probe.sh"]`. The image rebuilds + republishes on
+the existing `build-publish` matrix (context is the repo root, so `scripts/ops/`
+is in scope).
+
+## Config / secrets
+
+- `PROBE_BASE_URL` — **non-secret** ConfigMap value (`http://backend:8000`,
+  in-cluster Service DNS), added to `k8s/overlays/prod/configmap-patch.yaml`.
+- `ALERT_NTFY_URL` — secret (ntfy topic URL), added empty to
+  `k8s/base/secret.example.yaml` with a comment (shared with the ALT-2 bridge).
+
+## Validation
+
+- `bash -n scripts/ops/uptime_probe.sh` clean. (shellcheck runs in dev/CI; not
+  installed on this box — the parse check + functional tests below cover it.)
+- **Functional test** against a local stub server:
+  - `/readyz/` → 503 ⇒ exit **1**, logs the failing endpoint, attempts push
+    (no URL set ⇒ safe "cannot push" warning, never crashes).
+  - both 200 ⇒ exit **0**, **silent** stderr (success path).
+- `kubectl kustomize k8s/overlays/prod` includes the CronJob + `PROBE_BASE_URL`;
+  `kubectl kustomize k8s/overlays/qa` is **byte-for-byte unchanged** (diff: empty).
+- `kubeconform -strict` runs in the existing k8s-manifests CI gate (#459).
+
+## Trade-off (documented for ALT-5)
+
+A transient blip can page every 5 min (acceptable for a floor probe). The
+rule-based ALT-1 path debounces with `for:` windows; the standalone probe
+deliberately does not, trading a little noise for working with no monitoring stack
+at all.
+
+## Next steps
+
+- ALT-4 adds the `alerting-lint` CI gate (promtool/amtool + the ALT-2 pytest).
+- ALT-5 documents how the probe fits the overall alerting story.

--- a/k8s/base/secret.example.yaml
+++ b/k8s/base/secret.example.yaml
@@ -17,7 +17,8 @@
 #     --from-literal=S3_ENDPOINT='https://blr1.digitaloceanspaces.com' \
 #     --from-literal=S3_BUCKET='openshiksha-backups' \
 #     --from-literal=S3_ACCESS_KEY='...' \
-#     --from-literal=S3_SECRET_KEY='...'
+#     --from-literal=S3_SECRET_KEY='...' \
+#     --from-literal=ALERT_NTFY_URL='https://ntfy.sh/openshiksha-shara-alerts'
 #
 # S3_* (BAK-3) are consumed ONLY by the prod-overlay backup CronJob (nightly
 # pg_dump -> S3-compatible upload). DigitalOcean Spaces is the intended target.
@@ -57,3 +58,7 @@ stringData:
   S3_BUCKET: ""
   S3_ACCESS_KEY: ""
   S3_SECRET_KEY: ""
+  # ntfy topic URL the prod-overlay uptime probe (ALT-3) pushes DOWN alerts to,
+  # and the same channel the Alertmanager→ntfy bridge (ALT-2) uses. Empty here;
+  # populate out-of-band in prod. Server-side only — never commit a real value.
+  ALERT_NTFY_URL: ""

--- a/k8s/overlays/prod/configmap-patch.yaml
+++ b/k8s/overlays/prod/configmap-patch.yaml
@@ -6,3 +6,6 @@ data:
   ALLOWED_HOSTS: openshiksha.org,www.openshiksha.org,backend
   CORS_ALLOWED_ORIGINS: https://openshiksha.org,https://www.openshiksha.org
   CSRF_TRUSTED_ORIGINS: https://openshiksha.org,https://www.openshiksha.org
+  # In-cluster base URL the ALT-3 uptime probe curls (/healthz/ + /readyz/).
+  # Non-secret Service DNS; the ntfy URL it pushes to is in openshiksha-secrets.
+  PROBE_BASE_URL: http://backend:8000

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -8,6 +8,9 @@ resources:
   # Prod-only: nightly Postgres backup (BAK-3). Lives in the overlay (not base) so
   # qa/dev never run it and never need S3 creds.
   - backup-cronjob.yaml
+  # Prod-only: standalone uptime probe every 5 min (ALT-3). Overlay-only so qa/dev
+  # kustomize output is unchanged and never needs ALERT_NTFY_URL.
+  - uptime-probe-cronjob.yaml
 
 images:
   - name: ghcr.io/openshiksha/openshiksha-backend

--- a/k8s/overlays/prod/uptime-probe-cronjob.yaml
+++ b/k8s/overlays/prod/uptime-probe-cronjob.yaml
@@ -1,0 +1,59 @@
+# Standalone in-cluster uptime probe (Production Observability Batch 4, ALT-3).
+#
+# Every 5 minutes, runs scripts/ops/uptime_probe.sh (baked into the BAK-1 backup
+# image, which already has curl + bash) to curl the backend /healthz/ + /readyz/.
+# On any non-200 it pushes a single-line DOWN alert to ntfy and exits non-zero so
+# the Job is marked failed. This is the floor-level "is it up?" alarm — it works
+# with ZERO Prometheus / Alertmanager deployed, complementing the rule-based
+# ALT-1/ALT-2 path.
+#
+# Prod-overlay-only (referenced from k8s/overlays/prod/kustomization.yaml, same
+# pattern as backup-cronjob.yaml) so qa/dev kustomize output is byte-for-byte
+# unchanged and never needs ALERT_NTFY_URL.
+#
+# PROBE_BASE_URL is a non-secret ConfigMap value (in-cluster Service DNS);
+# ALERT_NTFY_URL is the ntfy topic URL from openshiksha-secrets (server-side only).
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: uptime-probe
+  labels:
+    app: uptime-probe
+spec:
+  schedule: "*/5 * * * *" # every 5 minutes
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app: uptime-probe
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: uptime-probe
+              # Reuse the already-published BAK-1 backup image (has curl + bash);
+              # override the backup ENTRYPOINT to run the probe instead.
+              image: ghcr.io/openshiksha/openshiksha-backup:prod
+              command: ["/usr/local/bin/uptime_probe.sh"]
+              env:
+                - name: PROBE_BASE_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: openshiksha-config
+                      key: PROBE_BASE_URL
+                - name: ALERT_NTFY_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: openshiksha-secrets
+                      key: ALERT_NTFY_URL
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi

--- a/scripts/ops/uptime_probe.sh
+++ b/scripts/ops/uptime_probe.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# uptime_probe.sh — dependency-free in-cluster uptime probe (Production
+# Observability Batch 4, ALT-3).
+#
+# Curls the backend liveness (`/healthz/`) and readiness (`/readyz/`) endpoints
+# and, on ANY non-200 (or a curl/connection failure), pushes a single-line alert
+# to ntfy and exits non-zero so the owning Kubernetes Job is marked failed (which
+# also surfaces in the Batch-2 Celery/Job visibility). The success path is SILENT
+# (no per-run spam). This is the floor-level "is the site up?" alarm — it works
+# with ZERO Prometheus / Alertmanager deployed, complementing the rule-based
+# ALT-1/ALT-2 path.
+#
+# Packaged into the BAK-1 backup image (which already has bash + curl +
+# ca-certificates) and run by k8s/overlays/prod/uptime-probe-cronjob.yaml every
+# 5 minutes. Prod-overlay-only, so qa/dev kustomize output is unchanged.
+#
+# Configuration (all via environment — the ntfy URL is a write capability and is
+# NEVER echoed):
+#   PROBE_BASE_URL   in-cluster base URL of the backend, e.g. http://backend:8000
+#                    (non-secret; a ConfigMap value).
+#   ALERT_NTFY_URL   ntfy topic URL to push DOWN alerts to (secret; server-side).
+#                    If unset, the probe still checks + exits non-zero on failure,
+#                    but cannot push (a warning is logged without the URL).
+set -euo pipefail
+
+BASE_URL="${PROBE_BASE_URL:-http://backend:8000}"
+
+# Push a single-line DOWN alert to ntfy. Never echoes ALERT_NTFY_URL.
+notify_down() {
+    msg="$1"
+    if [ -z "${ALERT_NTFY_URL:-}" ]; then
+        echo "uptime_probe: ALERT_NTFY_URL unset; cannot push alert" >&2
+        return 0
+    fi
+    curl --silent --show-error --max-time 10 \
+        -H "Title: OpenShiksha DOWN" \
+        -H "Priority: high" \
+        -H "Tags: rotating_light" \
+        -d "$msg" \
+        "$ALERT_NTFY_URL" >/dev/null 2>&1 || \
+        echo "uptime_probe: failed to push ntfy alert" >&2
+}
+
+# Probe one endpoint; echo its HTTP status (000 on connection failure). The probe
+# itself must not abort on a curl non-zero, so the call is guarded.
+probe() {
+    path="$1"
+    curl --silent --output /dev/null --max-time 10 \
+        --write-out "%{http_code}" "${BASE_URL}${path}" 2>/dev/null || echo "000"
+}
+
+failures=""
+for path in "/healthz/" "/readyz/"; do
+    code="$(probe "$path")"
+    if [ "$code" != "200" ]; then
+        echo "uptime_probe: ${path} returned ${code}" >&2
+        failures="${failures} ${path}=${code}"
+    fi
+done
+
+if [ -n "$failures" ]; then
+    notify_down "Backend health check failed:${failures} (base ${BASE_URL})"
+    exit 1
+fi
+
+echo "uptime_probe: OK (healthz + readyz 200)"
+exit 0


### PR DESCRIPTION
## Production Observability — Batch 4 (Uptime & alerting), ALT-3

**Classification:** New · prod-overlay-only · independent of ALT-1/2

A floor-level **"is the site up?"** alarm that works with **zero Prometheus /
Alertmanager deployed** — the complement to the rule-based ALT-1/ALT-2 path.

- **`scripts/ops/uptime_probe.sh`** (`set -euo pipefail`) — curls `/healthz/` +
  `/readyz/`; on any non-200 (or connection failure → `000`) pushes a **single-line**
  DOWN alert to ntfy (high priority, `rotating_light`) naming the failing endpoint +
  code, and exits non-zero so the Job is marked failed. **Success path is silent.**
  ntfy URL read from env, **never echoed**.
- **`k8s/overlays/prod/uptime-probe-cronjob.yaml`** — `batch/v1 CronJob`, `*/5 * * * *`,
  `Forbid` concurrency, `backoffLimit: 1`, `OnFailure`. Referenced only from the
  prod kustomization (same pattern as `backup-cronjob.yaml`).

### Image decision — no new publish target
Reuses the already-published **BAK-1 backup image** (has `curl`+`bash`); the probe
script is added to `backend/Dockerfile.backup` and the CronJob overrides the backup
ENTRYPOINT via `command:`. The image rebuilds on the existing `build-publish` matrix
(context = repo root, so `scripts/ops/` is in scope).

### Config / secrets
- `PROBE_BASE_URL` (`http://backend:8000`) — non-secret, added to prod `configmap-patch.yaml`.
- `ALERT_NTFY_URL` — secret, added empty to `secret.example.yaml` (shared with the ALT-2 bridge).

### Validation
- `bash -n` clean. **Functional test** vs a stub server: `/readyz/`→503 ⇒ exit **1** + alert attempt; both 200 ⇒ exit **0**, silent.
- `kubectl kustomize prod` includes the CronJob + `PROBE_BASE_URL`; **`kubectl kustomize qa` is byte-for-byte unchanged** (diff empty). `kubeconform -strict` runs in the existing k8s-manifests gate.

### Trade-off (for ALT-5 runbook)
A transient blip can page every 5 min — acceptable for a floor probe; the ALT-1 rule path debounces with `for:` windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)