### PR TITLE
feat(obs): expose Grafana at openshiksha.org/grafana (login-gated sub-path)

### DIFF
--- a/k8s/monitoring/grafana.yaml
+++ b/k8s/monitoring/grafana.yaml
@@ -267,8 +267,15 @@ spec:
                   key: GRAFANA_ADMIN_PASSWORD
             - name: GF_AUTH_ANONYMOUS_ENABLED
               value: "false"
+            # Served behind the ingress at https://openshiksha.org/grafana
+            # (prod ingress routes /grafana → this Service). serve_from_sub_path
+            # makes Grafana emit asset/redirect URLs under the /grafana prefix so
+            # it works without a strip-prefix middleware. Login-gated (anonymous
+            # off, admin password from the Secret).
             - name: GF_SERVER_ROOT_URL
-              value: http://localhost:3000
+              value: https://openshiksha.org/grafana
+            - name: GF_SERVER_SERVE_FROM_SUB_PATH
+              value: "true"
           volumeMounts:
             - name: datasources
               mountPath: /etc/grafana/provisioning/datasources

--- a/k8s/overlays/prod/ingress-patch.yaml
+++ b/k8s/overlays/prod/ingress-patch.yaml
@@ -34,6 +34,17 @@ spec:
                 name: backend
                 port:
                   number: 8000
+          # Grafana (OACT-3 monitoring stack), served at /grafana. Login-gated;
+          # Grafana serves from this sub-path (GF_SERVER_SERVE_FROM_SUB_PATH=true)
+          # so no strip-prefix middleware is needed. The grafana Service only
+          # exists once an operator applies k8s/monitoring; until then /grafana 503s.
+          - path: /grafana
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana
+                port:
+                  number: 3000
           - path: /
             pathType: Prefix
             backend:


### PR DESCRIPTION
## Summary
Makes the OACT-3 Grafana reachable at **https://openshiksha.org/grafana** so you don't need a port-forward.

- **`k8s/overlays/prod/ingress-patch.yaml`** — routes `/grafana` (apex host) → `grafana:3000`.
- **`k8s/monitoring/grafana.yaml`** — `GF_SERVER_ROOT_URL=https://openshiksha.org/grafana` + `GF_SERVER_SERVE_FROM_SUB_PATH=true` so Grafana emits asset/redirect URLs under the sub-path (no strip-prefix middleware needed).

## Security
Anonymous auth stays **off**; the admin password comes from `openshiksha-secrets`. The only new public surface is a login page (reuses the existing apex TLS cert — no new DNS/cert).

## Deploy notes
- The ingress patch is in the prod overlay → auto-deploys on merge (`deploy-prod`).
- The `grafana.yaml` env change is in `k8s/monitoring` (operator-applied) → I'll re-apply it live on the droplet so the running pod picks up the sub-path config.
- The `grafana` Service only exists once `k8s/monitoring` is applied (it is, on prod), so `/grafana` resolves; on a cluster without the stack it 503s harmlessly.

## Verify
- `kubectl kustomize k8s/overlays/prod` renders with the `/grafana` path; `k8s/monitoring` still renders.
- After deploy: `https://openshiksha.org/grafana` shows the Grafana login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)