### PR TITLE
fix(obs): exempt /metrics/ from HTTPS redirect so Prometheus can scrape it

### DIFF
--- a/backend/openshiksha/settings/production.py
+++ b/backend/openshiksha/settings/production.py
@@ -20,6 +20,14 @@ SECURE_SSL_REDIRECT = True
 # SECURE_SSL_REDIRECT triggers an infinite redirect loop. Only safe when the
 # ingress strips this header from client input (Traefik does by default).
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+# Prometheus (OACT-1) scrapes /metrics/ in-cluster over plain HTTP — TLS
+# terminates at the ingress, not at the backend pod, and the ingress does not
+# route /metrics/ at all. Without an exemption SECURE_SSL_REDIRECT 301s that
+# scrape to https://backend:8000, which serves no TLS, so the scrape fails with
+# a timeout. Exempt the token-gated metrics path (the value is matched against
+# the path with its leading slash stripped). Only reachable in-cluster, so this
+# does not widen any public surface.
+SECURE_REDIRECT_EXEMPT = [r"^metrics/$"]
 SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
 SECURE_BROWSER_XSS_FILTER = True

--- a/k8s/overlays/prod/configmap-patch.yaml
+++ b/k8s/overlays/prod/configmap-patch.yaml
@@ -9,3 +9,8 @@ data:
   # In-cluster base URL the ALT-3 uptime probe curls (/healthz/ + /readyz/).
   # Non-secret Service DNS; the ntfy URL it pushes to is in openshiksha-secrets.
   PROBE_BASE_URL: http://backend:8000
+  # Expose the Prometheus /metrics/ endpoint (MET-1) so the OACT-1 monitoring
+  # stack can scrape it. The endpoint is token-gated by METRICS_TOKEN (in
+  # openshiksha-secrets). Declared here so deploy-prod (kubectl apply -k
+  # overlays/prod on every qa push) keeps it enabled rather than dropping it.
+  METRICS_ENABLED: "true"


### PR DESCRIPTION
## Summary
Makes the OACT-1 Prometheus scrape of the backend actually succeed in prod.

**Found live while deploying the monitoring stack to the droplet:** the scrape target `http://backend:8000/metrics/` is `health=down` with `Get "https://backend:8000/metrics/": context deadline exceeded`. Cause: `production.py` sets `SECURE_SSL_REDIRECT=True` + `SECURE_PROXY_SSL_HEADER`, so a plain-HTTP request without `X-Forwarded-Proto: https` is 301'd to `https://backend:8000` — which serves no TLS (TLS terminates at the ingress). Prometheus can't add custom request headers, and the ingress doesn't route `/metrics/`, so the scrape can only work in-cluster over HTTP.

## Fix
- `SECURE_REDIRECT_EXEMPT = [r"^metrics/$"]` in `production.py` — exempts only the token-gated metrics path from the redirect. Reachable in-cluster only (ingress doesn't route it), so no public surface is widened.
- Pin `METRICS_ENABLED: "true"` in `k8s/overlays/prod/configmap-patch.yaml` so `deploy-prod` (`kubectl apply -k overlays/prod` on every qa push) keeps the endpoint enabled instead of dropping the value I set out-of-band.

## Verify
- `/metrics/` returns 200 with the bearer token, 403 without (already confirmed live).
- Prod settings load with `SECURE_REDIRECT_EXEMPT == ['^metrics/$']`.
- `kubectl kustomize k8s/overlays/prod` carries `METRICS_ENABLED: "true"`.
- After this deploys, the Prometheus target flips to `health=up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)