### PR TITLE
feat(obs): OACT-9 — opt-in persistent-storage overlay for the monitoring stack

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -94,12 +94,18 @@ jobs:
               # above never renders it. Gate it the same way so a typo in the
               # Prometheus/Alertmanager/Grafana manifests fails at PR time, not at
               # `kubectl apply` on the droplet.
+              # The persistent overlay (k8s/monitoring-persistent, OACT-9) is the
+              # opt-in PVC-backed variant of the same stack; render+validate it too
+              # so a typo in the overlay's PVCs or volume patches also fails at PR
+              # time. Both variants are gated on every PR.
               run: |
-                echo "::group::monitoring"
-                kubectl kustomize k8s/monitoring \
-                  | kubeconform -strict -summary -ignore-missing-schemas \
-                      -kubernetes-version 1.31.0 -
-                echo "::endgroup::"
+                for stack in k8s/monitoring k8s/monitoring-persistent; do
+                  echo "::group::$stack"
+                  kubectl kustomize "$stack" \
+                    | kubeconform -strict -summary -ignore-missing-schemas \
+                        -kubernetes-version 1.31.0 -
+                  echo "::endgroup::"
+                done
 
     alerting-lint:
         name: Alerting Artifacts (promtool + amtool)

--- a/docs/changes/2026-06-30-oact9-persistent-storage-overlay.md
+++ b/docs/changes/2026-06-30-oact9-persistent-storage-overlay.md
@@ -1,0 +1,64 @@
+# OACT-9 — Opt-in persistent-storage overlay for the monitoring stack
+
+**Date:** 2026-06-30
+**Initiative:** Observability Activation (Batch 2 — durability & drift-safety)
+**Classification:** Improve (infra)
+
+## Summary
+
+The base `k8s/monitoring` uses `emptyDir` for both the Prometheus TSDB and
+Grafana's state. With the base's `strategy: Recreate`, every pod restart (node
+reboot, image bump, `kubectl rollout`) wipes all metrics history and Grafana
+state — a data-loss trap once an operator relies on trend data. This adds a
+ready-to-apply overlay that swaps both volumes to PersistentVolumeClaims, while
+the base stays light.
+
+## What changed
+
+- New `k8s/monitoring-persistent/`:
+  - `pvcs.yaml` — `prometheus-tsdb` (8Gi) and `grafana-data` (2Gi), both
+    `ReadWriteOnce`, no `storageClassName` (k3s `local-path` binds them; a non-k3s
+    operator sets a class).
+  - `patch-prometheus-tsdb.yaml` / `patch-grafana-data.yaml` — JSON6902 patches
+    that remove each volume's `emptyDir` source and add a `persistentVolumeClaim`.
+  - `kustomization.yaml` — `resources: ../monitoring` + the PVCs, plus the two
+    patches. Apply with `kubectl apply -k k8s/monitoring-persistent` **instead of**
+    the base.
+- `.github/workflows/ci-cd.yaml` — the monitoring validation step now renders +
+  kubeconform-validates **both** `k8s/monitoring` and `k8s/monitoring-persistent`
+  on every PR.
+- `docs/ops/monitoring-deploy.md` — new "Ephemeral vs persistent storage" section
+  (when to pick which, the storageClass note).
+
+## Design decisions & gotchas
+
+- **Sibling dir, not nested.** The plan named `k8s/monitoring/overlays/persistent`,
+  but kustomize forbids an overlay whose base is its own **ancestor** directory
+  ("cycle detected"), and the base must stay applyable as
+  `kubectl apply -k k8s/monitoring`. So the overlay is a sibling
+  (`k8s/monitoring-persistent`) referencing `../monitoring` — no base resource-list
+  duplication, no drift hazard.
+- **JSON6902, not `$retainKeys`.** A strategic-merge patch can only *add*
+  `persistentVolumeClaim`, leaving `emptyDir` in place (a Volume may set only one
+  source), and this kustomize build (kubectl v1.34) does not honour the
+  `$retainKeys` directive — it left the directive key literally in the output and
+  kept both sources. The JSON6902 remove-then-add is explicit and renders a clean
+  single-source volume.
+
+## Tests
+
+- `kubectl kustomize k8s/monitoring-persistent` renders; verified both target
+  volumes end up with **only** `persistentVolumeClaim` (no residual `emptyDir`),
+  the two PVCs are namespaced `openshiksha-prod` at 8Gi/2Gi, and the base still
+  renders `emptyDir` (unchanged).
+- kubeconform (`-strict`) runs in the extended CI monitoring step (not installed
+  locally).
+
+## Migration notes
+
+None — additive, opt-in. The base default is untouched; operators choose the
+overlay only when they want retention.
+
+## Next steps
+
+- OACT-11: Batch 2 close-out (ledger + STATUS + change doc index).

--- a/docs/ops/monitoring-deploy.md
+++ b/docs/ops/monitoring-deploy.md
@@ -24,10 +24,29 @@ apply.*
 | Grafana | `grafana/grafana:11.2.0` | `grafana:3000` | Dashboards (Prometheus datasource + MET-5 overview) |
 
 **Resource footprint** (requests across the four containers): ~**0.21 vCPU** /
-~**0.47 GiB** memory requested (limits ~1.05 vCPU / ~0.94 GiB). All TSDB / Grafana
-state is `emptyDir` (ephemeral) to stay light — swap in a PVC if you want
-retention across pod restarts. **Confirm the droplet has headroom before
-applying.**
+~**0.47 GiB** memory requested (limits ~1.05 vCPU / ~0.94 GiB). **Confirm the
+droplet has headroom before applying.**
+
+### Ephemeral vs persistent storage
+
+The base `k8s/monitoring` uses `emptyDir` for both the Prometheus TSDB and
+Grafana's state — light, but a pod restart (node reboot, image bump,
+`kubectl rollout`) **wipes all metrics history and Grafana state**. Fine for a
+first-light apply; a data-loss trap once you rely on a week of trend data.
+
+For retention across restarts, apply the **opt-in persistent overlay instead of
+the base** — it swaps both volumes to `PersistentVolumeClaim`s (OACT-9):
+
+```bash
+kubectl apply -k k8s/monitoring-persistent   # PVC-backed, retains history
+# — vs —
+kubectl apply -k k8s/monitoring              # emptyDir, light, ephemeral
+```
+
+The overlay's PVCs (`prometheus-tsdb` 8Gi, `grafana-data` 2Gi) declare no
+`storageClassName`, so the k3s droplet's default `local-path` provisioner binds
+them. On a non-k3s cluster, set an explicit `storageClassName` on the two PVCs in
+`k8s/monitoring-persistent/pvcs.yaml`.
 
 ## Prerequisites (operator-provisioned, out-of-band)
 

--- a/k8s/monitoring-persistent/kustomization.yaml
+++ b/k8s/monitoring-persistent/kustomization.yaml
@@ -1,0 +1,49 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Opt-in persistent-storage overlay for the monitoring stack (OACT-9).
+#
+# The base k8s/monitoring/ intentionally uses `emptyDir` for both the Prometheus
+# TSDB and Grafana's state so a first-light apply stays light. But `emptyDir` +
+# the base's `strategy: Recreate` means every pod restart (node reboot, image
+# bump, `kubectl rollout`) WIPES all metrics history and Grafana session state.
+# The moment an operator relies on a week of trend data, that's a data-loss trap.
+#
+# This overlay swaps both volumes to PersistentVolumeClaims. Apply it INSTEAD OF
+# the base when you want retention across restarts:
+#
+#   kubectl apply -k k8s/monitoring-persistent
+#
+# It is a SIBLING of k8s/monitoring (not nested under it): kustomize forbids an
+# overlay whose base is its own ancestor directory, and the base must stay
+# applyable as `kubectl apply -k k8s/monitoring`. This overlay layers the two PVCs
+# + volume patches on top of that base via `resources: ../monitoring`, so it never
+# duplicates the base resource list (no drift hazard).
+#
+# The PVCs declare no storageClassName, so on the k3s droplet the default
+# `local-path` provisioner binds them. A non-k3s operator sets their own class on
+# the two PVCs. ReadWriteOnce is correct here: single-node droplet + the base's
+# `Recreate` strategy means the old pod is torn down before the new one binds the
+# volume, so no two pods ever contend.
+namespace: openshiksha-prod
+
+resources:
+  - ../monitoring
+  - pvcs.yaml
+
+# JSON6902 patches: a strategic-merge patch can only ADD persistentVolumeClaim,
+# leaving emptyDir in place (a Volume may set only one source), and the
+# `$retainKeys` directive that would drop emptyDir is not honoured by this
+# kustomize build. So each patch explicitly removes the `emptyDir` source and
+# adds a `persistentVolumeClaim` on the same volume. Both target volumes are the
+# LAST volume (index 3) of their Deployment — a render+grep test guards the swap,
+# so a future volume reorder that breaks the index fails CI, not the droplet.
+patches:
+  - path: patch-prometheus-tsdb.yaml
+    target:
+      kind: Deployment
+      name: prometheus
+  - path: patch-grafana-data.yaml
+    target:
+      kind: Deployment
+      name: grafana

--- a/k8s/monitoring-persistent/patch-grafana-data.yaml
+++ b/k8s/monitoring-persistent/patch-grafana-data.yaml
@@ -1,0 +1,9 @@
+# Swap the Grafana `grafana-data` volume (the last volume, index 3: datasources,
+# dashboards-provider, dashboard-overview, grafana-data) from `emptyDir` to the
+# grafana-data PVC. See patch-prometheus-tsdb.yaml for the remove-then-add shape.
+- op: remove
+  path: /spec/template/spec/volumes/3/emptyDir
+- op: add
+  path: /spec/template/spec/volumes/3/persistentVolumeClaim
+  value:
+    claimName: grafana-data

--- a/k8s/monitoring-persistent/patch-prometheus-tsdb.yaml
+++ b/k8s/monitoring-persistent/patch-prometheus-tsdb.yaml
@@ -1,0 +1,9 @@
+# Swap the Prometheus `tsdb` volume (the last volume, index 3: config, rules,
+# secrets, tsdb) from `emptyDir` to the prometheus-tsdb PVC. Remove the emptyDir
+# source, then add the PVC source on the same volume — a Volume may set only one.
+- op: remove
+  path: /spec/template/spec/volumes/3/emptyDir
+- op: add
+  path: /spec/template/spec/volumes/3/persistentVolumeClaim
+  value:
+    claimName: prometheus-tsdb

--- a/k8s/monitoring-persistent/pvcs.yaml
+++ b/k8s/monitoring-persistent/pvcs.yaml
@@ -1,0 +1,29 @@
+# PVCs backing the monitoring stack's durable state (OACT-9). No storageClassName
+# → the k3s default `local-path` provisioner binds them on the droplet; a non-k3s
+# operator sets an explicit class. Sizes are conservative starting points for a
+# single-node droplet with the base's 7d Prometheus retention.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-tsdb
+  labels:
+    app: prometheus
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 8Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-data
+  labels:
+    app: grafana
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi


### PR DESCRIPTION
## Classification
**Improve** (infra) — Observability Activation, Batch 2.

## Problem
The base `k8s/monitoring` uses `emptyDir` for both the Prometheus TSDB and Grafana
state; with `strategy: Recreate`, every pod restart (node reboot, image bump,
`kubectl rollout`) **wipes all metrics history and Grafana state** — a data-loss
trap once an operator relies on trend data.

## Change
- New `k8s/monitoring-persistent/` overlay: two `PersistentVolumeClaim`s
  (`prometheus-tsdb` 8Gi, `grafana-data` 2Gi, `ReadWriteOnce`, no
  `storageClassName` → k3s `local-path` binds them) + JSON6902 patches that swap
  each volume from `emptyDir` to its PVC. Apply with
  `kubectl apply -k k8s/monitoring-persistent` **instead of** the base.
- CI monitoring step now renders + kubeconform-validates **both** the base and the
  persistent overlay on every PR.
- Runbook gains an "Ephemeral vs persistent storage" section.

## Design notes
- **Sibling, not nested** (`k8s/monitoring-persistent`, not
  `k8s/monitoring/overlays/persistent`): kustomize forbids an overlay whose base
  is its ancestor directory, and the base must stay applyable as
  `kubectl apply -k k8s/monitoring`. The overlay references `../monitoring`, so no
  base resource-list duplication.
- **JSON6902, not `$retainKeys`**: a strategic merge can only *add*
  `persistentVolumeClaim` (leaving `emptyDir` — a Volume may set only one source),
  and this kustomize build (kubectl v1.34) doesn't honour `$retainKeys`. The
  explicit remove-then-add renders a clean single-source volume.

## Tests
- `kubectl kustomize k8s/monitoring-persistent` renders; verified both target
  volumes end with **only** `persistentVolumeClaim`, PVCs namespaced
  `openshiksha-prod` at 8Gi/2Gi, and the base still renders `emptyDir` (unchanged).
- kubeconform `-strict` runs in the extended CI step.

## How to verify
`kubectl kustomize k8s/monitoring-persistent` — Prometheus/Grafana Deployments
reference the PVCs; `kubectl kustomize k8s/monitoring` still shows `emptyDir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)