### PR TITLE
feat(i18n): T-5 — restore the Marathi (mr) UI pilot for shot 7

### DIFF
--- a/frontend_modern/src/shared/i18n/coverage.test.ts
+++ b/frontend_modern/src/shared/i18n/coverage.test.ts
@@ -19,9 +19,11 @@ import { LOCALES, localeLoaders, type Locale, type LocaleMeta } from './locales/
 const TOTAL_KEYS = Object.keys(en).length;
 
 // Floors per pilot locale: the minimum key count that must stay covered. Raise
-// as a locale graduates surfaces; never let it drop. There are currently no
-// pilot locales (Marathi was removed); add an entry here when one ships.
-const PILOT_FLOORS: Partial<Record<Locale, number>> = {};
+// as a locale graduates surfaces; never let it drop. Marathi (mr) is the launch
+// pilot — the student loop the video films (switcher, auth, dashboard,
+// assignments, streaks, offline/sync). The floor is set a little under the
+// shipped subset so a stray deletion trips it without churning on every add.
+const PILOT_FLOORS: Partial<Record<Locale, number>> = { mr: 60 };
 
 const counts: Partial<Record<Locale, number>> = {};
 

--- a/frontend_modern/src/shared/i18n/i18n.test.tsx
+++ b/frontend_modern/src/shared/i18n/i18n.test.tsx
@@ -5,6 +5,7 @@ import { useT } from './useT';
 import { LanguageSwitcher } from './LanguageSwitcher';
 import { en } from './locales/en';
 import { hi } from './locales/hi';
+import { LOCALES } from './locales/registry';
 
 /** Tiny probe component exposing the i18n surface to assertions. */
 const Probe = ({ vars }: { vars?: Record<string, string | number> }) => {
@@ -129,15 +130,15 @@ describe('i18n', () => {
   });
 
   describe('LanguageSwitcher', () => {
-    it('renders one button per registered locale (EN | हिं)', () => {
+    it('renders one button per registered locale (registry-driven)', () => {
       render(
         <I18nProvider>
           <LanguageSwitcher />
         </I18nProvider>,
       );
       const buttons = screen.getAllByRole('button');
-      expect(buttons).toHaveLength(2);
-      expect(buttons.map((b) => b.textContent)).toEqual(['EN', 'हिं']);
+      expect(buttons).toHaveLength(LOCALES.length);
+      expect(buttons.map((b) => b.textContent)).toEqual(LOCALES.map((l) => l.label));
     });
 
     it('toggles the locale with aria-pressed state', async () => {

--- a/frontend_modern/src/shared/i18n/locales/mr.ts
+++ b/frontend_modern/src/shared/i18n/locales/mr.ts
@@ -1,0 +1,117 @@
+import type { LocaleDict } from './en';
+
+/**
+ * Marathi (मराठी) locale — a **pilot** dictionary (subset coverage).
+ *
+ * Per the registry North Star, a regional language ships surface-by-surface:
+ * this pilot covers the student loop the launch video films — the switcher,
+ * auth/login, the student dashboard + assignment list, streaks, and the
+ * offline/sync surfaces (shots 7 & 8). Every key it *does* define is guarded by
+ * the parity test (must exist in English, matching `{var}` placeholders, never
+ * blank); everything not listed here falls back to English at runtime
+ * (principle 3 — English is the fallback, never a blank).
+ *
+ * Typed `Partial<LocaleDict>` because a pilot is intentionally a subset. As more
+ * surfaces graduate, add their keys here and raise the floor in coverage.test.ts.
+ * Classroom-English domain words (Dashboard, Assignment, CBSE, OpenShiksha) are
+ * transliterated/kept, matching the Hindi convention.
+ */
+export const mr: Partial<LocaleDict> = {
+  // ── Common / switcher ────────────────────────────────────────────────
+  'common.language': 'भाषा',
+  'common.languageSwitchTo': 'भाषा बदला: {language}',
+  'common.cancel': 'रद्द करा',
+  'common.practice': 'सराव',
+  'common.topicsOne': '{count} विषय',
+  'common.topicsMany': '{count} विषय',
+
+  // ── Auth hero (chalkboard panel, shared by login + register) ─────────
+  'auth.heroHeadline': 'शिकण्याची किल्ली, एक-एक प्रश्नातून.',
+  'auth.heroSubtext':
+    'तुमच्या गतीने सराव, त्वरित तपासणी, आणि प्रत्येक विद्यार्थ्याला पुढे काय शिकायचे हे सांगणारी माहिती.',
+  'auth.heroFootnote': 'CBSE · इयत्ता 7–10 · English & मराठी',
+
+  // ── Login page ───────────────────────────────────────────────────────
+  'login.title': 'पुन्हा स्वागत आहे',
+  'login.subtitle': 'शिकणे सुरू ठेवण्यासाठी साइन इन करा.',
+  'login.username': 'वापरकर्तानाव',
+  'login.usernamePlaceholder': 'तुमचे वापरकर्तानाव टाका',
+  'login.password': 'पासवर्ड',
+  'login.passwordPlaceholder': 'तुमचा पासवर्ड टाका',
+  'login.submit': 'साइन इन',
+  'login.submitting': 'साइन इन करत आहे…',
+  'login.error': 'चुकीचे वापरकर्तानाव किंवा पासवर्ड. कृपया पुन्हा प्रयत्न करा.',
+  'login.noAccount': 'खाते नाही?',
+  'login.registerLink': 'नोंदणी करा',
+  'login.schoolQuestion': 'तुम्ही शाळा आहात का?',
+  'login.enquireLink': 'OpenShiksha बद्दल चौकशी करा',
+
+  // ── Student dashboard ────────────────────────────────────────────────
+  'dashboard.greeting': 'नमस्कार, {name}!',
+  'dashboard.title': 'तुमचा डॅशबोर्ड',
+  'dashboard.subtitle': 'ही तुमची असाइनमेंट्स आहेत.',
+  'dashboard.myProgress': 'माझी प्रगती →',
+  'dashboard.loadError': 'असाइनमेंट्स लोड होऊ शकल्या नाहीत. कृपया पान रिफ्रेश करा.',
+  'dashboard.openEmptyTitle': 'तुम्ही अजून कोणत्याही वर्गात नोंदणी केलेली नाही',
+  'dashboard.openEmptyDescription':
+    'स्वतः सराव सुरू करण्यासाठी सामायिक प्रश्नसंच पाहा.',
+  'dashboard.browseSubjects': 'विषय पाहा →',
+
+  // ── Assignment list ──────────────────────────────────────────────────
+  'assignments.emptyTitle': 'अजून असाइनमेंट नाही',
+  'assignments.emptyDescription': 'तुमचे शिक्षक लवकरच काही देतील. नंतर पुन्हा पाहा!',
+  'assignments.sectionOverdue': 'मुदत उलटलेली',
+  'assignments.sectionDueSoon': 'लवकरच देय',
+  'assignments.sectionUpcoming': 'आगामी',
+  'assignments.sectionCompleted': 'पूर्ण झालेली',
+
+  // ── Assignment card ──────────────────────────────────────────────────
+  'assignment.overdueBy': '{distance} मुदत उलटली',
+  'assignment.dueIn': 'देय {distance}',
+  'assignment.submittedAgo': '{distance} पूर्वी सादर केले',
+  'assignment.submitted': 'सादर केले',
+  'assignment.remedialBadge': 'उपचारात्मक सराव',
+  'assignment.progress': 'प्रगती',
+  'assignment.ctaReview': 'पुनरावलोकन',
+  'assignment.ctaContinue': 'सुरू ठेवा',
+  'assignment.ctaStart': 'सुरू करा',
+
+  // ── Streak badge ─────────────────────────────────────────────────────
+  'streak.days': '{count}-दिवसांची मालिका',
+  'streak.tierStarter': 'जोरात',
+  'streak.tierWeek': 'आठवड्याचा योद्धा',
+  'streak.tierMonth': 'महिन्याचा मास्टर',
+  'streak.tierChampion': 'विजेता',
+  'streak.best': 'सर्वोत्तम: {count}',
+  'streak.grace': 'सूट ✓',
+  'streak.graceTitle': 'सवलतीचा दिवस वापरला — एक दिवस चुकूनही मालिका कायम राहिली',
+
+  // ── Connectivity banner ──────────────────────────────────────────────
+  'connectivity.offlineTitle': 'तुम्ही ऑफलाइन आहात',
+  'connectivity.offlineBanner': 'तुम्ही ऑफलाइन आहात — जतन केलेले काम दाखवत आहे.',
+  'connectivity.backOnline': 'पुन्हा ऑनलाइन.',
+
+  // ── Offline sync status ──────────────────────────────────────────────
+  'sync.savedOffline': 'या डिव्हाइसवर जतन केले · तुम्ही ऑनलाइन आल्यावर सिंक होईल',
+  'sync.syncing': 'सिंक होत आहे…',
+  'sync.synced': 'जतन केले',
+  'sync.syncFailed': 'सिंक होऊ शकले नाही — पुन्हा प्रयत्न करेल',
+  'sync.pendingOne': '{count} बदल सिंक होण्याच्या प्रतीक्षेत',
+  'sync.pendingMany': '{count} बदल सिंक होण्याच्या प्रतीक्षेत',
+
+  // ── PWA install + update prompts ─────────────────────────────────────
+  'pwa.installPrompt': 'OpenShiksha तुमच्या होम स्क्रीनवर जोडा.',
+  'pwa.install': 'इंस्टॉल करा',
+  'pwa.installDismiss': 'इंस्टॉल सूचना बंद करा',
+  'pwa.updateAvailable': 'नवीन आवृत्ती उपलब्ध आहे.',
+  'pwa.refresh': 'रिफ्रेश करा',
+
+  // ── Web Push notifications ───────────────────────────────────────────
+  'push.prompt': 'तुमच्या फोनवर रिमाइंडर मिळवा.',
+  'push.enable': 'चालू करा',
+  'push.dismiss': 'सूचना विनंती बंद करा',
+  'push.enabled': 'रिमाइंडर चालू',
+  'push.label': 'पुश सूचना',
+  'push.description': 'असाइनमेंट लवकरच देय असताना या डिव्हाइसवर सूचना मिळवा.',
+  'push.blocked': 'तुमच्या ब्राउझर सेटिंग्जमध्ये सूचना अवरोधित आहेत.',
+};

--- a/frontend_modern/src/shared/i18n/locales/registry.ts
+++ b/frontend_modern/src/shared/i18n/locales/registry.ts
@@ -23,7 +23,7 @@ import type { LocaleDict } from './en';
  * array) so `t()` keys and locale params stay statically checked; the
  * `satisfies` below keeps the union and the registry honest about each other.
  */
-export type Locale = 'en' | 'hi';
+export type Locale = 'en' | 'hi' | 'mr';
 
 export interface LocaleMeta {
   /** Registry key — matches a `locales/<code>.ts` module. */
@@ -51,6 +51,7 @@ export const localeLoaders: Partial<
   Record<Locale, () => Promise<{ default?: LocaleDict } & Record<string, unknown>>>
 > = {
   hi: () => import('./hi'),
+  mr: () => import('./mr'),
 };
 
 export const LOCALES = [
@@ -69,6 +70,14 @@ export const LOCALES = [
     htmlLang: 'hi',
     intlLocale: 'hi-IN',
     coverage: 'complete',
+  },
+  {
+    code: 'mr',
+    label: 'मरा',
+    nativeName: 'मराठी',
+    htmlLang: 'mr',
+    intlLocale: 'mr-IN',
+    coverage: 'pilot',
   },
 ] as const satisfies readonly LocaleMeta[];
 


### PR DESCRIPTION
## What

Restores **मराठी** to the language switcher as a **pilot** (subset-coverage) locale, taking the switcher back to three languages (EN | हिं | मरा). Marathi had been removed from the frontend registry; the backend `preferred_language` already accepts `mr`.

Pure product code + tests — no docs. Content-only per the registry North Star (no consumer edits):
- `locales/mr.ts` — 74-key pilot dictionary (student loop: switcher, auth/login, dashboard, assignments, streaks, connectivity/offline-sync, PWA/push). Everything else falls back to English at runtime.
- `registry.ts` — widen `Locale` union with `mr`, add lazy loader, `LOCALES` entry (label `मरा`, coverage `pilot`)
- `coverage.test.ts` — add an `mr` pilot floor of 60
- `i18n.test.tsx` — switcher test made registry-driven (was hardcoded to EN | हिं)

## Verify

- `npx vitest run src/shared/i18n/` -> 35/35 green (registry, parity, coverage, format, switcher)
- `npm run type-check`, `npm run lint`, `npm run build` all pass; `mr` ships as its own lazy chunk
