### PR TITLE
feat(obs): OACT-3 — Grafana provisioned with datasource + MET-5 dashboard

### DIFF
--- a/k8s/monitoring/grafana.yaml
+++ b/k8s/monitoring/grafana.yaml
@@ -1,0 +1,316 @@
+# Grafana for the OpenShiksha monitoring stack (Observability Activation, OACT-3).
+#
+# Provisioned with a Prometheus datasource (the OACT-1 prometheus:9090 Service)
+# and the MET-5 starter dashboard (docs/ops/grafana/openshiksha-overview.json),
+# both auto-loaded at startup. NO Ingress - reach it via:
+#
+#   kubectl -n openshiksha-prod port-forward svc/grafana 3000:3000
+#
+# Keeping Grafana off the public internet avoids a new attack surface on the live
+# droplet. Admin password comes from openshiksha-secrets (GRAFANA_ADMIN_PASSWORD).
+#
+# The dashboard JSON declares a `${DS_PROMETHEUS}` datasource input; file-based
+# provisioning doesn't resolve `__inputs`, so the provisioned datasource is marked
+# isDefault - panels with an unresolved datasource fall back to the default. Keep
+# the datasource uid fixed (`prometheus`) so it's stable across restarts.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  labels:
+    app: grafana
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        uid: prometheus
+        url: http://prometheus:9090
+        isDefault: true
+        editable: false
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards-provider
+  labels:
+    app: grafana
+data:
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: openshiksha
+        orgId: 1
+        type: file
+        disableDeletion: true
+        allowUiUpdates: false
+        options:
+          path: /var/lib/grafana/dashboards
+          foldersFromFilesStructure: false
+---
+# Verbatim copy of docs/ops/grafana/openshiksha-overview.json (MET-5). Canonical
+# source stays in docs/; this ConfigMap is the deployable copy auto-loaded by the
+# dashboard provider above - keep the two in sync.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-overview
+  labels:
+    app: grafana
+data:
+  openshiksha-overview.json: |
+    {
+      "__inputs": [
+        {
+          "name": "DS_PROMETHEUS",
+          "label": "Prometheus",
+          "description": "Prometheus datasource scraping the OpenShiksha backend /metrics endpoint.",
+          "type": "datasource",
+          "pluginId": "prometheus",
+          "pluginName": "Prometheus"
+        }
+      ],
+      "__requires": [
+        { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+        { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" }
+      ],
+      "annotations": { "list": [] },
+      "editable": true,
+      "graphTooltip": 0,
+      "schemaVersion": 39,
+      "tags": ["openshiksha", "observability"],
+      "templating": { "list": [] },
+      "time": { "from": "now-6h", "to": "now" },
+      "timezone": "",
+      "title": "OpenShiksha — Overview",
+      "uid": "openshiksha-overview",
+      "version": 1,
+      "panels": [
+        {
+          "id": 1,
+          "title": "Request rate (req/s)",
+          "type": "timeseries",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+          "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+              "expr": "sum(rate(openshiksha_http_requests_total[5m])) by (status_class)",
+              "legendFormat": "{{status_class}}"
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "title": "Request latency p95 (s)",
+          "type": "timeseries",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+          "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+              "expr": "histogram_quantile(0.95, sum(rate(openshiksha_http_request_duration_seconds_bucket[5m])) by (le, method))",
+              "legendFormat": "{{method}}"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "title": "Grade-queue depth",
+          "type": "stat",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "gridPos": { "h": 8, "w": 6, "x": 0, "y": 8 },
+          "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+              "expr": "openshiksha_submissions_pending_grading",
+              "legendFormat": "pending"
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "title": "Active assignments",
+          "type": "stat",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "gridPos": { "h": 8, "w": 6, "x": 6, "y": 8 },
+          "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+              "expr": "openshiksha_assignments_active",
+              "legendFormat": "active"
+            }
+          ]
+        },
+        {
+          "id": 5,
+          "title": "Celery failures (24h window)",
+          "type": "timeseries",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "gridPos": { "h": 8, "w": 6, "x": 12, "y": 8 },
+          "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+              "expr": "openshiksha_celery_tasks{status=\"FAILURE\"}",
+              "legendFormat": "failures"
+            }
+          ]
+        },
+        {
+          "id": 6,
+          "title": "Oldest pending Celery task (s)",
+          "type": "timeseries",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "gridPos": { "h": 8, "w": 6, "x": 18, "y": 8 },
+          "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+              "expr": "openshiksha_celery_oldest_pending_seconds",
+              "legendFormat": "oldest pending"
+            }
+          ]
+        },
+        {
+          "id": 7,
+          "title": "Process resident memory (RSS)",
+          "type": "timeseries",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+          "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+              "expr": "process_resident_memory_bytes",
+              "legendFormat": "RSS"
+            }
+          ]
+        },
+        {
+          "id": 8,
+          "title": "Build info",
+          "type": "table",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+              "expr": "openshiksha_build_info",
+              "format": "table",
+              "instant": true
+            }
+          ]
+        }
+      ]
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  labels:
+    app: grafana
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3000
+      targetPort: 3000
+      name: http
+  selector:
+    app: grafana
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  labels:
+    app: grafana
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:11.2.0
+          ports:
+            - containerPort: 3000
+              name: http
+          env:
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: openshiksha-secrets
+                  key: GRAFANA_ADMIN_PASSWORD
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "false"
+            - name: GF_SERVER_ROOT_URL
+              value: http://localhost:3000
+          volumeMounts:
+            - name: datasources
+              mountPath: /etc/grafana/provisioning/datasources
+              readOnly: true
+            - name: dashboards-provider
+              mountPath: /etc/grafana/provisioning/dashboards
+              readOnly: true
+            - name: dashboard-overview
+              mountPath: /var/lib/grafana/dashboards
+              readOnly: true
+            - name: grafana-data
+              mountPath: /var/lib/grafana
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+      volumes:
+        - name: datasources
+          configMap:
+            name: grafana-datasources
+        - name: dashboards-provider
+          configMap:
+            name: grafana-dashboards-provider
+        - name: dashboard-overview
+          configMap:
+            name: grafana-dashboard-overview
+        - name: grafana-data
+          emptyDir: {}

--- a/k8s/monitoring/kustomization.yaml
+++ b/k8s/monitoring/kustomization.yaml
@@ -22,4 +22,5 @@ resources:
   - prometheus.yaml
   # OACT-2: Alertmanager + ntfy-bridge sidecar (routes the ALT-1 alerts to ntfy).
   - alertmanager.yaml
-  # OACT-3 appends grafana.yaml.
+  # OACT-3: Grafana provisioned with the Prometheus datasource + MET-5 dashboard.
+  - grafana.yaml


### PR DESCRIPTION
## Classification
**New / Infra** — Observability Activation, increment OACT-3. **Stacked on OACT-2 ([#489](https://github.com/openshiksha/openshiksha/pull/489)) → OACT-1 ([#488](https://github.com/openshiksha/openshiksha/pull/488))**; retarget to `qa` after the parents merge.

## Summary
Completes the standalone `k8s/monitoring/` stack with Grafana, finishing the Observability Activation deployment surface.

- **ConfigMap `grafana-datasources`** — provisions a Prometheus datasource at `http://prometheus:9090` (fixed `uid: prometheus`, `isDefault: true`).
- **ConfigMap `grafana-dashboards-provider`** — file provider pointing at `/var/lib/grafana/dashboards`.
- **ConfigMap `grafana-dashboard-overview`** — verbatim `docs/ops/grafana/openshiksha-overview.json` (MET-5, 8 panels), auto-loaded.
- **Deployment `grafana`** — `grafana/grafana:11.2.0`, anonymous auth off, admin password from `openshiksha-secrets` (`GRAFANA_ADMIN_PASSWORD`), `emptyDir` for `/var/lib/grafana`.
- **Service `grafana`** ClusterIP :3000 — **no Ingress**.

## Access (no public ingress)
```
kubectl -n openshiksha-prod port-forward svc/grafana 3000:3000
```
Keeping Grafana off the public internet avoids a new attack surface on the live droplet.

## Datasource binding
The dashboard JSON declares a `${DS_PROMETHEUS}` input. File-based provisioning doesn't resolve `__inputs`, so the provisioned datasource is marked `isDefault` and panels with the unresolved reference fall back to it — standard for provisioned community dashboards.

## Verify
- `kubectl kustomize k8s/monitoring` renders (835 lines, 14 resources); the embedded dashboard parses as JSON (title + 8 panels) and both provisioning YAMLs parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)