### PR TITLE
feat(obs): OACT-8 — self-scrape the monitoring stack + MonitoringTargetDown alert

### DIFF
--- a/docs/changes/2026-06-30-oact8-monitoring-self-scrape.md
+++ b/docs/changes/2026-06-30-oact8-monitoring-self-scrape.md
@@ -1,0 +1,55 @@
+# OACT-8 — Self-scrape the monitoring stack
+
+**Date:** 2026-06-30
+**Initiative:** Observability Activation (Batch 2 — durability & drift-safety)
+**Classification:** Improve (infra)
+
+## Summary
+
+`prometheus.yml` had a single scrape job (`openshiksha-backend`). If Prometheus
+couldn't reach Alertmanager, or Prometheus itself were degraded, there was no
+`up{}` series for the monitoring stack's own components — so nothing could alert
+on them. The watcher wasn't watched.
+
+## What changed
+
+- **`k8s/monitoring/prometheus.yaml`** — added two additive scrape jobs to the
+  `prometheus-config` ConfigMap:
+  - `prometheus` → `localhost:9090` (Prometheus's own `/metrics`)
+  - `alertmanager` → `alertmanager:9093`
+- **`docs/ops/prometheus/openshiksha-alerts.yml`** (canonical) + the
+  `prometheus-rules` ConfigMap in `prometheus.yaml` (deployable copy) — added one
+  alert rule, kept structurally identical (parity-guarded by OACT-6):
+  - `MonitoringTargetDown`: `up{job=~"prometheus|alertmanager"} == 0`, `for: 10m`,
+    `severity: warning`, summary "A monitoring-stack target is down".
+  - `warning` (not critical): the app still serves while the monitoring stack
+    cycles. `for: 10m` avoids flapping on a monitoring-stack rollout/restart.
+- **`docs/ops/prometheus/openshiksha-alerts.test.yml`** — two promtool cases: an
+  `alertmanager` target held down past `10m` fires the alert; a healthy
+  `prometheus` target never fires.
+- **`docs/ops/monitoring-deploy.md`** — the "is it live?" checklist now lists the
+  two self-scrape targets and the 9th (`MonitoringTargetDown`) rule.
+
+## Legacy reference
+
+None — standard Prometheus self-monitoring.
+
+## Tests
+
+- `promtool check rules` / `promtool test rules` run in the existing
+  `alerting-lint` CI job (promtool is not installed locally).
+- Verified locally: the manifest `prometheus-rules` copy is **structurally equal**
+  to the canonical source (the OACT-6 parity guard will enforce this once both
+  merge); total rules = 9 with `MonitoringTargetDown` present; the three scrape
+  jobs render; `kubectl kustomize k8s/monitoring` builds clean; both alert YAML
+  and the test YAML parse.
+
+## Migration notes
+
+None — additive ConfigMap edits. The new targets only resolve once the stack is
+applied in-cluster; `up==0` pre-apply is precisely the signal, gated `for: 10m`
+to avoid boot-time flaps.
+
+## Next steps
+
+- OACT-9: opt-in persistent-storage overlay.

--- a/docs/ops/monitoring-deploy.md
+++ b/docs/ops/monitoring-deploy.md
@@ -94,8 +94,9 @@ backend /metrics/  →  Prometheus (scrape + ALT-1 rules)  →  Alertmanager
 2. **Prometheus scrape target is UP**:
    ```bash
    kubectl -n openshiksha-prod port-forward svc/prometheus 9090:9090
-   # → http://localhost:9090/targets : openshiksha-backend should be UP
-   # → http://localhost:9090/rules   : the 8 ALT-1 rules should be loaded
+   # → http://localhost:9090/targets : openshiksha-backend, prometheus, and
+   #                                    alertmanager (OACT-8 self-scrape) should be UP
+   # → http://localhost:9090/rules   : the 8 ALT-1 rules + MonitoringTargetDown (OACT-8) loaded
    ```
 
 3. **Alertmanager is reachable** and the bridge is wired:

--- a/docs/ops/prometheus/openshiksha-alerts.test.yml
+++ b/docs/ops/prometheus/openshiksha-alerts.test.yml
@@ -54,3 +54,29 @@ tests:
             exp_annotations:
               summary: "Grading queue backlog (>50 pending for 30m)"
               description: "60 submissions have been awaiting a grade for over 30m (threshold 50). Check the Celery worker and the grade_submission task — the grading pipeline may be stalled or under-provisioned."
+
+  # OACT-8 monitoring self-health: alertmanager down (up==0) held past the 10m
+  # `for:` MUST fire MonitoringTargetDown (warning); a healthy up==1 must NOT.
+  - interval: 1m
+    input_series:
+      - series: 'up{job="alertmanager"}'
+        values: "0x15" # down, held past the 10m `for:` window
+    alert_rule_test:
+      - eval_time: 12m
+        alertname: MonitoringTargetDown
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: alertmanager
+            exp_annotations:
+              summary: "A monitoring-stack target is down"
+              description: "A monitoring-stack self-scrape target (alertmanager) has been unreachable for 10m (up == 0). Prometheus or Alertmanager is degraded, so alerting about that component is blind — check the monitoring stack pods in openshiksha-prod."
+
+  - interval: 1m
+    input_series:
+      - series: 'up{job="prometheus"}'
+        values: "1x15" # healthy — must never fire
+    alert_rule_test:
+      - eval_time: 12m
+        alertname: MonitoringTargetDown
+        exp_alerts: []

--- a/docs/ops/prometheus/openshiksha-alerts.yml
+++ b/docs/ops/prometheus/openshiksha-alerts.yml
@@ -172,3 +172,22 @@ groups:
             Prometheus has been unable to scrape the openshiksha-backend target for
             5m (up == 0). The /metrics endpoint — and likely the app — is
             unreachable. Check the pod, readiness probe, and ingress.
+
+      # Monitoring-stack self-health (OACT-8): the stack scrapes its own Prometheus
+      # (job=prometheus) and Alertmanager (job=alertmanager) targets. If either is
+      # down, no other alert about that component can fire — this closes the
+      # "who watches the watcher" gap. Gated `for: 10m` so a rollout/restart of the
+      # monitoring stack itself doesn't flap. `warning`, not critical: the app can
+      # still serve while the monitoring stack cycles.
+      - alert: MonitoringTargetDown
+        expr: up{job=~"prometheus|alertmanager"} == 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "A monitoring-stack target is down"
+          description: >-
+            A monitoring-stack self-scrape target ({{ $labels.job }}) has been
+            unreachable for 10m (up == 0). Prometheus or Alertmanager is degraded,
+            so alerting about that component is blind — check the monitoring stack
+            pods in openshiksha-prod.

--- a/k8s/monitoring/prometheus.yaml
+++ b/k8s/monitoring/prometheus.yaml
@@ -46,6 +46,18 @@ data:
           credentials_file: /etc/prometheus/secrets/metrics_token
         static_configs:
           - targets: ["backend:8000"]
+
+      # Self-monitoring (OACT-8): scrape Prometheus's own /metrics and
+      # Alertmanager's, so the stack has an `up{}` series for itself. Without
+      # these, a degraded Prometheus or a down Alertmanager produces no signal to
+      # alert on — the "who watches the watcher" gap. The MonitoringTargetDown
+      # rule below fires on `up{job=~"prometheus|alertmanager"} == 0`.
+      - job_name: prometheus
+        static_configs:
+          - targets: ["localhost:9090"]
+      - job_name: alertmanager
+        static_configs:
+          - targets: ["alertmanager:9093"]
 ---
 # Verbatim copy of docs/ops/prometheus/openshiksha-alerts.yml (ALT-1). The canonical
 # source of truth stays in docs/ (validated by the `alerting-lint` CI job with
@@ -177,6 +189,19 @@ data:
                 Prometheus has been unable to scrape the openshiksha-backend target for
                 5m (up == 0). The /metrics endpoint — and likely the app — is
                 unreachable. Check the pod, readiness probe, and ingress.
+
+          - alert: MonitoringTargetDown
+            expr: up{job=~"prometheus|alertmanager"} == 0
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: "A monitoring-stack target is down"
+              description: >-
+                A monitoring-stack self-scrape target ({{ $labels.job }}) has been
+                unreachable for 10m (up == 0). Prometheus or Alertmanager is degraded,
+                so alerting about that component is blind — check the monitoring stack
+                pods in openshiksha-prod.
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Classification
**Improve** (infra) — Observability Activation, Batch 2.

## Problem
`prometheus.yml` scraped only `openshiksha-backend`. If Prometheus couldn't reach
Alertmanager, or Prometheus itself were degraded, there was no `up{}` series for
the monitoring stack's own components — nothing could alert on them. The watcher
wasn't watched.

## Change
- Added two additive scrape jobs to the `prometheus-config` ConfigMap:
  `prometheus` → `localhost:9090`, `alertmanager` → `alertmanager:9093`.
- Added one alert rule to the **canonical** `docs/ops/prometheus/openshiksha-alerts.yml`
  and re-copied it (structurally identical, parity-guarded by
  [#498](https://github.com/openshiksha/openshiksha/pull/498)) into the
  `prometheus-rules` ConfigMap:
  - `MonitoringTargetDown`: `up{job=~"prometheus|alertmanager"} == 0`, `for: 10m`,
    `severity: warning`. `warning` (app serves while the stack cycles); `for: 10m`
    avoids flapping on a monitoring-stack rollout.
- Added two promtool test cases (down `alertmanager` fires past 10m; healthy
  `prometheus` never fires).
- Updated `docs/ops/monitoring-deploy.md` checklist (self-scrape targets + 9th rule).

## Legacy reference
None — standard Prometheus self-monitoring.

## Tests
- `promtool check rules` / `promtool test rules` run in the existing `alerting-lint`
  CI job.
- Locally verified: manifest `prometheus-rules` copy is **structurally equal** to
  the canonical source (9 rules, `MonitoringTargetDown` present); three scrape jobs
  render; `kubectl kustomize k8s/monitoring` builds clean; alert + test YAML parse.

## How to verify
`kubectl kustomize k8s/monitoring` renders; `promtool test rules docs/ops/prometheus/openshiksha-alerts.test.yml` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)