### PR TITLE
feat(obs): OACT-4 — wire record_backup_run into the nightly backup CronJob

### DIFF
--- a/k8s/overlays/prod/backup-cronjob.yaml
+++ b/k8s/overlays/prod/backup-cronjob.yaml
@@ -8,6 +8,20 @@
 # The four S3_* keys are documented in k8s/base/secret.example.yaml and populated
 # out-of-band into the openshiksha-secrets Secret (DigitalOcean Spaces is the
 # intended S3-compatible target). DATABASE_URL is the existing key.
+#
+# OACT-4 (Observability Activation): the pod is now two-phase so the
+# openshiksha_backup_age_seconds freshness gauge (BAK-4 / MET-2) actually
+# populates in prod. The backup image has no Django, so it can't write a
+# BackupRun row itself:
+#   * initContainer `backup` runs the real pg_dump→S3 (unchanged image/env) and,
+#     on success, writes /work/result.env (STATUS/SIZE/KEY) to a shared emptyDir.
+#   * main container `record` (the backend image, which HAS Django) reads that
+#     file and runs `manage.py record_backup_run ... || true`.
+# initContainers run to completion before the main container, so the sequencing is
+# free. The `|| true` guarantees the record step can NEVER fail the backup — a
+# missing gauge update is strictly better than a broken backup. A FAILED backup
+# fails the init phase (no record written); the OpenShikshaBackupStale/NeverRun
+# alerts cover that case via the gauge going stale.
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -28,7 +42,13 @@ spec:
             app: postgres-backup
         spec:
           restartPolicy: OnFailure
-          containers:
+          volumes:
+            # Shared between the backup init phase (writes result.env) and the
+            # record main container (reads it). Ephemeral — only needs to live for
+            # the pod's lifetime.
+            - name: backup-result
+              emptyDir: {}
+          initContainers:
             - name: backup
               image: ghcr.io/openshiksha/openshiksha-backup:prod
               env:
@@ -59,10 +79,48 @@ spec:
                       key: S3_SECRET_KEY
                 - name: RETENTION_DAYS
                   value: "14"
+                # OACT-4: pg_backup.sh writes STATUS/SIZE/KEY here on success.
+                - name: RESULT_FILE
+                  value: /work/result.env
+              volumeMounts:
+                - name: backup-result
+                  mountPath: /work
               resources:
                 requests:
                   cpu: 50m
                   memory: 64Mi
+                limits:
+                  cpu: 500m
+                  memory: 256Mi
+          containers:
+            # Records the BackupRun row that drives openshiksha_backup_age_seconds.
+            # Uses the backend image (it has Django + the management command); the
+            # backup image does not. Best-effort: `|| true` so it can never fail the
+            # already-completed backup.
+            - name: record
+              image: ghcr.io/openshiksha/openshiksha-backend:prod
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -a
+                  [ -f /work/result.env ] && . /work/result.env
+                  set +a
+                  python manage.py record_backup_run \
+                    --status "${STATUS:-success}" \
+                    --size "${SIZE:-0}" \
+                    --key "${KEY:-}" || true
+              envFrom:
+                - configMapRef:
+                    name: openshiksha-config
+                - secretRef:
+                    name: openshiksha-secrets
+              volumeMounts:
+                - name: backup-result
+                  mountPath: /work
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
                 limits:
                   cpu: 500m
                   memory: 256Mi

--- a/scripts/backup/pg_backup.sh
+++ b/scripts/backup/pg_backup.sh
@@ -47,6 +47,18 @@ S3_PREFIX="${S3_PREFIX:-postgres/}"
 RETENTION_DAYS="${RETENTION_DAYS:-14}"
 S3_ENDPOINT="${S3_ENDPOINT:-}"
 
+# Optional BAK-4 hand-off: when RESULT_FILE is set (the prod CronJob's two-phase
+# pod, OACT-4), write the outcome to a shared file so the sibling `record`
+# container can persist a BackupRun row that populates the
+# openshiksha_backup_age_seconds freshness gauge. Best-effort and only on the
+# success path — a failed backup exits non-zero before this runs (set -e), so the
+# init phase fails the pod and the staleness alert covers it. Never fails the backup.
+RESULT_FILE="${RESULT_FILE:-}"
+write_result() {
+    [[ -n "$RESULT_FILE" ]] || return 0
+    printf 'STATUS=%s\nSIZE=%s\nKEY=%s\n' "$1" "${2:-}" "${3:-}" > "$RESULT_FILE" || true
+}
+
 # --- Resolve DB connection -------------------------------------------------
 # pg_dump reads PG* env vars natively; if DATABASE_URL is given, pg_dump accepts
 # a connection URI as a positional argument, so we never have to parse it
@@ -78,6 +90,7 @@ log "Dump complete: ${SIZE_BYTES} bytes"
 # --- Local mode: stop here -------------------------------------------------
 if [[ -z "$S3_ENDPOINT" ]]; then
     log "S3_ENDPOINT unset → LOCAL MODE: dump kept at ${DUMP_FILE} (no upload)."
+    write_result success "$SIZE_BYTES" "$DUMP_FILE"
     echo "$DUMP_FILE"
     exit 0
 fi
@@ -104,4 +117,5 @@ mc rm --recursive --force --older-than "${RETENTION_DAYS}d" \
     log "WARN: prune step reported a non-fatal error (continuing)."
 
 log "Backup OK: ${OBJECT_KEY} (${SIZE_BYTES} bytes)"
+write_result success "$SIZE_BYTES" "$OBJECT_KEY"
 echo "$OBJECT_KEY"


### PR DESCRIPTION
## Classification
**Improve / Infra** — Observability Activation, increment OACT-4. **Independent of OACT-1..3** (base `qa`).

## Summary
The `record_backup_run` command and `openshiksha_backup_age_seconds` gauge already exist and are tested — but **nothing calls the command in prod**, so the gauge always reads the no-data sentinel. The backup image (`postgres:15-alpine` + `mc`) has **no Django**, so it can't record the run itself.

Restructures the prod backup pod into two phases:
- **initContainer `backup`** — the existing `openshiksha-backup:prod` container (same env), now also writing `/work/result.env` (`STATUS`/`SIZE`/`KEY`) to a shared `emptyDir` on success.
- **main container `record`** — the `openshiksha-backend:prod` image (it has Django), sources that file and runs `python manage.py record_backup_run --status … --size … --key … || true`.

`pg_backup.sh` gains an opt-in `RESULT_FILE` write (best-effort, success path only — a failed backup exits non-zero before it under `set -e`).

## Safety
- initContainers run to completion before the main container → free sequencing, no race.
- `|| true` means the record step **can never fail the backup** — a missing gauge update is strictly better than a broken backup.
- A **failed** backup fails the init phase (no record written); `OpenShikshaBackupStale`/`NeverRun` cover that via the gauge going stale.
- **This file auto-deploys on the next `qa` push** (prod overlay). Blast radius is the nightly backup pod only, and the record step is non-fatal by construction.

## Verify
- `kubectl kustomize k8s/overlays/prod` renders; CronJob now has `initContainers: [backup]`, `containers: [record]`, shared volume `backup-result`.
- `kubectl kustomize k8s/overlays/qa` is **byte-for-byte unchanged** (prod-only file).
- `bash -n scripts/backup/pg_backup.sh` passes.
- `pytest backend/.../core/tests/test_metrics_backup.py` → **5 passed** (command/gauge unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)