### PR TITLE
docs(obs): OACT-7 — reconcile stale Grafana access docs with #494 ingress

### DIFF
--- a/docs/changes/2026-06-30-oact7-grafana-access-docs.md
+++ b/docs/changes/2026-06-30-oact7-grafana-access-docs.md
@@ -1,0 +1,42 @@
+# OACT-7 — Reconcile stale Grafana access docs
+
+**Date:** 2026-06-30
+**Initiative:** Observability Activation (Batch 2 — durability & drift-safety)
+**Classification:** Docs (reconciliation)
+
+## Summary
+
+`#494` gave Grafana a real public ingress route (`openshiksha.org/grafana`,
+login-gated, served from a sub-path), but two operator-facing docs still claimed
+the opposite — "NO Ingress — reach it via port-forward". An operator reading them
+would port-forward and never discover the public sub-path. Stale ops docs during
+a live bring-up are how mistakes happen.
+
+## What changed
+
+- **`k8s/monitoring/grafana.yaml` header** — replaced the "NO Ingress / keep it
+  off the public internet" block with the real access model: primary access is
+  the login-gated `openshiksha.org/grafana` sub-path via the prod-overlay ingress
+  (`k8s/overlays/prod/ingress-patch.yaml`); port-forward is now the **fallback**.
+  Mirrors the ingress patch's own caveat that the `grafana` Service only exists
+  once `k8s/monitoring` is applied, so `/grafana` 503s until then.
+- **`docs/ops/monitoring-deploy.md`** — the "Grafana shows data" verification step
+  now leads with the sub-path URL + `GRAFANA_ADMIN_PASSWORD` login and spells out
+  the 503-until-applied ordering between the auto-deploying ingress route and the
+  operator-applied Service; port-forward retained as the fallback path.
+
+## Legacy reference
+
+None — doc reconciliation of net-new modern infra.
+
+## Tests
+
+No code. Read-back + grep confirm no stale primary-access claim remains
+("NO Ingress" / "off the public internet" / "no public ingress" all gone;
+`port-forward svc/grafana` appears only as the fallback). The OACT-6 parity guard
+is unaffected — only the manifest's leading comment changed, not the embedded
+ConfigMap data.
+
+## Next steps
+
+None for this item.

--- a/docs/ops/monitoring-deploy.md
+++ b/docs/ops/monitoring-deploy.md
@@ -110,11 +110,21 @@ backend /metrics/  →  Prometheus (scrape + ALT-1 rules)  →  Alertmanager
    ```
    A `TestPing` push should land in the ntfy topic.
 
-4. **Grafana shows data** (no public ingress — port-forward):
+4. **Grafana shows data** (primary access — login-gated public sub-path):
+   ```
+   # → https://openshiksha.org/grafana  (admin / GRAFANA_ADMIN_PASSWORD)
+   # → "OpenShiksha — Overview" dashboard auto-provisioned, panels render
+   ```
+   The prod overlay's ingress (`k8s/overlays/prod/ingress-patch.yaml`, #494)
+   routes `/grafana` → the `grafana` Service, and Grafana serves from that
+   sub-path (`GF_SERVER_ROOT_URL` + `GF_SERVER_SERVE_FROM_SUB_PATH=true`).
+   **Ordering caveat:** the `/grafana` ingress route auto-deploys with the prod
+   overlay, but the `grafana` Service only exists once you have applied
+   `k8s/monitoring` (this step's prerequisite) — until then `/grafana` returns
+   **503**. If the sub-path misbehaves, fall back to a port-forward:
    ```bash
    kubectl -n openshiksha-prod port-forward svc/grafana 3000:3000
    # → http://localhost:3000 (admin / GRAFANA_ADMIN_PASSWORD)
-   # → "OpenShiksha — Overview" dashboard auto-provisioned, panels render
    ```
 
 5. **Backup freshness gauge reads real data** (after the next nightly backup, or a

--- a/k8s/monitoring/grafana.yaml
+++ b/k8s/monitoring/grafana.yaml
@@ -2,12 +2,22 @@
 #
 # Provisioned with a Prometheus datasource (the OACT-1 prometheus:9090 Service)
 # and the MET-5 starter dashboard (docs/ops/grafana/openshiksha-overview.json),
-# both auto-loaded at startup. NO Ingress - reach it via:
+# both auto-loaded at startup.
+#
+# Access (primary): login-gated at https://openshiksha.org/grafana. The prod
+# overlay's ingress (k8s/overlays/prod/ingress-patch.yaml, added in #494) routes
+# /grafana → this Service, and the Deployment below serves from that sub-path
+# (GF_SERVER_ROOT_URL + GF_SERVER_SERVE_FROM_SUB_PATH=true) so no strip-prefix
+# middleware is needed. NOTE: the ingress /grafana route auto-deploys with the
+# prod overlay, but the `grafana` Service only exists once an operator applies
+# k8s/monitoring — until then /grafana returns 503 (mirrors the caveat in the
+# ingress patch). Admin password comes from openshiksha-secrets
+# (GRAFANA_ADMIN_PASSWORD).
+#
+# Access (fallback): in-cluster port-forward, for debugging before the ingress is
+# live or when the sub-path is misbehaving:
 #
 #   kubectl -n openshiksha-prod port-forward svc/grafana 3000:3000
-#
-# Keeping Grafana off the public internet avoids a new attack surface on the live
-# droplet. Admin password comes from openshiksha-secrets (GRAFANA_ADMIN_PASSWORD).
 #
 # The dashboard JSON declares a `${DS_PROMETHEUS}` datasource input; file-based
 # provisioning doesn't resolve `__inputs`, so the provisioned datasource is marked


### PR DESCRIPTION
## Classification
**Docs** (reconciliation) — Observability Activation, Batch 2.

## Problem
[#494](https://github.com/openshiksha/openshiksha/pull/494) gave Grafana a real
public ingress route (`openshiksha.org/grafana`, login-gated, sub-path-served),
but two operator-facing docs still said the opposite — "NO Ingress — reach it via
port-forward". An operator reading them would port-forward and miss the public
sub-path.

## Change
- **`k8s/monitoring/grafana.yaml` header** — replaced the "NO Ingress / off the
  public internet" block with the real model: primary access is the login-gated
  `openshiksha.org/grafana` sub-path via the prod-overlay ingress; port-forward is
  now the fallback. Mirrors the ingress patch's caveat that the `grafana` Service
  only exists once `k8s/monitoring` is applied (so `/grafana` 503s until then).
- **`docs/ops/monitoring-deploy.md`** — the "Grafana shows data" step leads with
  the sub-path URL + `GRAFANA_ADMIN_PASSWORD` login and spells out the
  503-until-applied ordering; port-forward retained as fallback.

## Legacy reference
None — doc reconciliation.

## Tests
No code. Grep confirms no stale primary-access claim remains ("NO Ingress" /
"off the public internet" / "no public ingress" gone; `port-forward svc/grafana`
appears only as the fallback). Only the manifest's leading comment changed — the
embedded ConfigMap data (and the OACT-6 parity guard) are unaffected.

## How to verify
Re-read both files; `grep -rn "NO Ingress" k8s/monitoring/grafana.yaml docs/ops/monitoring-deploy.md` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)