### PR TITLE
feat(obs): OACT-1 — standalone Prometheus manifest + CI kustomize/kubeconform gate

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -88,6 +88,18 @@ jobs:
                         -kubernetes-version 1.31.0 -
                   echo "::endgroup::"
                 done
+            - name: Render & schema-validate the standalone monitoring stack
+              # k8s/monitoring (Observability Activation, OACT-1..3) is an
+              # operator-applied stack NOT referenced by any overlay, so the loop
+              # above never renders it. Gate it the same way so a typo in the
+              # Prometheus/Alertmanager/Grafana manifests fails at PR time, not at
+              # `kubectl apply` on the droplet.
+              run: |
+                echo "::group::monitoring"
+                kubectl kustomize k8s/monitoring \
+                  | kubeconform -strict -summary -ignore-missing-schemas \
+                      -kubernetes-version 1.31.0 -
+                echo "::endgroup::"
 
     alerting-lint:
         name: Alerting Artifacts (promtool + amtool)

--- a/k8s/base/secret.example.yaml
+++ b/k8s/base/secret.example.yaml
@@ -18,7 +18,9 @@
 #     --from-literal=S3_BUCKET='openshiksha-backups' \
 #     --from-literal=S3_ACCESS_KEY='...' \
 #     --from-literal=S3_SECRET_KEY='...' \
-#     --from-literal=ALERT_NTFY_URL='https://ntfy.sh/openshiksha-shara-alerts'
+#     --from-literal=ALERT_NTFY_URL='https://ntfy.sh/openshiksha-shara-alerts' \
+#     --from-literal=METRICS_TOKEN='...' \
+#     --from-literal=GRAFANA_ADMIN_PASSWORD='...'
 #
 # S3_* (BAK-3) are consumed ONLY by the prod-overlay backup CronJob (nightly
 # pg_dump -> S3-compatible upload). DigitalOcean Spaces is the intended target.
@@ -62,3 +64,11 @@ stringData:
   # and the same channel the Alertmanager→ntfy bridge (ALT-2) uses. Empty here;
   # populate out-of-band in prod. Server-side only — never commit a real value.
   ALERT_NTFY_URL: ""
+  # Bearer token the standalone monitoring stack (k8s/monitoring, OACT-1) presents
+  # when scraping the backend /metrics/ endpoint (MET-1). May be empty (the gate
+  # then accepts unauthenticated scrapes), but set it when METRICS_ENABLED=true so
+  # the in-cluster endpoint isn't openly scrapable. Consumed only by Prometheus.
+  METRICS_TOKEN: ""
+  # Grafana admin password for the OACT-3 Grafana deployment (k8s/monitoring).
+  # Consumed only by the operator-applied monitoring stack; empty here.
+  GRAFANA_ADMIN_PASSWORD: ""

--- a/k8s/monitoring/kustomization.yaml
+++ b/k8s/monitoring/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Standalone monitoring stack (Observability Activation, OACT-1..3).
+#
+# IMPORTANT — this kustomization is INTENTIONALLY NOT referenced by any overlay
+# (k8s/overlays/{qa,prod}). `deploy-prod` runs `kubectl apply -k
+# k8s/overlays/prod` on every push to qa; if the monitoring stack lived in the
+# prod overlay it would auto-deploy Prometheus/Alertmanager/Grafana onto the live
+# single-node droplet with no operator opt-in. Instead an operator deploys it
+# DELIBERATELY, when the droplet has headroom:
+#
+#   kubectl apply -k k8s/monitoring
+#
+# See docs/ops/monitoring-deploy.md (OACT-5) for prerequisites (METRICS_ENABLED,
+# the METRICS_TOKEN / ALERT_NTFY_URL / GRAFANA_ADMIN_PASSWORD secret keys) and the
+# end-to-end "is it live?" checklist.
+namespace: openshiksha-prod
+
+resources:
+  # OACT-1: Prometheus (scrape backend /metrics + load the ALT-1 alert rules).
+  # OACT-2 appends alertmanager.yaml; OACT-3 appends grafana.yaml.
+  - prometheus.yaml

--- a/k8s/monitoring/prometheus.yaml
+++ b/k8s/monitoring/prometheus.yaml
@@ -1,0 +1,276 @@
+# Prometheus for the OpenShiksha monitoring stack (Observability Activation, OACT-1).
+#
+# Scrapes the backend `/metrics/` endpoint (MET-1) and loads the ALT-1 alert
+# rules. Operator-applied via `kubectl apply -k k8s/monitoring` — NOT wired into
+# any overlay, so a push to qa never auto-deploys it. See the kustomization header
+# and docs/ops/monitoring-deploy.md (OACT-5).
+#
+# Prerequisites the operator provisions out-of-band (documented in OACT-5):
+#   * openshiksha-config ConfigMap: METRICS_ENABLED=true (the /metrics/ view is
+#     404 until then — backend/openshiksha/apps/api/views/metrics.py).
+#   * openshiksha-secrets Secret: METRICS_TOKEN (may be empty; if set, the scrape
+#     bearer below must carry it — it is mounted as a credentials file).
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  labels:
+    app: prometheus
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 30s
+      evaluation_interval: 30s
+
+    rule_files:
+      - /etc/prometheus/rules/openshiksha-alerts.yml
+
+    # OACT-2 fills in alerting.alertmanagers (http://alertmanager:9093). Until
+    # then the rules evaluate but fire nowhere — Prometheus alone makes the
+    # metrics live and queryable.
+    alerting:
+      alertmanagers: []
+
+    scrape_configs:
+      - job_name: openshiksha-backend
+        metrics_path: /metrics/
+        scheme: http
+        # The MET-1 gate accepts an optional bearer token. METRICS_TOKEN is
+        # mounted as a file from openshiksha-secrets (empty file == no token,
+        # which the endpoint also accepts). The job label `openshiksha-backend`
+        # is what the ALT-1 `up{job="openshiksha-backend"}` rule matches.
+        authorization:
+          type: Bearer
+          credentials_file: /etc/prometheus/secrets/metrics_token
+        static_configs:
+          - targets: ["backend:8000"]
+---
+# Verbatim copy of docs/ops/prometheus/openshiksha-alerts.yml (ALT-1). The canonical
+# source of truth stays in docs/ (validated by the `alerting-lint` CI job with
+# `promtool check rules`); this ConfigMap is the deployable copy. Keep the two in
+# sync — if you edit the rules, edit them there and re-copy here.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-rules
+  labels:
+    app: prometheus
+data:
+  openshiksha-alerts.yml: |
+    groups:
+      - name: openshiksha-backups
+        rules:
+          - alert: OpenShikshaBackupStale
+            expr: openshiksha_backup_age_seconds > 129600
+            for: 10m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Postgres backup is stale (>36h old)"
+              description: >-
+                The newest successful Postgres backup is
+                {{ $value | humanizeDuration }} old (threshold 36h). The nightly
+                backup CronJob has likely failed or stopped. Check the CronJob and run
+                the BAK-2 restore drill to confirm recoverability.
+
+          - alert: OpenShikshaBackupNeverRun
+            expr: (openshiksha_backup_last_success_timestamp == 0) or absent(openshiksha_backup_last_success_timestamp)
+            for: 6h
+            labels:
+              severity: critical
+            annotations:
+              summary: "No successful Postgres backup on record"
+              description: >-
+                No successful Postgres backup has ever been recorded (the
+                last-success timestamp is 0 or the gauge is absent for 6h). If this is
+                a fresh deployment, run a first backup; otherwise the backup path is
+                broken — check the CronJob, S3 creds, and BackupRun records.
+
+      - name: openshiksha-grading
+        rules:
+          - alert: OpenShikshaGradeQueueBacklog
+            expr: openshiksha_submissions_pending_grading > 50
+            for: 30m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Grading queue backlog (>50 pending for 30m)"
+              description: >-
+                {{ $value }} submissions have been awaiting a grade for over 30m
+                (threshold 50). Check the Celery worker and the grade_submission task —
+                the grading pipeline may be stalled or under-provisioned.
+
+          - alert: OpenShikshaCeleryOldestPending
+            expr: openshiksha_celery_oldest_pending_seconds > 900
+            for: 15m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Oldest pending Celery task >15m old"
+              description: >-
+                The oldest non-terminal Celery task is
+                {{ $value | humanizeDuration }} old (threshold 15m). Tasks are queuing
+                faster than the worker drains them — check worker health and concurrency.
+
+          - alert: OpenShikshaCeleryFailureRate
+            expr: >-
+              sum(openshiksha_celery_tasks{status="FAILURE"})
+              /
+              clamp_min(sum(openshiksha_celery_tasks), 1)
+              > 0.10
+            for: 15m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Celery task failure rate >10% (24h window)"
+              description: >-
+                {{ $value | humanizePercentage }} of Celery tasks in the last 24h are
+                in FAILURE (threshold 10%). Check the worker logs and the failing task
+                type. (Only has data under the django-db result backend — MET-3.)
+
+      - name: openshiksha-http
+        rules:
+          - alert: OpenShikshaHighHTTPErrorRate
+            expr: >-
+              sum(rate(openshiksha_http_requests_total{status_class="5xx"}[5m]))
+              /
+              clamp_min(sum(rate(openshiksha_http_requests_total[5m])), 0.001)
+              > 0.05
+            for: 10m
+            labels:
+              severity: critical
+            annotations:
+              summary: "HTTP 5xx error ratio >5%"
+              description: >-
+                {{ $value | humanizePercentage }} of HTTP responses in the last 5m are
+                5xx (threshold 5%). The backend is serving errors — check pod logs,
+                Sentry, and recent deploys.
+
+          - alert: OpenShikshaHighLatencyP95
+            expr: >-
+              histogram_quantile(
+                0.95,
+                sum(rate(openshiksha_http_request_duration_seconds_bucket[5m])) by (le)
+              ) > 1.5
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: "HTTP p95 latency >1.5s"
+              description: >-
+                p95 request latency is {{ $value | humanizeDuration }} over the last 5m
+                (threshold 1.5s). The backend is slow — check DB load, the grade queue,
+                and resource limits.
+
+      - name: openshiksha-availability
+        rules:
+          - alert: OpenShikshaTargetDown
+            expr: up{job="openshiksha-backend"} == 0
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Backend scrape target is down"
+              description: >-
+                Prometheus has been unable to scrape the openshiksha-backend target for
+                5m (up == 0). The /metrics endpoint — and likely the app — is
+                unreachable. Check the pod, readiness probe, and ingress.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  labels:
+    app: prometheus
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9090
+      targetPort: 9090
+      name: http
+  selector:
+    app: prometheus
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  labels:
+    app: prometheus
+spec:
+  replicas: 1
+  # Single-node droplet + an emptyDir TSDB → Recreate, never two pods contending
+  # for the same (ephemeral) volume.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v2.54.1
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            # 7d retention keeps the TSDB small on the droplet's local disk.
+            - --storage.tsdb.path=/prometheus
+            - --storage.tsdb.retention.time=7d
+            - --web.enable-lifecycle
+          ports:
+            - containerPort: 9090
+              name: http
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus/prometheus.yml
+              subPath: prometheus.yml
+            - name: rules
+              mountPath: /etc/prometheus/rules
+            - name: secrets
+              mountPath: /etc/prometheus/secrets
+              readOnly: true
+            - name: tsdb
+              mountPath: /prometheus
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 9090
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 9090
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+        - name: rules
+          configMap:
+            name: prometheus-rules
+        - name: secrets
+          secret:
+            secretName: openshiksha-secrets
+            # METRICS_TOKEN is optional; if the operator hasn't set it the file is
+            # simply absent and the scrape sends an empty bearer (also accepted).
+            optional: true
+            items:
+              - key: METRICS_TOKEN
+                path: metrics_token
+        - name: tsdb
+          emptyDir: {}


### PR DESCRIPTION
## Classification
**New / Infra** — Observability Activation, increment OACT-1.

## Summary
Packages the validated ALT-1 Prometheus alert rules into a **deployable, operator-applied** monitoring stack. The last four observability batches built the instrument panel; this batch plugs it in.

New `k8s/monitoring/` kustomization (standalone, **not** referenced by any overlay):
- **ConfigMap `prometheus-config`** — `prometheus.yml` scraping the `backend:8000` Service at `/metrics/` under job `openshiksha-backend` (the label `up{job="openshiksha-backend"}` in ALT-1 matches), 30s interval, `METRICS_TOKEN` presented via a mounted credentials file.
- **ConfigMap `prometheus-rules`** — verbatim copy of `docs/ops/prometheus/openshiksha-alerts.yml` (canonical source stays in `docs/`, still gated by `alerting-lint`/promtool).
- **Deployment `prometheus`** — pinned `prom/prometheus:v2.54.1`, 7d `emptyDir` TSDB (`--storage.tsdb.retention.time=7d`), requests 100m/256Mi, limits 500m/512Mi, `/-/ready` + `/-/healthy` probes.
- **Service `prometheus`** ClusterIP :9090.

`alerting.alertmanagers` is left empty here — **OACT-2** wires it to Alertmanager.

## Why standalone (not the prod overlay)
`deploy-prod` runs `kubectl apply -k k8s/overlays/prod` on **every push to `qa`**. If the monitoring stack lived in the prod overlay, merging it would auto-deploy Prometheus onto the live single-node droplet with no operator opt-in. Instead the operator runs `kubectl apply -k k8s/monitoring` deliberately, when the droplet has headroom.

## CI gate
Extends the `k8s-manifests` job with a step that renders `k8s/monitoring` and validates it with `kubeconform -strict` — a typo'd manifest key fails at PR time, not at `kubectl apply`.

## Verify
- `kubectl kustomize k8s/monitoring` renders (258 lines); both embedded ConfigMap block-scalars parse as valid YAML.
- `kubectl kustomize k8s/overlays/prod` and `.../qa` render unchanged (the overlays don't reference monitoring).
- Prerequisites for an operator (documented in OACT-5): `METRICS_ENABLED=true` in `openshiksha-config`, `METRICS_TOKEN` in `openshiksha-secrets` (added to `secret.example.yaml` here).

## Tests
Infra-only; validation is the CI kustomize+kubeconform gate plus the existing `alerting-lint` promtool checks on the canonical rules file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)