### PR TITLE
ci: retarget deploy-qa job off deleted `modernization` branch

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -546,18 +546,24 @@ jobs:
     # ─── Deploy to QA env ────────────────────────────────────────────────────
     # DISABLED for now: there is no dedicated qa cluster yet. The single droplet
     # currently serves the PROD env, deployed from the `qa` branch (see deploy-prod
-    # below). The wiring here is a stale future-state sketch — it still triggers on
-    # the retired `modernization` branch, so the `if` below can never match. Before
-    # activating, decide which branch should feed a dedicated qa env (the old
-    # modernization -> qa flow no longer exists) and update the trigger. Gated off
-    # by the `QA_ENV_ENABLED` repo variable (currently unset, so this job never
-    # runs). To activate: provision a qa cluster + its `openshiksha-qa` secret,
-    # fix the branch trigger, then set the repo Actions variable QA_ENV_ENABLED=true.
+    # below), so no branch feeds a separate qa env today. This job is a future-state
+    # sketch of the wiring, kept as the reference implementation.
+    #
+    # Activation is fully config-driven so nothing here has to be edited (and no
+    # dead branch name is hard-coded — the trigger used to name the retired
+    # `modernization` branch, which no longer exists):
+    #   1. Provision a qa cluster + its `openshiksha-qa` secret.
+    #   2. Set repo Actions variable `QA_ENV_BRANCH` to the branch that should feed
+    #      qa (must differ from `qa`, which deploys to prod).
+    #   3. Set repo Actions variable `QA_ENV_ENABLED=true`.
+    # Both variables are unset today, so the `if` below can never match and the job
+    # never runs. `QA_ENV_BRANCH` unset ⇒ the ref compares against `refs/heads/`,
+    # which is never a real ref, so `QA_ENV_ENABLED` alone can't fire a deploy.
     deploy-qa:
         name: Deploy to QA Cluster
         timeout-minutes: 15
         needs: build-publish
-        if: github.ref == 'refs/heads/modernization' && vars.QA_ENV_ENABLED == 'true'
+        if: github.ref == format('refs/heads/{0}', vars.QA_ENV_BRANCH) && vars.QA_ENV_ENABLED == 'true'
         runs-on: ubuntu-latest
         environment: qa
         steps:

--- a/README.md
+++ b/README.md
@@ -147,7 +147,9 @@ feature/*  ──PR──▶  qa  ──(CI builds + deploys)──▶  producti
   the images and **deploys to production** (`openshiksha.org`) automatically, so
   it stays green and reviewed at all times.
 - A dedicated **qa environment** is wired but disabled until a second cluster
-  exists — see the `deploy-qa` job, gated behind the `QA_ENV_ENABLED` variable.
+  exists — see the `deploy-qa` job. Activation is config-driven: set the
+  `QA_ENV_BRANCH` (the branch that feeds qa) and `QA_ENV_ENABLED` repo variables;
+  both are unset today, so the job never runs.
 
 Deployment specifics (k3s, kustomize overlays, secrets, TLS, rollback) are in
 [`docs/deploy/README.md`](docs/deploy/README.md).

--- a/docs/changes/2026-06-30-deploy-qa-dead-branch-ref.md
+++ b/docs/changes/2026-06-30-deploy-qa-dead-branch-ref.md
@@ -1,0 +1,55 @@
+# Retarget the `deploy-qa` CI job off the deleted `modernization` branch
+
+**Date:** 2026-06-30
+**Type:** infra hygiene / drift-safety (CI)
+
+## Problem
+
+The `modernization` branch was squash-merged into `qa` and **deleted** when the
+modern stack became the trunk. The dead-branch cleanup done in
+[#440](https://github.com/openshiksha/openshiksha/pull/440) (CI/Dependabot
+*triggers*) and [#487](https://github.com/openshiksha/openshiksha/pull/487)
+(contributor docs) left one known reference behind: the `deploy-qa` job in
+`ci-cd.yaml` still gated on `refs/heads/modernization`.
+
+```yaml
+if: github.ref == 'refs/heads/modernization' && vars.QA_ENV_ENABLED == 'true'
+```
+
+`#487` deferred it on purpose to keep that change docs-only and atomic (see its
+"Out of scope" note). It is harmless today — the job is double-gated behind the
+unset `QA_ENV_ENABLED` variable, so it never runs — but the condition references
+a branch that can never exist again, which reads as broken to anyone who tries to
+activate it. This closes that last `modernization` reference in `.github/`.
+
+## What changed
+
+- **`.github/workflows/ci-cd.yaml`** — the `deploy-qa` trigger no longer
+  hard-codes a branch name. Activation is now config-driven via a new
+  `QA_ENV_BRANCH` repo variable:
+
+  ```yaml
+  if: github.ref == format('refs/heads/{0}', vars.QA_ENV_BRANCH) && vars.QA_ENV_ENABLED == 'true'
+  ```
+
+  The surrounding comment block is rewritten to document the three-step
+  activation (provision a qa cluster + secret → set `QA_ENV_BRANCH` → set
+  `QA_ENV_ENABLED=true`).
+- **`README.md`** — the branch-model note now mentions the `QA_ENV_BRANCH`
+  variable alongside `QA_ENV_ENABLED`.
+
+## Behaviour (unchanged — the job still never runs)
+
+Both `QA_ENV_BRANCH` and `QA_ENV_ENABLED` are unset in the repo. With
+`QA_ENV_BRANCH` unset, `format('refs/heads/{0}', '')` renders `refs/heads/`,
+which is never a real ref, so the branch comparison can never be true — and
+`QA_ENV_ENABLED` remains a second independent gate. The job is exactly as
+disabled as before, now without naming a deleted branch. No other job depends on
+`deploy-qa` (`build-publish`/`deploy-prod` do not `needs:` it), so nothing else
+is affected. `actionlint` validates the workflow in the `workflow-lint` job.
+
+## Why not delete the job instead
+
+`README.md` and `docs/deploy/README.md` both cite `deploy-qa` as the reference
+wiring for a future dedicated qa cluster. Repairing it (rather than deleting it)
+preserves that documented scaffolding while removing the drift.


### PR DESCRIPTION
## What

The `deploy-qa` job in `ci-cd.yaml` still gated on `refs/heads/modernization` — a branch **deleted** when the modern stack became the `qa` trunk. It's the last `modernization` reference left in `.github/`.

```yaml
# before
if: github.ref == 'refs/heads/modernization' && vars.QA_ENV_ENABLED == 'true'
# after
if: github.ref == format('refs/heads/{0}', vars.QA_ENV_BRANCH) && vars.QA_ENV_ENABLED == 'true'
```

Activation is now **config-driven** via a new `QA_ENV_BRANCH` repo variable instead of a hard-coded branch name, and the surrounding comment block documents the three-step activation.

## Why

`#440` cleaned the CI/Dependabot *triggers* off `modernization` and `#487` cleaned the contributor *docs*, but [#487 explicitly deferred](https://github.com/openshiksha/openshiksha/blob/qa/docs/changes/2026-06-29-branch-model-docs-qa-trunk.md) this job to keep that PR docs-only. This closes it. The condition named a branch that can never exist again, which reads as broken to anyone trying to activate the job.

## Behaviour — unchanged (job still never runs)

Both `QA_ENV_BRANCH` and `QA_ENV_ENABLED` are unset. With `QA_ENV_BRANCH` unset, `format('refs/heads/{0}', '')` → `refs/heads/`, never a real ref, so the branch gate can never be true — and `QA_ENV_ENABLED` remains a second independent gate. No job `needs:` `deploy-qa`, so nothing else is affected. `actionlint` (workflow-lint job) validates the expression.

Repaired rather than deleted because `README.md` and `docs/deploy/README.md` cite `deploy-qa` as the reference wiring for a future dedicated qa cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)