### PR TITLE
docs: retarget contributor branch model from deleted `modernization` to `qa` trunk

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,12 +20,13 @@ pre-commit install
 ## Branch model
 
 ```
-feature/*  ──PR──▶  modernization  ──PR──▶  qa  ──▶  production
+feature/*  ──PR──▶  qa  ──(CI builds + auto-deploys)──▶  production
 ```
 
-- Branch off **`modernization`** and open your PR **against `modernization`**.
-- `qa` is the release branch (a merge there deploys to production), so it is not
-  a PR target for feature work.
+- Branch off **`qa`** and open your PR **against `qa`**. `qa` is the trunk — all
+  feature work integrates here.
+- A merge to `qa` is a release: CI builds the images and deploys to production
+  automatically, so keep `qa` green and review every PR before merging.
 - Use descriptive branch names: `feat/...`, `fix/...`, `docs/...`, `chore/...`.
 
 See [`docs/dev/git-strategy.md`](docs/dev/git-strategy.md) for the full rationale.

--- a/README.md
+++ b/README.md
@@ -139,16 +139,15 @@ k3s cluster (image pinned by commit SHA, `kubectl rollout status` waited on).
 ### Branch → environment model
 
 ```
-feature/*  ──PR──▶  modernization  ──PR──▶  qa  ──(CI builds + deploys)──▶  production (openshiksha.org)
-   dev work          integration            release branch
+feature/*  ──PR──▶  qa  ──(CI builds + deploys)──▶  production (openshiksha.org)
+   dev work       trunk + release branch
 ```
 
-- **`modernization`** — active development / integration branch; feature PRs land here.
-- **`qa`** — the release branch. A merge here builds the images and **deploys to
-  production** (`openshiksha.org`) automatically.
-- A dedicated **qa environment** (taking `modernization`) is wired but disabled
-  until a second cluster exists — see the `deploy-qa` job, gated behind the
-  `QA_ENV_ENABLED` variable.
+- **`qa`** — the trunk and release branch; feature PRs land here. A merge builds
+  the images and **deploys to production** (`openshiksha.org`) automatically, so
+  it stays green and reviewed at all times.
+- A dedicated **qa environment** is wired but disabled until a second cluster
+  exists — see the `deploy-qa` job, gated behind the `QA_ENV_ENABLED` variable.
 
 Deployment specifics (k3s, kustomize overlays, secrets, TLS, rollback) are in
 [`docs/deploy/README.md`](docs/deploy/README.md).

--- a/docs/changes/2026-06-29-branch-model-docs-qa-trunk.md
+++ b/docs/changes/2026-06-29-branch-model-docs-qa-trunk.md
@@ -1,0 +1,45 @@
+# Retarget contributor branch-model docs from deleted `modernization` to the `qa` trunk
+
+**Date:** 2026-06-29
+**Type:** docs / infra hygiene
+
+## Problem
+
+The `modernization` branch was squash-merged into `qa` and **deleted** when the
+modern stack became the trunk, but the contributor-facing documentation still
+told people to branch off and PR against `modernization`. For a repo on the
+open-source-readiness track, that is broken onboarding: a new contributor
+following `CONTRIBUTING.md` or the README would target a branch that no longer
+exists, and a repo admin following `docs/infra/branch-protection.md` would try to
+protect a non-existent branch.
+
+This continues the dead-branch cleanup started in #440 (which repointed the
+Dependabot/CI *triggers* from `modernization` to `qa`) — that PR fixed the
+machinery; this one fixes the human-facing docs.
+
+## What changed (docs only — no code or CI behaviour)
+
+- **`CONTRIBUTING.md`** — branch-model diagram + instructions now say *branch off
+  `qa`, PR against `qa`*, and explain that a merge to `qa` is an auto-deploying
+  release.
+- **`README.md`** — "Branch → environment model" section corrected to the
+  single-trunk `feature/* → qa → production` flow.
+- **`docs/dev/git-strategy.md`** — rewritten. The old file was the original
+  migration-era plan (legacy Python 2.7 on `main`, modern work on
+  `modernization`, a "Migration to Production" cut-over, `frontend/` paths). All
+  of that is complete and obsolete. The new version documents the current
+  trunk-based model, the feature workflow, the PR process, and a short history
+  note pointing at `setup-modernization.md` and `legacy/`.
+- **`docs/dev/README.md`** — the one-line branch-model summary updated.
+- **`docs/infra/branch-protection.md`** — now protects the single `qa` trunk
+  (was: `modernization` + `qa`); verification `gh api` snippet updated.
+
+## Out of scope (intentionally left)
+
+- The `deploy-qa` job in `ci-cd.yaml` still gates on `refs/heads/modernization`,
+  but its own comment documents it as a disabled future-state sketch (also
+  double-gated behind the unset `QA_ENV_ENABLED` variable), so it never runs.
+  Left as-is to keep this change docs-only and atomic.
+- Historical references in `docs/changes/`, `docs/daily-plans/`,
+  `docs/deploy/README.md`, and `frontend_modern/README.md` are dated record /
+  narrative, not live branch guidance — preserved as history.

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -7,7 +7,7 @@ Hands-on guides for working in the OpenShiksha repo. Start with the
 | --- | --- |
 | [local-development.md](local-development.md) | Full local setup — Docker Compose (backend + Postgres + Redis + Celery), the Vite dev server, seeding demo data, and the Cabinet question import. |
 | [cheat-sheet.md](cheat-sheet.md) | Quick-reference commands for everyday development (running services, tests, migrations, common tasks). |
-| [git-strategy.md](git-strategy.md) | The branch model (`feature/* → modernization → qa → production`) and the rationale behind it. |
+| [git-strategy.md](git-strategy.md) | The branch model (`feature/* → qa → production`) and the rationale behind it. |
 | [setup-modernization.md](setup-modernization.md) | Historical record of how the modern `backend/` + `frontend_modern/` stack was bootstrapped alongside the legacy monolith. |
 
 See also: [Deployment](../deploy/README.md) · [Initiatives](../initiatives/README.md) · [Contributing](../../CONTRIBUTING.md).

--- a/docs/dev/git-strategy.md
+++ b/docs/dev/git-strategy.md
@@ -1,398 +1,95 @@
-# OpenShiksha Modernization - Git Branching Strategy
+# OpenShiksha — Git Branching Strategy
 
 ## Overview
 
-The modernization will happen on a dedicated `modernization` branch, keeping the legacy Python 2.7 code on `main` branch until the modern version is production-ready.
+OpenShiksha uses a simple **trunk-based** model. All feature work integrates into
+a single long-lived branch, **`qa`**, which is also the release branch: a merge to
+`qa` builds the production images and deploys them automatically (see
+[`.github/workflows/ci-cd.yaml`](../../.github/workflows/ci-cd.yaml)).
 
-## Branch Structure
+> **History.** The codebase was rebuilt from a legacy Django 1.11 / Python 2.7
+> monolith onto Django 4.2 + React 18. That rebuild happened on a dedicated
+> `modernization` branch, which was squash-merged into `qa` and **deleted** once
+> the modern stack became the trunk. The retired monolith now lives under
+> [`legacy/`](../../legacy/) for reference. See
+> [setup-modernization.md](setup-modernization.md) for how the modern stack was
+> bootstrapped. **Do not branch from or PR against `modernization` — it no longer
+> exists.**
+
+## Branch structure
 
 ```
-main (legacy Django 1.11/Python 2.7)
-  │
-  └── modernization (Django 4.2/Python 3.11 + React 18)
-       │
-       ├── feature/phase-0-setup
-       ├── feature/phase-1-api
-       ├── feature/phase-2-student-frontend
-       └── ... (feature branches for each phase)
+qa (trunk + release — Django 4.2 / Python 3.12 + React 18)
+ │   merge here ⇒ CI builds images + auto-deploys to production
+ │
+ ├── feat/...     feature work
+ ├── fix/...      bug fixes
+ ├── docs/...     documentation
+ ├── chore/...    tooling / housekeeping
+ └── infra/...    CI / infrastructure
 ```
 
-## Branching Strategy
+- **`qa`** (protected) — the trunk. Every change lands here via PR. A merge is a
+  release, so it stays green and reviewed at all times.
+- **`prod`** — when pushed, CI also builds images tagged `prod`, but the live
+  cluster is currently rolled out from `qa` (the `deploy-prod` job triggers on
+  `qa`). Treat `prod` as a future-state release-train branch, not part of the
+  day-to-day flow.
 
-### Main Branches
-
-1. **`main`** (protected)
-   - Legacy codebase (Django 1.11/Python 2.7)
-   - Keep for reference and emergency hotfixes
-   - **DO NOT delete or modify** during modernization
-   - Read-only during modernization period
-
-2. **`modernization`** (protected)
-   - Base branch for all modern development
-   - Django 4.2 + Python 3.11 + React 18
-   - All new code goes here
-   - Will eventually replace `main` when complete
-
-### Feature Branches
-
-Create feature branches off `modernization` for each phase/task:
+## Feature workflow
 
 ```bash
-# Pattern: feature/phase-X-description
-feature/phase-0-setup
-feature/phase-1-auth
-feature/phase-1-questions
-feature/phase-2-student-ui
-feature/phase-3-teacher-ui
-etc.
+# Always start from an up-to-date trunk
+git checkout qa
+git pull origin qa
+
+# Create a descriptive feature branch
+git checkout -b feat/short-description
+
+# ...work, commit (pre-commit hooks run black/isort/flake8)...
+git push -u origin feat/short-description
+
+# Open a PR on GitHub: feat/short-description → qa
 ```
 
-## Initial Setup
-
-### Step 1: Check Current Branch
+Keep a branch up to date with the trunk before merge:
 
 ```bash
-cd "c:\Users\shara\OneDrive\Desktop\My Stuff\Work\Dev\OpenShiksha"
-git status
-git branch -a
+git checkout feat/short-description
+git pull origin qa        # or: git merge qa
+# resolve conflicts, push
 ```
 
-### Step 2: Create Modernization Branch
+## Pull request process
 
-```bash
-# Create and switch to modernization branch
-git checkout -b modernization
+1. **Open a PR** from your feature branch → `qa`.
+2. **CI runs automatically** (lint, type-check, security audit, backend + frontend
+   tests, e2e, visual regression, k8s/alerting manifest validation).
+3. **Get a review** — at least one approval (see branch protection below).
+4. **Merge** once CI is green and the conversation is resolved.
+5. **Delete** the feature branch.
 
-# Verify you're on the new branch
-git branch
-```
+One concern per PR — split mechanical changes (e.g. file moves) from behavioural
+ones so reviews stay tractable. See [CONTRIBUTING.md](../../CONTRIBUTING.md) for
+commit/PR conventions.
 
-### Step 3: Set Up Modern Structure
+## Branch protection
 
-The modern structure will coexist with legacy:
+`qa` should be protected: require a PR + 1 approval, require passing status checks,
+and disallow force-pushes and deletion. The full recommended GitHub configuration
+is documented in
+[`docs/infra/branch-protection.md`](../infra/branch-protection.md).
 
-```
-OpenShiksha/
-├── openshiksha/          # Legacy code (untouched on modernization branch)
-├── backend/              # NEW: Modern Django backend
-├── frontend/             # NEW: Modern React frontend
-├── docker-compose.yml    # NEW: Docker setup
-├── .env.example          # NEW: Environment template
-├── LOCAL_DEVELOPMENT.md  # NEW: Dev guide
-├── CHEAT_SHEET.md        # NEW: Quick reference
-└── README.md             # UPDATE: Point to modernization
-```
-
-### Step 4: Add New Files
-
-```bash
-# Check what's new
-git status
-
-# Add new files (do NOT add openshiksha-modern directory)
-git add backend/
-git add frontend/
-git add docker-compose.yml
-git add LOCAL_DEVELOPMENT.md
-git add CHEAT_SHEET.md
-git add GIT_STRATEGY.md
-
-# Commit
-git commit -m "Phase 0: Initialize modern project structure
-
-- Add Django 4.2 backend setup
-- Add React 18 + TypeScript frontend setup
-- Add Docker Compose configuration
-- Add development documentation
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>"
-
-# Push to remote
-git push -u origin modernization
-```
-
-## Development Workflow
-
-### Starting New Work
-
-```bash
-# Always start from modernization branch
-git checkout modernization
-git pull origin modernization
-
-# Create feature branch
-git checkout -b feature/phase-0-docker-setup
-
-# Work on your feature...
-# Make commits...
-
-# Push feature branch
-git push -u origin feature/phase-0-docker-setup
-```
-
-### Committing Changes
-
-Follow this commit message format:
-
-```
-Phase X: Brief description
-
-- Detailed change 1
-- Detailed change 2
-- Detailed change 3
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
-```
-
-### Merging Features
-
-```bash
-# From feature branch, update with latest modernization
-git checkout feature/phase-0-docker-setup
-git pull origin modernization
-git merge modernization
-
-# Resolve any conflicts
-# Run tests
-# Push
-
-# Create Pull Request: feature/phase-0-docker-setup → modernization
-```
-
-### Pull Request Process
-
-1. **Create PR** from feature branch → `modernization`
-2. **Review** changes
-3. **Run tests** (CI/CD will auto-run)
-4. **Merge** to modernization
-5. **Delete** feature branch
-
-## Directory Structure on Modernization Branch
-
-```
-OpenShiksha/
-│
-├── openshiksha/                    # LEGACY (reference only)
-│   ├── core/
-│   ├── edge/
-│   ├── cabinet/
-│   └── ... (old Django 1.11 code)
-│
-├── backend/                        # NEW: Modern Django backend
-│   ├── openshiksha/               # Django project
-│   │   ├── settings/
-│   │   │   ├── base.py
-│   │   │   ├── development.py
-│   │   │   └── production.py
-│   │   ├── urls.py
-│   │   └── wsgi.py
-│   ├── apps/                      # Django apps
-│   │   ├── core/                  # Modernized core
-│   │   ├── edge/                  # Modernized analytics
-│   │   ├── cabinet/               # Modernized cabinet integration
-│   │   └── api/                   # REST API
-│   ├── manage.py
-│   ├── requirements.txt
-│   ├── Dockerfile
-│   └── .env.example
-│
-├── frontend/                       # NEW: React frontend
-│   ├── src/
-│   │   ├── features/
-│   │   │   ├── assignments/
-│   │   │   ├── analytics/
-│   │   │   ├── questions/
-│   │   │   └── auth/
-│   │   ├── shared/
-│   │   ├── types/
-│   │   └── App.tsx
-│   ├── package.json
-│   ├── tsconfig.json
-│   ├── vite.config.ts
-│   ├── Dockerfile
-│   └── .env.example
-│
-├── docs/                           # Documentation
-├── scripts/                        # Utility scripts
-├── .github/                        # CI/CD workflows
-├── docker-compose.yml
-├── .gitignore
-├── LOCAL_DEVELOPMENT.md
-├── CHEAT_SHEET.md
-├── GIT_STRATEGY.md
-└── README.md                       # Updated for modernization
-```
-
-## Important Rules
+## Rules of thumb
 
 ### ✅ DO
-
-- Create all new code in `backend/` and `frontend/` directories
-- Work on feature branches off `modernization`
-- Keep `openshiksha/` legacy directory untouched (reference only)
-- Update tracker after each task
-- Write clear commit messages with phase context
-- Push regularly to backup work
+- Branch off `qa` and PR back into `qa`.
+- Use the `feat/` `fix/` `docs/` `chore/` `infra/` prefixes.
+- Keep `qa` releasable — it deploys to production on merge.
+- Write clear, conventional-commit messages.
 
 ### ❌ DON'T
-
-- **Don't modify** legacy `openshiksha/` code on modernization branch
-- **Don't merge** modernization into main until fully complete
-- **Don't delete** legacy code (keep for reference)
-- **Don't work directly** on modernization branch (use feature branches)
-- **Don't force push** to protected branches
-
-## Migration to Production
-
-When modernization is complete (Phase 6):
-
-### Option 1: Replace Main (Recommended)
-
-```bash
-# Backup old main
-git checkout main
-git tag legacy-backup
-git push origin legacy-backup
-
-# Replace main with modernization
-git checkout modernization
-git merge -s ours main  # Keep modernization code
-git checkout main
-git merge modernization
-git push origin main
-
-# Archive legacy
-git tag legacy-django-1.11
-git push origin legacy-django-1.11
-```
-
-### Option 2: Parallel Deployment
-
-Keep both branches and deploy from `modernization`:
-
-```bash
-# Production deploys from modernization branch
-git checkout modernization
-git pull origin modernization
-# Deploy...
-
-# Legacy remains on main for emergency reference
-```
-
-## .gitignore Updates
-
-Make sure `.gitignore` includes:
-
-```gitignore
-# Python
-__pycache__/
-*.py[cod]
-*$py.class
-*.so
-.Python
-venv/
-env/
-.env
-*.log
-
-# Django
-db.sqlite3
-/media/
-/staticfiles/
-/logs/
-
-# Node
-node_modules/
-dist/
-build/
-.npm
-*.log
-
-# IDEs
-.vscode/
-.idea/
-*.swp
-
-# OS
-.DS_Store
-Thumbs.db
-
-# Docker
-docker-compose.override.yml
-
-# Temporary
-*.tmp
-*.bak
-openshiksha-modern/  # Remove this temp directory
-```
-
-## Emergency Rollback
-
-If something goes wrong:
-
-```bash
-# List all branches
-git branch -a
-
-# Switch back to legacy
-git checkout main
-
-# Or restore from backup
-git checkout legacy-backup
-```
-
-## Branch Protection Rules (GitHub)
-
-Configure on GitHub repository settings:
-
-### `main` branch:
-- ✅ Require pull request reviews
-- ✅ Require status checks to pass
-- ✅ Require branches to be up to date
-- ✅ Include administrators
-- ❌ Allow force pushes
-
-### `modernization` branch:
-- ✅ Require pull request reviews
-- ✅ Require status checks to pass
-- ✅ Require branches to be up to date
-- ✅ Include administrators
-- ❌ Allow force pushes
-
-## Quick Reference
-
-```bash
-# Start new feature
-git checkout modernization && git pull
-git checkout -b feature/phase-X-name
-
-# Daily work
-git add .
-git commit -m "Phase X: Description"
-git push
-
-# Update from modernization
-git pull origin modernization
-
-# Create PR (on GitHub)
-feature/phase-X-name → modernization
-
-# After merge
-git checkout modernization
-git pull
-git branch -d feature/phase-X-name
-```
-
-## Current Status
-
-- **Active Branch**: `modernization`
-- **Current Phase**: Phase 0 - Preparation
-- **Next**: Create feature branch for Phase 0 setup
-
----
-
-**Remember**: Legacy code stays on `main`, all modern code goes on `modernization` branch! 🚀
+- **Don't** branch from or target `modernization` (deleted).
+- **Don't** commit directly to `qa` — always go through a PR.
+- **Don't** force-push or delete protected branches.
+- **Don't** edit retired code under `legacy/` as part of feature work.

--- a/docs/infra/branch-protection.md
+++ b/docs/infra/branch-protection.md
@@ -2,9 +2,12 @@
 
 GitHub branch protection rules cannot live in the repo as configuration; they must be configured by a repo admin in **Settings → Branches → Branch protection rules**. This document is the source of truth for what those settings should be, so they can be re-applied if the repo is migrated, forked, or accidentally reset.
 
-Two protected branches: **`modernization`** (feature integration) and **`qa`** (release candidate). `prod` deploys automatically and follows the same rules as `qa`.
+One protected branch: **`qa`** — the trunk and release branch. A merge to `qa`
+builds the production images and deploys them, so it carries the strictest rules.
+(`prod` exists as a future-state release-train branch and should get the same rules
+if/when it becomes part of the active deploy flow.)
 
-## Settings to apply to `modernization` and `qa`
+## Settings to apply to `qa`
 
 In **Settings → Branches → Add branch protection rule**, set the branch name pattern to the target branch, then enable:
 
@@ -35,12 +38,12 @@ In **Settings → Branches → Add branch protection rule**, set the branch name
 
 | Setting | Reason |
 |---|---|
-| Require PR + 1 approval | Catches obvious mistakes; one set of human eyes on every change reaching `modernization`/`qa`. |
+| Require PR + 1 approval | Catches obvious mistakes; one set of human eyes on every change reaching `qa`. |
 | Dismiss stale approvals on new commits | Prevents "approved, then silently changed" bypass. |
 | Require status checks | CI catches lint/type/test/security regressions before merge. The required-check list mirrors the job names that block release. |
 | Require up-to-date branches | Forces rebases before merge so the CI signal is meaningful against the latest target. |
 | Require conversation resolution | Ensures review comments aren't merged-over. |
-| Block force-push and deletion | `modernization` and `qa` are shared history — losing commits or rewriting history breaks everyone's clones. |
+| Block force-push and deletion | `qa` is shared history — losing commits or rewriting history breaks everyone's clones. |
 | Apply to admins ("Do not allow bypassing") | Self-explanatory; the rules are worthless if the most active committers can skip them. |
 
 ## Repo-level settings for Dependabot auto-merge
@@ -59,8 +62,7 @@ After applying, the easiest sanity check is to open a draft PR with a deliberate
 To inspect the current configuration via the CLI:
 
 ```bash
-gh api repos/openshiksha/openshiksha/branches/modernization/protection
 gh api repos/openshiksha/openshiksha/branches/qa/protection
 ```
 
-If either command returns `404 Not Found`, protection is not configured on that branch and this document should be applied.
+If the command returns `404 Not Found`, protection is not configured on `qa` and this document should be applied.


### PR DESCRIPTION
## What

The `modernization` branch was squash-merged into `qa` and **deleted** when the modern stack became the trunk, but the contributor-facing docs still instruct people to branch off / PR against `modernization`. This corrects the human-facing branch-model documentation to the current single-trunk reality.

Continues the dead-branch cleanup from #440 — that PR repointed the Dependabot/CI **triggers** to `qa`; this one fixes the **docs** a new contributor (or repo admin) actually reads.

## Why it matters

For a repo on the open-source-readiness track, this is broken onboarding:
- A contributor following `CONTRIBUTING.md` or the README would target a branch that no longer exists.
- An admin following `docs/infra/branch-protection.md` would try to protect a non-existent branch.

## Changes (docs only — no code or CI behaviour change)

- **`CONTRIBUTING.md`** — branch model → `feature/* → qa → production`; explains a merge to `qa` is an auto-deploying release.
- **`README.md`** — "Branch → environment model" section corrected to the single-trunk flow.
- **`docs/dev/git-strategy.md`** — rewritten. The old file was the original migration-era plan (Python 2.7 legacy on `main`, work on `modernization`, a cut-over plan, stale `frontend/` paths) — all complete and obsolete. New version documents the current trunk model + feature/PR workflow, with a history note pointing at `setup-modernization.md` and `legacy/`.
- **`docs/dev/README.md`** — one-line branch-model summary updated.
- **`docs/infra/branch-protection.md`** — protect the single `qa` trunk (was `modernization` + `qa`); verification snippet updated.

## Out of scope (intentional)

- The `deploy-qa` job in `ci-cd.yaml` still gates on `refs/heads/modernization`, but its own comment documents it as a disabled future-state sketch (also double-gated behind the unset `QA_ENV_ENABLED` var), so it never fires. Left as-is to keep this PR docs-only and atomic.
- Historical references in `docs/changes/`, `docs/daily-plans/`, `docs/deploy/README.md`, `frontend_modern/README.md` are dated record/narrative, not live guidance — preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)