### PR TITLE
deps(frontend): fix the npm audit gate blocking every open PR

### DIFF
--- a/frontend_modern/package-lock.json
+++ b/frontend_modern/package-lock.json
@@ -2128,9 +2128,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2148,9 +2145,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2168,9 +2162,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2188,9 +2179,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2208,9 +2196,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2228,9 +2213,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3040,9 +3022,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3060,9 +3039,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3080,9 +3056,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3100,9 +3073,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4383,16 +4353,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/brace-expansion/node_modules/balanced-match": {
@@ -5295,9 +5265,9 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5532,9 +5502,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -5579,9 +5549,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7386,9 +7356,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/frontend_modern/package.json
+++ b/frontend_modern/package.json
@@ -81,6 +81,9 @@
   "overrides": {
     "eslint-plugin-jsx-a11y": {
       "eslint": "$eslint"
-    }
+    },
+    "brace-expansion@1": "^1.1.18",
+    "brace-expansion@2": "^2.1.4",
+    "brace-expansion@5": "^5.0.9"
   }
 }

--- a/frontend_modern/scripts/check-npm-audit.mjs
+++ b/frontend_modern/scripts/check-npm-audit.mjs
@@ -27,25 +27,6 @@ export const BLOCKING_SEVERITIES = new Set(['high', 'critical']);
 
 export const ALLOWLIST = [
   {
-    id: 'GHSA-3jxr-9vmj-r5cp',
-    package: 'brace-expansion',
-    reason:
-      'DoS via exponential-time brace expansion. Reachable only through two dev-only ' +
-      'transitive chains (eslint-plugin-jsx-a11y -> minimatch@3, and ' +
-      'vite-plugin-pwa -> workbox-build -> jake -> filelist -> minimatch@5). Never ships ' +
-      'to users, and CI input is the repo itself, not attacker-controlled. The patched ' +
-      'brace-expansion 5.0.8 exports a named `expand` instead of a callable default, so ' +
-      'an override breaks both minimatch callers; npm\'s only suggested fix is a major ' +
-      'downgrade of eslint-plugin-jsx-a11y and vite-plugin-pwa.',
-    review: 'Remove once minimatch/filelist ship releases pulling a patched brace-expansion.',
-  },
-  {
-    id: 'GHSA-mh99-v99m-4gvg',
-    package: 'brace-expansion',
-    reason: 'Same package, same two dev-only chains, same blocked remediation as GHSA-3jxr-9vmj-r5cp.',
-    review: 'Remove together with GHSA-3jxr-9vmj-r5cp.',
-  },
-  {
     id: 'GHSA-qwww-vcr4-c8h2',
     package: 'react-router',
     reason:


### PR DESCRIPTION
## Why

The `check:audit` gate is failing on all three open PRs (#549, #550, #551) — it is a repo-wide break, not something any of those PRs caused. Landing this on `qa` unblocks all of them.

## What was failing

`GHSA-rgw5-rvv9-x895` — brace-expansion DoS that bypasses the CVE-2026-14257 mitigation the two existing allowlist entries covered.

## Fix

**brace-expansion via `overrides`, not a third allowlist entry.** The old entry claimed an override was impossible because patched 5.0.8 exports a named `expand` instead of a callable default. That no longer holds: all three vulnerable copies have in-range patched releases and `minimatch@10` already declares `^5.0.5`.

| chain | before | after |
|---|---|---|
| `eslint-plugin-jsx-a11y → minimatch@3` | 1.1.15 | 1.1.18 |
| `vite-plugin-pwa → workbox-build → jake → filelist → minimatch@5` | 2.1.1 | 2.1.4 |
| `eslint → minimatch@10` | 5.0.6 | 5.0.9 |

The two brace-expansion allowlist entries are removed — the gate itself now reports them `STALE`.

**Two more high advisories** surfaced in the same run (the gate queries the live registry, so it sees advisories newer than the last CI run). Both are plain in-range lockfile moves:

- `fast-uri` 3.1.4 → 3.1.5 — GHSA-7p8r-x3mc-p8w7, host confusion via backslash authority introducer
- `nanoid` 3.3.16 → 3.3.18 — GHSA-2v37-7h3g-55p8, custom generators loop indefinitely when size is zero

The fast-uri half makes **#549 redundant** — that PR should close itself once this lands.

## Verification (local)

- `npm run check:audit` — OK, react-router the only remaining allowlist entry
- `npm run lint` — clean
- `npm run type-check` — clean
- `npm run test -- --run` — 89 files, 631 tests, all passing
- `npm run build` — PWA/workbox precache generates fine (this is the chain carrying the overridden brace-expansion@2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)