### PR TITLE
feat(community): CP-1 — content-pack schema + pure validator (T-2)

### DIFF
--- a/backend/openshiksha/apps/core/content_packs.py
+++ b/backend/openshiksha/apps/core/content_packs.py
@@ -1,0 +1,174 @@
+"""
+Pure, DB-free validation of a **content pack** — the keystone of the community
+content pipeline (CP-1).
+
+A content pack is a versioned JSON bundle an outside contributor authors to add
+questions to the shared bank. It is *data*, validated by construction before it
+is ever staged (CP-2) or approved (CP-3): widget **code** never travels this
+path — only ``widget_config`` data, which is re-checked against the same vendored
+per-kind schemas the live authoring surface uses.
+
+Two validation layers, mirroring :mod:`openshiksha.apps.core.widgets`:
+
+    1. **Structural** — the pack is validated against the vendored
+       ``data/content_pack.schema.json`` (Draft 2020-12): required fields,
+       field types, enums, bounds, ``additionalProperties: false``.
+    2. **Per-widget** — every subpart carrying a non-blank ``widget_kind`` has
+       its ``widget_config`` run through
+       :func:`openshiksha.apps.core.widgets.validate_widget_config`, so a
+       malformed widget config is rejected here, not discovered in the sandbox.
+
+**On the DRF coupling (decided in CP-1):** ``validate_widget_config`` raises a
+``rest_framework.serializers.ValidationError`` because it is primarily an
+API-write guard. The content-pack pipeline is not an HTTP request, so we do
+**not** leak that type: this module catches it and re-raises everything as a
+single pack-native :class:`ContentPackError` carrying a flat, human-readable
+``errors`` list. Callers (the ``import_content_pack`` command in CP-2, the CI
+check in CP-5) depend only on this module's own exception, never on DRF.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from rest_framework import serializers
+
+from openshiksha.apps.core.widgets import validate_widget_config
+
+_SCHEMA_PATH: Path = Path(__file__).resolve().parent / "data" / "content_pack.schema.json"
+
+#: The only pack schema version this validator understands.
+SUPPORTED_PACK_VERSION = "1.0"
+
+
+class ContentPackError(Exception):
+    """A content pack failed validation.
+
+    ``errors`` is a flat list of human-readable, location-scoped messages (one
+    per distinct problem) so a CLI or CI job can print them verbatim. This is the
+    *only* exception this module raises — the DRF ``ValidationError`` that the
+    widget validator throws is caught and folded into ``errors`` so callers never
+    couple to ``rest_framework``.
+    """
+
+    def __init__(self, errors: list[str]):
+        self.errors = errors
+        super().__init__("; ".join(errors) if errors else "invalid content pack")
+
+
+@lru_cache(maxsize=1)
+def load_content_pack_schema() -> dict:
+    """Return the vendored content-pack JSON Schema (cached)."""
+
+    with _SCHEMA_PATH.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+@lru_cache(maxsize=1)
+def _pack_validator():
+    """Build (and cache) a Draft 2020-12 validator for the pack schema."""
+
+    from jsonschema import Draft202012Validator
+
+    schema = load_content_pack_schema()
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema)
+
+
+def _structural_errors(pack: Any) -> list[str]:
+    """All JSON-Schema violations of ``pack``, as sorted, location-scoped strings."""
+
+    errors = sorted(_pack_validator().iter_errors(pack), key=lambda e: list(e.path))
+    return [_format_schema_error(err) for err in errors]
+
+
+def _format_schema_error(err) -> str:  # noqa: ANN001 - jsonschema ValidationError
+    """Render a jsonschema error as a path-scoped, contributor-readable message."""
+
+    location = "/".join(str(p) for p in err.path)
+    where = "pack" if not location else f"pack field '{location}'"
+    return f"{where}: {err.message}"
+
+
+def _widget_errors(pack: Any) -> list[str]:
+    """Validate each widget-bearing subpart's config via the widget validator.
+
+    Only runs once the structure is known to be a dict with a list of questions
+    (the caller gates on structural validity first). Catches the widget
+    validator's DRF ``ValidationError`` and flattens it into pack-native,
+    location-scoped strings so no ``rest_framework`` type escapes this module.
+    """
+
+    messages: list[str] = []
+    for q_idx, question in enumerate(pack.get("questions", [])):
+        for subpart in question.get("subparts", []):
+            kind = subpart.get("widget_kind", "")
+            if not kind:
+                continue
+            s_idx = subpart.get("index", "?")
+            where = f"questions[{q_idx}].subparts[index={s_idx}]"
+            try:
+                validate_widget_config(kind, subpart.get("widget_config", {}))
+            except serializers.ValidationError as exc:
+                for msg in _flatten_drf_detail(exc.detail):
+                    messages.append(f"{where}: {msg}")
+    return messages
+
+
+def _flatten_drf_detail(detail: Any) -> list[str]:
+    """Flatten a DRF ``ValidationError.detail`` (dict/list/str) into plain strings."""
+
+    if isinstance(detail, dict):
+        out: list[str] = []
+        for value in detail.values():
+            out.extend(_flatten_drf_detail(value))
+        return out
+    if isinstance(detail, (list, tuple)):
+        out = []
+        for item in detail:
+            out.extend(_flatten_drf_detail(item))
+        return out
+    return [str(detail)]
+
+
+def content_pack_errors(pack: Any) -> list[str]:
+    """Return every validation error for ``pack`` (empty list ⇒ valid). Never raises.
+
+    Structural errors short-circuit widget validation: there is no point running
+    the widget validator over a pack whose shape we don't yet trust.
+    """
+
+    structural = _structural_errors(pack)
+    if structural:
+        return structural
+    return _widget_errors(pack)
+
+
+def validate_content_pack(pack: Any) -> None:
+    """Raise :class:`ContentPackError` if ``pack`` is invalid; else return ``None``."""
+
+    errors = content_pack_errors(pack)
+    if errors:
+        raise ContentPackError(errors)
+
+
+def is_valid_content_pack(pack: Any) -> bool:
+    """Boolean form of :func:`validate_content_pack` (never raises)."""
+
+    return not content_pack_errors(pack)
+
+
+def content_pack_hash(pack: Any) -> str:
+    """A stable SHA-256 over the pack's canonical JSON.
+
+    Key-independent of dict ordering and insignificant whitespace, so re-importing
+    the byte-for-byte-equivalent pack yields the same hash. CP-2/CP-3 use this to
+    make import idempotent and to key the ``superseded`` transition.
+    """
+
+    canonical = json.dumps(pack, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/backend/openshiksha/apps/core/data/content_pack.schema.json
+++ b/backend/openshiksha/apps/core/data/content_pack.schema.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "openshiksha:content-pack/v1",
+  "title": "OpenShiksha content pack",
+  "description": "A versioned, self-describing bundle of question-bank content authored by an external contributor. Validated by construction (CP-1) before it is ever staged (CP-2) or approved into the shared bank (CP-3). Taxonomy references (standard/subject/chapter) are carried as human-readable identifiers here; the importer resolves them to FKs at stage time.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["pack_version", "provenance", "questions"],
+  "properties": {
+    "pack_version": {
+      "description": "Content-pack schema version. Only \"1.0\" exists today; a mismatch is a hard reject so an older importer never silently mis-reads a newer pack.",
+      "const": "1.0"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "description": "Optional human label for the pack (shown in the review queue)."
+    },
+    "provenance": {
+      "$ref": "#/$defs/provenance"
+    },
+    "questions": {
+      "type": "array",
+      "minItems": 1,
+      "description": "The questions this pack contributes. Never empty — an empty pack is a mistake, not a no-op.",
+      "items": { "$ref": "#/$defs/question" }
+    }
+  },
+  "$defs": {
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["author", "license"],
+      "description": "Honest attribution block. author + license are mandatory so approved content always lands with a credit and a usage grant.",
+      "properties": {
+        "author": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200,
+          "description": "Who authored the pack (person or organisation)."
+        },
+        "license": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100,
+          "description": "The license the content is offered under (e.g. \"CC-BY-4.0\")."
+        },
+        "source": {
+          "type": "string",
+          "maxLength": 2000,
+          "description": "Optional URL or citation for where the content came from."
+        },
+        "contact": {
+          "type": "string",
+          "maxLength": 200,
+          "description": "Optional contact (email / handle) for the contributor."
+        }
+      }
+    },
+    "question": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["standard", "subject", "chapter", "subparts"],
+      "properties": {
+        "standard": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 12,
+          "description": "Grade/standard number (1..12)."
+        },
+        "subject": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100,
+          "description": "Subject name, resolved to a Subject FK at import."
+        },
+        "chapter": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200,
+          "description": "Chapter name, resolved to a Chapter FK at import."
+        },
+        "question_type": {
+          "description": "Answer type for the question. Defaults to \"mcq\" at import if omitted.",
+          "enum": ["mcq", "fill_blank", "matching", "multi_select", "numeric", "short_answer", "compound"]
+        },
+        "difficulty": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 5,
+          "description": "1=easiest .. 5=hardest. Defaults to 2 at import if omitted."
+        },
+        "stem_text": {
+          "type": "string",
+          "maxLength": 20000,
+          "description": "Optional shared stem rendered once above the subpart list."
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1, "maxLength": 100 },
+          "description": "Optional free-text tags; matched/created at import."
+        },
+        "subparts": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/subpart" }
+        }
+      }
+    },
+    "subpart": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["index", "question_text"],
+      "properties": {
+        "index": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "0-indexed order within the question."
+        },
+        "subpart_type": {
+          "description": "Per-subpart answer type; blank falls back to the parent question_type.",
+          "enum": ["mcq", "fill_blank", "matching", "multi_select", "numeric", "short_answer", ""]
+        },
+        "question_text": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 20000,
+          "description": "Prompt (LaTeX or plain text). Never blank."
+        },
+        "options": {
+          "type": ["array", "null"],
+          "description": "MCQ choices; null for non-MCQ types.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["key", "text"],
+            "properties": {
+              "key": { "type": "string", "minLength": 1 },
+              "text": { "type": "string" }
+            }
+          }
+        },
+        "correct_answer": {
+          "type": "object",
+          "description": "Answer data, e.g. {\"type\": \"mcq\", \"answer\": 2}."
+        },
+        "variable_constraints": {
+          "type": ["object", "null"],
+          "description": "Croupier variable definitions for {{token}} substitution."
+        },
+        "image_url": {
+          "type": "string",
+          "maxLength": 2000,
+          "description": "Optional image URL shown above the prompt."
+        },
+        "solution_text": { "type": "string", "maxLength": 20000 },
+        "hint_text": { "type": "string", "maxLength": 20000 },
+        "widget_kind": {
+          "type": "string",
+          "maxLength": 64,
+          "description": "Registry key of an interactive widget, or blank. Validated against the vendored per-kind widget schema in addition to this schema."
+        },
+        "widget_config": {
+          "type": "object",
+          "description": "Per-widget config; validated against the kind's params schema via validate_widget_config."
+        }
+      }
+    }
+  }
+}

--- a/backend/openshiksha/apps/core/tests/test_content_packs.py
+++ b/backend/openshiksha/apps/core/tests/test_content_packs.py
@@ -1,0 +1,260 @@
+"""
+Tests for CP-1 — the pure content-pack validator
+(``openshiksha.apps.core.content_packs``).
+
+No DB: every case is a dict validated against the vendored schema + the widget
+config validator. Covers the accept path and a reject case per field class
+(missing required, wrong type, bad enum, bounds, unknown key, empty pack,
+provenance gaps, and a bad widget config), plus the hash contract.
+"""
+
+import copy
+
+import pytest
+
+from openshiksha.apps.core.content_packs import (
+    ContentPackError,
+    content_pack_errors,
+    content_pack_hash,
+    is_valid_content_pack,
+    validate_content_pack,
+)
+
+
+def _valid_pack() -> dict:
+    """A minimal, fully valid pack with one MCQ subpart and one widget subpart."""
+
+    return {
+        "pack_version": "1.0",
+        "name": "Fractions starter pack",
+        "provenance": {
+            "author": "Jane Contributor",
+            "license": "CC-BY-4.0",
+            "source": "https://example.org/fractions",
+            "contact": "jane@example.org",
+        },
+        "questions": [
+            {
+                "standard": 5,
+                "subject": "Mathematics",
+                "chapter": "Fractions",
+                "question_type": "mcq",
+                "difficulty": 2,
+                "tags": ["fractions", "basics"],
+                "subparts": [
+                    {
+                        "index": 0,
+                        "subpart_type": "mcq",
+                        "question_text": "Which is one half?",
+                        "options": [
+                            {"key": "A", "text": "1/2"},
+                            {"key": "B", "text": "1/3"},
+                        ],
+                        "correct_answer": {"type": "mcq", "answer": "A"},
+                    }
+                ],
+            },
+            {
+                "standard": 6,
+                "subject": "Mathematics",
+                "chapter": "Number line",
+                "subparts": [
+                    {
+                        "index": 0,
+                        "question_text": "Mark 3 on the line.",
+                        "correct_answer": {"type": "numeric", "answer": 3},
+                        "widget_kind": "number-line",
+                        "widget_config": {"min": 0, "max": 10, "step": 1},
+                    }
+                ],
+            },
+        ],
+    }
+
+
+# ── accept path ──────────────────────────────────────────────────────────────
+
+
+def test_valid_pack_passes():
+    pack = _valid_pack()
+    assert content_pack_errors(pack) == []
+    assert is_valid_content_pack(pack)
+    validate_content_pack(pack)  # does not raise
+
+
+def test_widget_token_binding_is_accepted():
+    """A ``{{var}}`` token in a widget field is a valid deferred croupier binding."""
+
+    pack = _valid_pack()
+    pack["questions"][1]["subparts"][0]["widget_config"] = {"min": 0, "max": "{{hi}}", "step": 1}
+    assert is_valid_content_pack(pack)
+
+
+# ── reject: top-level structure ──────────────────────────────────────────────
+
+
+def test_missing_pack_version_rejected():
+    pack = _valid_pack()
+    del pack["pack_version"]
+    errors = content_pack_errors(pack)
+    assert errors
+    assert any("pack_version" in e for e in errors)
+
+
+def test_wrong_pack_version_rejected():
+    pack = _valid_pack()
+    pack["pack_version"] = "2.0"
+    assert not is_valid_content_pack(pack)
+
+
+def test_empty_questions_rejected():
+    pack = _valid_pack()
+    pack["questions"] = []
+    assert not is_valid_content_pack(pack)
+
+
+def test_unknown_top_level_key_rejected():
+    pack = _valid_pack()
+    pack["surprise"] = True
+    errors = content_pack_errors(pack)
+    assert any("surprise" in e or "additional" in e.lower() for e in errors)
+
+
+# ── reject: provenance ───────────────────────────────────────────────────────
+
+
+def test_missing_provenance_rejected():
+    pack = _valid_pack()
+    del pack["provenance"]
+    assert not is_valid_content_pack(pack)
+
+
+def test_provenance_without_license_rejected():
+    pack = _valid_pack()
+    del pack["provenance"]["license"]
+    errors = content_pack_errors(pack)
+    assert any("license" in e for e in errors)
+
+
+def test_provenance_blank_author_rejected():
+    pack = _valid_pack()
+    pack["provenance"]["author"] = ""
+    assert not is_valid_content_pack(pack)
+
+
+# ── reject: question / subpart field classes ─────────────────────────────────
+
+
+def test_standard_out_of_range_rejected():
+    pack = _valid_pack()
+    pack["questions"][0]["standard"] = 13
+    assert not is_valid_content_pack(pack)
+
+
+def test_bad_question_type_enum_rejected():
+    pack = _valid_pack()
+    pack["questions"][0]["question_type"] = "essay"
+    assert not is_valid_content_pack(pack)
+
+
+def test_difficulty_out_of_range_rejected():
+    pack = _valid_pack()
+    pack["questions"][0]["difficulty"] = 9
+    assert not is_valid_content_pack(pack)
+
+
+def test_subpart_missing_question_text_rejected():
+    pack = _valid_pack()
+    del pack["questions"][0]["subparts"][0]["question_text"]
+    assert not is_valid_content_pack(pack)
+
+
+def test_subpart_blank_question_text_rejected():
+    pack = _valid_pack()
+    pack["questions"][0]["subparts"][0]["question_text"] = ""
+    assert not is_valid_content_pack(pack)
+
+
+def test_negative_subpart_index_rejected():
+    pack = _valid_pack()
+    pack["questions"][0]["subparts"][0]["index"] = -1
+    assert not is_valid_content_pack(pack)
+
+
+def test_no_subparts_rejected():
+    pack = _valid_pack()
+    pack["questions"][0]["subparts"] = []
+    assert not is_valid_content_pack(pack)
+
+
+def test_unknown_subpart_key_rejected():
+    pack = _valid_pack()
+    pack["questions"][0]["subparts"][0]["reward"] = 100
+    assert not is_valid_content_pack(pack)
+
+
+def test_malformed_option_rejected():
+    pack = _valid_pack()
+    pack["questions"][0]["subparts"][0]["options"] = [{"key": "A"}]  # missing text
+    assert not is_valid_content_pack(pack)
+
+
+# ── reject: widget config (the DRF-coupling boundary) ────────────────────────
+
+
+def test_unknown_widget_kind_rejected_as_pack_error():
+    pack = _valid_pack()
+    pack["questions"][1]["subparts"][0]["widget_kind"] = "not-a-widget"
+    with pytest.raises(ContentPackError) as exc_info:
+        validate_content_pack(pack)
+    # The DRF ValidationError is folded into pack-native strings, not leaked.
+    assert exc_info.value.errors
+    assert any("not-a-widget" in e for e in exc_info.value.errors)
+
+
+def test_invalid_widget_config_rejected():
+    pack = _valid_pack()
+    # step must be > 0 (exclusiveMinimum) per the number-line schema.
+    pack["questions"][1]["subparts"][0]["widget_config"] = {"step": -5}
+    errors = content_pack_errors(pack)
+    assert errors
+    assert any("subparts" in e for e in errors)
+
+
+def test_widget_config_error_is_never_drf_type():
+    pack = _valid_pack()
+    pack["questions"][1]["subparts"][0]["widget_kind"] = "not-a-widget"
+    try:
+        validate_content_pack(pack)
+    except ContentPackError:
+        pass  # expected
+    except Exception as exc:  # pragma: no cover - guards the DRF-leak contract
+        pytest.fail(f"leaked non-pack exception type: {type(exc)!r}")
+
+
+def test_structural_errors_short_circuit_widget_validation():
+    """A structurally broken pack reports structure, not widget, errors."""
+
+    pack = _valid_pack()
+    del pack["pack_version"]
+    pack["questions"][1]["subparts"][0]["widget_kind"] = "not-a-widget"
+    errors = content_pack_errors(pack)
+    # widget check is skipped, so no 'not-a-widget' message surfaces.
+    assert not any("not-a-widget" in e for e in errors)
+
+
+# ── hash contract ────────────────────────────────────────────────────────────
+
+
+def test_hash_is_stable_across_key_order():
+    pack = _valid_pack()
+    reordered = copy.deepcopy(pack)
+    reordered["provenance"] = dict(reversed(list(reordered["provenance"].items())))
+    assert content_pack_hash(pack) == content_pack_hash(reordered)
+
+
+def test_hash_changes_with_content():
+    pack = _valid_pack()
+    mutated = copy.deepcopy(pack)
+    mutated["questions"][0]["difficulty"] = 5
+    assert content_pack_hash(pack) != content_pack_hash(mutated)

--- a/docs/initiatives/community-contributions.md
+++ b/docs/initiatives/community-contributions.md
@@ -66,7 +66,7 @@ Approval is idempotent — re-approving a materialized pack is a no-op keyed on
 
 | ID | Increment | Status |
 |----|-----------|--------|
-| CP-1 | **Content-pack schema** (the keystone): versioned JSON schema for a pack of questions/subparts (incl. `widget_kind`/`widget_config`, reusing the vendored widget schemas + `validate_widget_config`) + provenance block (author, source, license). Pure validator `backend/openshiksha/apps/core/content_packs.py` + schema `…/apps/core/data/content_pack.schema.json` + tests (valid/invalid per field class). No DB writes yet. | ⬜ |
+| CP-1 | **Content-pack schema** (the keystone): versioned JSON schema for a pack of questions/subparts (incl. `widget_kind`/`widget_config`, reusing the vendored widget schemas + `validate_widget_config`) + provenance block (author, source, license). Pure validator `backend/openshiksha/apps/core/content_packs.py` + schema `…/apps/core/data/content_pack.schema.json` + tests (valid/invalid per field class). No DB writes yet. | ✅ |
 | CP-2 | **`manage.py import_content_pack <file> [--dry-run]`**: validates via CP-1, stages each question as a **`ContentSubmission`** row (Question has **no** status field — see grounding note; don't overload `is_active`, which is soft-delete), never active; idempotent by pack hash; report output. Tests: dry-run, import, re-import no-dupe, invalid rejected. | ⬜ |
 | CP-3 | **Submission review model + API**: `ContentSubmission` (pack metadata, state machine pending→approved/rejected, reviewer, notes) with admin-only endpoints; approving materializes the pack's questions into the bank (`school=null` shared bank, `created_by`=reviewer, attribution from the provenance block); rejecting archives with a reason. Mirror the existing `TeacherWidgetVisibility.PENDING_REVIEW` moderation precedent (`models.py:1133`). Tests incl. permission walls. | ⬜ |
 | CP-4 | **Review UI (admin)**: a "Submissions" queue page — pack summary, per-question preview (reusing the existing QuestionPreviewPanel/widget sandbox preview), Approve/Reject with note. The maintainer's one-click approval surface. | ⬜ |
@@ -93,11 +93,16 @@ point could unreviewed content reach a student.
 - [ ] **T-1 (2026-07-05):** OSS-1 cold-clone audit — follow README verbatim on a
       fresh clone; log every failure/missing step; fix the README (+ compose
       docs) in one PR; record time-to-running in the PR description.
-- [ ] **T-2 (2026-07-05):** CP-1 content-pack schema + pure validator + tests
+- [x] **T-2 (2026-07-05):** CP-1 content-pack schema + pure validator + tests
       (`backend/openshiksha/apps/core/content_packs.py`,
       `backend/openshiksha/apps/core/data/content_pack.schema.json`). Reuse
       `validate_widget_config` (widgets.py:105) for widget-bearing subparts —
       note it raises DRF `ValidationError`; decide whether to wrap. No DB writes.
+      **Done: wrap.** The DRF error is caught and folded into a pack-native
+      `ContentPackError(errors=[...])` so callers never couple to `rest_framework`.
+      Added a `content_pack_hash` helper (canonical-JSON SHA-256) that CP-2/CP-3
+      will key idempotency + `superseded` on. Structural errors short-circuit
+      widget validation.
 - [ ] **T-3 (2026-07-06):** CP-3 `ContentSubmission` model only (no API/UI yet) —
       fields per the state machine above (`pack_hash`, `provenance` JSON,
       `state`, `reviewer` FK, `note`, timestamps); migration + model tests for
@@ -110,3 +115,4 @@ point could unreviewed content reach a student.
 |------|-----------|----|----|
 | 2026-07-05 | Initiative opened (post-launch-video pivot). Tracks A+B scoped; T-1/T-2 queued. | — | Launch video shipped 2026-07-05 (`launch-video-final3`, local-only asset); routines repurposed from the launch track to this initiative. |
 | 2026-07-06 | Grounded CP-1/2/3 against code (real paths `backend/openshiksha/apps/core/…`; `validate_widget_config` raises DRF error; Question has no status field; `TeacherWidgetVisibility.PENDING_REVIEW` precedent). Decided CP-3 state machine (4 states). Queued T-3 (ContentSubmission model). | — | No external contributors waiting; execute has not yet started T-1/T-2. |
+| 2026-07-06 | **CP-1 shipped** (T-2): `content_pack.schema.json` (v1.0, provenance required) + pure `content_packs.py` validator (structural + per-widget) + `content_pack_hash` + 24 tests (accept + reject per field class). DRF `ValidationError` wrapped into pack-native `ContentPackError`. | #PENDING | No DB writes; unblocks CP-2. |


### PR DESCRIPTION
## CP-1 — the content-pipeline keystone (Track B, task T-2)

First increment of the [Community Contributions](docs/initiatives/community-contributions.md) content pipeline: a **versioned schema + pure validator** for an external content pack. No DB writes — this is the mechanical gate CP-2 (import) and CP-5 (CI) ride on.

### What lands
- **`data/content_pack.schema.json`** (v1.0): a pack = `pack_version` + required `provenance` (author + license mandatory) + non-empty `questions[]` → `subparts[]`, each carrying the real `QuestionSubpart` fields incl. `widget_kind`/`widget_config`. `additionalProperties: false` throughout.
- **`content_packs.py`**: two-layer validation mirroring `widgets.py` — structural (Draft 2020-12) then per-widget (`validate_widget_config` on every widget-bearing subpart). Plus `content_pack_hash` (canonical-JSON SHA-256) for CP-2/CP-3 idempotency + `superseded`.
- **24 tests**: accept path + a reject case per field class + the hash contract.

### Decision: the DRF coupling (called out in the grounding note)
`validate_widget_config` raises a `rest_framework.serializers.ValidationError` (it's an API-write guard). This pipeline isn't an HTTP request, so we **wrap, not leak**: the DRF error is caught and folded into a pack-native `ContentPackError(errors=[...])`. Downstream callers depend only on this module's own exception. A test asserts no non-pack exception type escapes. Structural errors short-circuit widget validation.

### Verification
- `pytest test_content_packs.py` → **24 passed**
- `manage.py check` → no issues

### Safety
Content is **data validated against schemas**; widget *code* still only ever arrives via normal PR review. No path here activates anything — CP-2 stages as pending, CP-3 gates on maintainer approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)