### PR TITLE
chore: drop the now-stale react-router audit allowlist entry

### DIFF
--- a/frontend_modern/scripts/check-npm-audit.mjs
+++ b/frontend_modern/scripts/check-npm-audit.mjs
@@ -25,20 +25,9 @@ import { execFileSync } from 'node:child_process';
 /** Severities that fail the build, mirroring `--audit-level=high`. */
 export const BLOCKING_SEVERITIES = new Set(['high', 'critical']);
 
-export const ALLOWLIST = [
-  {
-    id: 'GHSA-qwww-vcr4-c8h2',
-    package: 'react-router',
-    reason:
-      'CSRF bypass in react-router RSC mode. This app is a plain SPA — it uses only ' +
-      'BrowserRouter/MemoryRouter, Routes, Route, Link, Navigate, useNavigate, useParams, ' +
-      'useSearchParams and useLocation. RSC mode, framework mode and server actions are not ' +
-      'used, so the vulnerable path does not exist here. The fix landed in react-router 8.3.0, ' +
-      'but react-router-dom has no v8 line, so adopting it means migrating every import off ' +
-      'react-router-dom AND taking a major — too large to ride along with a dependency bump.',
-    review: 'Remove when the react-router v8 migration lands.',
-  },
-];
+// Empty is the goal state: every advisory currently has a real upgrade path, so
+// nothing needs accepting. Keep it that way — prefer fixing over adding here.
+export const ALLOWLIST = [];
 
 /**
  * Flatten `npm audit --json` into the distinct advisories behind it.


### PR DESCRIPTION
Small follow-up to close the loop on the dependency sweep.

## What

`GHSA-qwww-vcr4-c8h2` is still in the npm-audit allowlist on `qa`, but it is no longer accurate. The entry said removal had to wait for "the react-router v8 migration" — upstream backported the fix, and the advisory now lists **7.18.2** as patched on the 7.x line. #551 already put react-router 7.18.2 on `qa`, so the advisory is genuinely **fixed**, not accepted.

## Why it is a separate PR

This was meant to ride along with #551 but raced with that PR's squash-merge and never landed.

**Nothing is broken.** A stale allowlist entry only warns — it does not fail the gate — which is why `qa` has stayed green. The gate has just been printing:

```
[npm-audit] STALE allowlist entry GHSA-qwww-vcr4-c8h2 (react-router) no longer matches — remove it.
```

This is cleanup of exactly what that message asks for.

## Result

The allowlist is now **empty** — every advisory in the tree has a real upgrade path rather than an acceptance. Added a note that empty is the goal state.

## Verification

- `npm run check:audit` → `OK — no unaccepted high/critical advisories (0 allowlisted)`
- gate's own unit tests → 12/12 passing with an empty list

🤖 Generated with [Claude Code](https://claude.com/claude-code)