### PR TITLE
test(obs): OACT-6 — manifest-vs-docs parity guard for monitoring stack

### DIFF
--- a/backend/openshiksha/apps/core/tests/test_monitoring_manifest_parity.py
+++ b/backend/openshiksha/apps/core/tests/test_monitoring_manifest_parity.py
@@ -1,0 +1,105 @@
+"""OACT-6 — Manifest-vs-docs parity guard for the monitoring stack.
+
+Two safety-critical artifacts are embedded **verbatim** inside the deployable
+`k8s/monitoring/` manifests, each a hand-maintained copy of a canonical source
+under `docs/ops/`:
+
+  * `k8s/monitoring/prometheus.yaml` → ConfigMap ``prometheus-rules`` embeds
+    ``docs/ops/prometheus/openshiksha-alerts.yml`` (the ALT-1 alert rules).
+  * `k8s/monitoring/grafana.yaml` → ConfigMap ``grafana-dashboard-overview``
+    embeds ``docs/ops/grafana/openshiksha-overview.json`` (the MET-5 dashboard).
+
+The only thing keeping them in sync today is a "keep the two in sync" comment.
+Edit one, forget the other, and the `alerting-lint` CI job (which lints the
+`docs/` copy) still passes while the **deployed** rules are stale — the classic
+observability failure where the alarm you think you changed didn't change.
+
+This is a pure file-parsing test (no DB, no Django models) that lives in the
+test suite purely so it runs in CI for free. It compares **parsed structure**
+(dicts/lists), not raw bytes, so the indentation/quoting the block-scalar embed
+introduces is tolerated while any real content drift fails loudly.
+
+Mirrors the existing repo parity idioms (widget-schema vendoring parity in
+``test_widget_fields.py``; the LA i18n key-parity guard).
+"""
+
+import json
+from pathlib import Path
+
+import yaml
+
+# tests/test_monitoring_manifest_parity.py -> repo root is parents[5]:
+#   [0]=tests [1]=core [2]=apps [3]=openshiksha [4]=backend [5]=<repo root>
+REPO_ROOT = Path(__file__).resolve().parents[5]
+
+
+def _load_configmap_data(manifest_path: Path, configmap_name: str, data_key: str) -> str:
+    """Return ``data[data_key]`` of the ConfigMap named ``configmap_name`` from a
+    multi-document YAML manifest, or fail with a clear message."""
+    docs = list(yaml.safe_load_all(manifest_path.read_text(encoding="utf-8")))
+    for doc in docs:
+        if (
+            isinstance(doc, dict)
+            and doc.get("kind") == "ConfigMap"
+            and doc.get("metadata", {}).get("name") == configmap_name
+        ):
+            data = doc.get("data") or {}
+            assert data_key in data, f"ConfigMap {configmap_name!r} in {manifest_path} has no data key {data_key!r}"
+            return data[data_key]
+    raise AssertionError(f"no ConfigMap named {configmap_name!r} found in {manifest_path}")
+
+
+class TestMonitoringManifestParity:
+    """The artifacts embedded in the deployable manifests must match their
+    canonical ``docs/ops/`` sources by parsed structure."""
+
+    def test_alert_rules_embed_matches_canonical_source(self):
+        manifest = REPO_ROOT / "k8s" / "monitoring" / "prometheus.yaml"
+        canonical = REPO_ROOT / "docs" / "ops" / "prometheus" / "openshiksha-alerts.yml"
+
+        embedded_raw = _load_configmap_data(manifest, "prometheus-rules", "openshiksha-alerts.yml")
+        embedded = yaml.safe_load(embedded_raw)
+        source = yaml.safe_load(canonical.read_text(encoding="utf-8"))
+
+        assert embedded == source, (
+            "The alert rules embedded in k8s/monitoring/prometheus.yaml "
+            "(ConfigMap prometheus-rules) have drifted from the canonical source "
+            "docs/ops/prometheus/openshiksha-alerts.yml. Re-copy the canonical "
+            "rules into the manifest ConfigMap."
+        )
+
+    def test_dashboard_embed_matches_canonical_source(self):
+        manifest = REPO_ROOT / "k8s" / "monitoring" / "grafana.yaml"
+        canonical = REPO_ROOT / "docs" / "ops" / "grafana" / "openshiksha-overview.json"
+
+        embedded_raw = _load_configmap_data(manifest, "grafana-dashboard-overview", "openshiksha-overview.json")
+        embedded = json.loads(embedded_raw)
+        source = json.loads(canonical.read_text(encoding="utf-8"))
+
+        assert embedded == source, (
+            "The Grafana dashboard embedded in k8s/monitoring/grafana.yaml "
+            "(ConfigMap grafana-dashboard-overview) has drifted from the canonical "
+            "source docs/ops/grafana/openshiksha-overview.json. Re-copy the "
+            "canonical dashboard JSON into the manifest ConfigMap."
+        )
+
+    def test_embedded_copies_are_non_empty_and_parse(self):
+        """A truncated paste must fail loudly rather than silently comparing empty."""
+        rules_raw = _load_configmap_data(
+            REPO_ROOT / "k8s" / "monitoring" / "prometheus.yaml",
+            "prometheus-rules",
+            "openshiksha-alerts.yml",
+        )
+        dashboard_raw = _load_configmap_data(
+            REPO_ROOT / "k8s" / "monitoring" / "grafana.yaml",
+            "grafana-dashboard-overview",
+            "openshiksha-overview.json",
+        )
+
+        rules = yaml.safe_load(rules_raw)
+        assert isinstance(rules, dict) and rules.get("groups"), "embedded alert rules parsed empty / missing 'groups'"
+
+        dashboard = json.loads(dashboard_raw)
+        assert isinstance(dashboard, dict) and dashboard.get(
+            "panels"
+        ), "embedded Grafana dashboard parsed empty / missing 'panels'"

--- a/docs/changes/2026-06-30-oact6-manifest-parity-guard.md
+++ b/docs/changes/2026-06-30-oact6-manifest-parity-guard.md
@@ -1,0 +1,57 @@
+# OACT-6 — Manifest-vs-docs parity guard
+
+**Date:** 2026-06-30
+**Initiative:** Observability Activation (Batch 2 — durability & drift-safety)
+**Classification:** New (test / CI guard)
+
+## Summary
+
+The deployable `k8s/monitoring/` manifests embed two safety-critical artifacts
+**verbatim**, each a hand-maintained copy of a canonical source under `docs/ops/`:
+
+- `k8s/monitoring/prometheus.yaml` → ConfigMap `prometheus-rules` embeds
+  `docs/ops/prometheus/openshiksha-alerts.yml` (the ALT-1 alert rules).
+- `k8s/monitoring/grafana.yaml` → ConfigMap `grafana-dashboard-overview` embeds
+  `docs/ops/grafana/openshiksha-overview.json` (the MET-5 dashboard).
+
+Until now the only thing keeping them in sync was a "keep the two in sync"
+comment. Editing the `docs/` copy while forgetting the manifest (or vice versa)
+leaves `alerting-lint` green — it lints the `docs/` source — while the
+**deployed** alarm is stale. That is the classic observability failure: the alert
+you think you changed didn't change.
+
+This adds a pytest that fails CI on any such drift.
+
+## What changed
+
+- New `backend/openshiksha/apps/core/tests/test_monitoring_manifest_parity.py`:
+  - `test_alert_rules_embed_matches_canonical_source` — parses the embedded
+    `prometheus-rules` ConfigMap data and the canonical YAML, asserts structural
+    equality.
+  - `test_dashboard_embed_matches_canonical_source` — same shape for the Grafana
+    dashboard JSON.
+  - `test_embedded_copies_are_non_empty_and_parse` — a truncated paste fails
+    loudly (`groups` / `panels` must be present).
+
+## Why parsed structure, not byte match
+
+The block-scalar embed reflows indentation and quoting, so a raw byte compare
+would be brittle and produce false failures. Comparing `yaml.safe_load` /
+`json.loads` output tolerates cosmetic reformatting while still catching any real
+content drift (a changed threshold, a renamed alert, a dropped panel).
+
+## Tests
+
+- 3 tests, all passing.
+- Prove-it-fails: temporarily changed a threshold in the manifest ConfigMap
+  (`> 129600` → `> 999999`); the rules-parity test went red with the actionable
+  "re-copy the canonical rules" message; reverted and it passed again.
+
+## Migration notes
+
+None — pure file-parsing test, no DB, no models, no manifest changes.
+
+## Next steps
+
+- OACT-8 will add a `MonitoringTargetDown` rule to the canonical source and
+  re-copy it into the manifest; this guard now enforces that re-copy.


### PR DESCRIPTION
## Classification
**New** (test / CI guard) — Observability Activation, Batch 2 (durability & drift-safety).

## Problem
`k8s/monitoring/prometheus.yaml` (ConfigMap `prometheus-rules`) and
`k8s/monitoring/grafana.yaml` (ConfigMap `grafana-dashboard-overview`) embed the
ALT-1 alert rules and MET-5 dashboard **verbatim** from their canonical sources
under `docs/ops/`. The only thing keeping the copies in sync was a "keep the two
in sync" comment. Edit the `docs/` copy and forget the manifest (or vice versa),
and `alerting-lint` stays green (it lints the `docs/` source) while the
**deployed** alarm is stale — the classic observability failure.

## Change
New `backend/openshiksha/apps/core/tests/test_monitoring_manifest_parity.py`:
- `test_alert_rules_embed_matches_canonical_source` — structural (parsed) equality
  of the embedded rules vs `docs/ops/prometheus/openshiksha-alerts.yml`.
- `test_dashboard_embed_matches_canonical_source` — same for the Grafana dashboard JSON.
- `test_embedded_copies_are_non_empty_and_parse` — a truncated paste fails loudly.

Compares parsed structure (not raw bytes) so the block-scalar embed's
indentation/quoting is tolerated while real content drift fails.

## Legacy reference
None — new guard. Mirrors the existing repo parity idioms (widget-schema
vendoring parity in `test_widget_fields.py`; the LA i18n key-parity guard).

## Tests
3 tests, all passing. Prove-it-fails: temporarily changed a manifest threshold
(`> 129600` → `> 999999`) → rules-parity test went red with an actionable
"re-copy the canonical rules" message → reverted → green.

## How to verify
`pytest backend/openshiksha/apps/core/tests/test_monitoring_manifest_parity.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)